### PR TITLE
Refactor overlay rendering

### DIFF
--- a/ZATACKA.html
+++ b/ZATACKA.html
@@ -60,13 +60,10 @@
         })
 
         app.ports.renderOverlay.subscribe(data => {
+            renderer.clearRectangle_overlay(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
             for (const square of data) {
                 renderer.drawSquare_overlay(square.position.leftEdge, square.position.topEdge, square.thickness, square.color)
             }
-        })
-
-        app.ports.clearOverlay.subscribe(data => {
-            renderer.clearRectangle_overlay(data.x, data.y, data.width, data.height)
         })
 
         document.addEventListener("keydown", event => {

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (bodyDrawingCmd, clearEverything, clearOverlay, drawSpawnIfAndOnlyIf, headDrawingCmd)
+port module Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
 
 import Color exposing (Color)
 import Types.Player exposing (Player)
@@ -13,9 +13,6 @@ port clear : { x : Int, y : Int, width : Int, height : Int } -> Cmd msg
 
 
 port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
-
-
-port clearOverlay : { x : Int, y : Int, width : Int, height : Int } -> Cmd msg
 
 
 bodyDrawingCmd : Thickness -> List ( Color, DrawingPosition ) -> Cmd msg
@@ -45,7 +42,7 @@ headDrawingCmd thickness =
 clearEverything : ( Int, Int ) -> Cmd msg
 clearEverything ( worldWidth, worldHeight ) =
     Cmd.batch
-        [ clearOverlay { x = 0, y = 0, width = worldWidth, height = worldHeight }
+        [ renderOverlay []
         , clear { x = 0, y = 0, width = worldWidth, height = worldHeight }
         ]
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,7 +1,7 @@
 module Main exposing (main)
 
 import Browser
-import Canvas exposing (bodyDrawingCmd, clearEverything, clearOverlay, drawSpawnIfAndOnlyIf, headDrawingCmd)
+import Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
 import Config exposing (config)
 import Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualPlayer, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 import Html exposing (Html, canvas, div)
@@ -118,8 +118,7 @@ update msg ({ pressedButtons } as model) =
                         MidRound tick <| modifyRound (always newCurrentRound) midRoundState
             in
             ( { model | gameState = newGameState }
-            , [ clearOverlay { x = 0, y = 0, width = config.world.width, height = config.world.height }
-              , headDrawingCmd config.kurves.thickness newPlayers.alive
+            , [ headDrawingCmd config.kurves.thickness newPlayers.alive
               , bodyDrawingCmd config.kurves.thickness newColoredDrawingPositions
               ]
                 |> Cmd.batch


### PR DESCRIPTION
The `clearOverlay` port is only ever used to clear the entire overlay canvas (i.e. never a specific region). This PR moves that functionality into the `renderOverlay` port, making it more akin to Elm's `view` function (i.e. it is now used to describe the entire desired state of the overlay canvas, rather than any additions to it).

As of this PR, clearing the overlay is simply done by rendering the empty list of squares. This is necessary when starting a new round, because otherwise the winning player's head is incorrectly shown while the players are spawning, but it's not necessary in `update` anymore, because it's implicitly done by the port itself.

This PR was made possible by #39.

💡 `git show --color-words='\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>