### PR TITLE
Replace pre-push hook with true CI

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,0 +1,16 @@
+name: Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validation:
+    name: PR Validation Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build Docker image
+        run: |
+          docker build .

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,13 +1,6 @@
 #!/bin/sh
 
-# From Git's sample pre-push hook:
-# > Information about the commits which are being pushed is supplied as lines to the standard input in the form:
-# >
-# >   <local ref> <local sha1> <remote ref> <remote sha1>
-
 set -eu
-
-branch_name_to_protect="main"
 
 if ! output=$(git status --porcelain) || [ -n "$output" ]; then
     echo "⚠️  Dirty working tree."
@@ -15,19 +8,4 @@ if ! output=$(git status --porcelain) || [ -n "$output" ]; then
     exit 1
 fi
 
-while read local_ref local_sha remote_ref remote_sha; do
-    if [ "$remote_ref" = "refs/heads/$branch_name_to_protect" ]; then
-        for commit in $(git log --pretty="%H" "$remote_sha..$local_sha"); do
-            if git -c advice.detachedHead=false checkout "$commit"; then
-                if ! docker build .; then
-                    echo "⚠️  Commit $commit seems problematic. Please rebase and fix it or use 'git push --no-verify' to override."
-                    git checkout "$branch_name_to_protect"
-                    exit 1
-                fi
-            fi
-        done
-    fi
-done
-
-git checkout "$branch_name_to_protect"
-exit 0
+docker build .


### PR DESCRIPTION
From now on, the plan is to make all changes via pull requests, so the purpose of the `pre-push` hook is reduced from a poor man's CI substitute to a basic sanity check providing faster feedback than waiting for a PR validation build.