### PR TITLE
Only use each port at most once per tick

### DIFF
--- a/ZATACKA.html
+++ b/ZATACKA.html
@@ -50,7 +50,9 @@
         const renderer = new Renderer(canvas_main, canvas_overlay)
 
         app.ports.render.subscribe(data => {
-            renderer.drawSquare(data.position.leftEdge, data.position.topEdge, data.thickness, data.color)
+            for (const square of data) {
+                renderer.drawSquare(square.position.leftEdge, square.position.topEdge, square.thickness, square.color)
+            }
         })
 
         app.ports.clear.subscribe(data => {
@@ -58,7 +60,9 @@
         })
 
         app.ports.renderOverlay.subscribe(data => {
-            renderer.drawSquare_overlay(data.position.leftEdge, data.position.topEdge, data.thickness, data.color)
+            for (const square of data) {
+                renderer.drawSquare_overlay(square.position.leftEdge, square.position.topEdge, square.thickness, square.color)
+            }
         })
 
         app.ports.clearOverlay.subscribe(data => {

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (bodyDrawingCmds, clearEverything, clearOverlay, drawSpawnIfAndOnlyIf, headDrawingCmds)
+port module Canvas exposing (bodyDrawingCmd, clearEverything, clearOverlay, drawSpawnIfAndOnlyIf, headDrawingCmd)
 
 import Color exposing (Color)
 import Types.Player exposing (Player)
@@ -6,40 +6,40 @@ import Types.Thickness as Thickness exposing (Thickness)
 import World exposing (DrawingPosition)
 
 
-port render : { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
+port render : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
 
 
 port clear : { x : Int, y : Int, width : Int, height : Int } -> Cmd msg
 
 
-port renderOverlay : { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
+port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
 
 
 port clearOverlay : { x : Int, y : Int, width : Int, height : Int } -> Cmd msg
 
 
-bodyDrawingCmds : Thickness -> List ( Color, DrawingPosition ) -> List (Cmd msg)
-bodyDrawingCmds thickness =
-    List.map
-        (\( color, position ) ->
-            render
+bodyDrawingCmd : Thickness -> List ( Color, DrawingPosition ) -> Cmd msg
+bodyDrawingCmd thickness =
+    render
+        << List.map
+            (\( color, position ) ->
                 { position = position
                 , thickness = Thickness.toInt thickness
                 , color = Color.toCssString color
                 }
-        )
+            )
 
 
-headDrawingCmds : Thickness -> List Player -> List (Cmd msg)
-headDrawingCmds thickness =
-    List.map
-        (\player ->
-            renderOverlay
+headDrawingCmd : Thickness -> List Player -> Cmd msg
+headDrawingCmd thickness =
+    renderOverlay
+        << List.map
+            (\player ->
                 { position = World.drawingPosition thickness player.state.position
                 , thickness = Thickness.toInt thickness
                 , color = Color.toCssString player.color
                 }
-        )
+            )
 
 
 clearEverything : ( Int, Int ) -> Cmd msg
@@ -62,11 +62,12 @@ drawSpawnIfAndOnlyIf shouldBeVisible player thickness =
             World.drawingPosition thickness player.state.position
     in
     if shouldBeVisible then
-        render
-            { position = drawingPosition
-            , thickness = thicknessAsInt
-            , color = Color.toCssString player.color
-            }
+        render <|
+            List.singleton
+                { position = drawingPosition
+                , thickness = thicknessAsInt
+                , color = Color.toCssString player.color
+                }
 
     else
         clear

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,7 +1,7 @@
 module Main exposing (main)
 
 import Browser
-import Canvas exposing (bodyDrawingCmds, clearEverything, clearOverlay, drawSpawnIfAndOnlyIf, headDrawingCmds)
+import Canvas exposing (bodyDrawingCmd, clearEverything, clearOverlay, drawSpawnIfAndOnlyIf, headDrawingCmd)
 import Config exposing (config)
 import Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualPlayer, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 import Html exposing (Html, canvas, div)
@@ -118,9 +118,10 @@ update msg ({ pressedButtons } as model) =
                         MidRound tick <| modifyRound (always newCurrentRound) midRoundState
             in
             ( { model | gameState = newGameState }
-            , clearOverlay { x = 0, y = 0, width = config.world.width, height = config.world.height }
-                :: headDrawingCmds config.kurves.thickness newPlayers.alive
-                ++ bodyDrawingCmds config.kurves.thickness newColoredDrawingPositions
+            , [ clearOverlay { x = 0, y = 0, width = config.world.width, height = config.world.height }
+              , headDrawingCmd config.kurves.thickness newPlayers.alive
+              , bodyDrawingCmd config.kurves.thickness newColoredDrawingPositions
+              ]
                 |> Cmd.batch
             )
 


### PR DESCRIPTION
When trying to merge the four ports into two (one for rendering and one for clearing), we ran into problems with batching and the order in which things happened: in particular, heads weren't visibly drawn during holes. This seemed to be caused by the same port being used multiple times in each tick.

This PR refactors the drawing implementation so that the rendering ports take a list of squares to draw instead of a single square, which in turn lets us limit the use of each port to at most once per tick.

💡 `git show --color-words='data|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>