### PR TITLE
Clean up type imports

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -7,11 +7,11 @@ import Round exposing (Players, Round, RoundInitialState, modifyAlive, modifyDea
 import Set exposing (Set)
 import Spawn exposing (generateHoleSize, generateHoleSpacing, generatePlayers)
 import Turning exposing (computeAngleChange, computeTurningState, turningStateFromHistory)
-import Types.Angle as Angle
+import Types.Angle as Angle exposing (Angle)
 import Types.Distance as Distance exposing (Distance(..))
 import Types.Player as Player exposing (Player, UserInteraction(..), modifyReversedInteractions)
 import Types.Speed as Speed exposing (Speed)
-import Types.Thickness as Thickness
+import Types.Thickness as Thickness exposing (Thickness)
 import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 import Types.TurningState exposing (TurningState)
@@ -89,7 +89,7 @@ prepareRoundHelper initialState =
         thePlayers =
             initialState.spawnedPlayers
 
-        thickness : Thickness.Thickness
+        thickness : Thickness
         thickness =
             config.kurves.thickness
 
@@ -233,7 +233,7 @@ updatePlayer turningState occupiedPixels player =
         distanceTraveledSinceLastTick =
             Speed.toFloat config.kurves.speed / Tickrate.toFloat config.kurves.tickrate
 
-        newDirection : Angle.Angle
+        newDirection : Angle
         newDirection =
             Angle.add player.state.direction <| computeAngleChange config.kurves turningState
 
@@ -248,7 +248,7 @@ updatePlayer turningState occupiedPixels player =
               y - distanceTraveledSinceLastTick * Angle.sin newDirection
             )
 
-        thickness : Thickness.Thickness
+        thickness : Thickness
         thickness =
             config.kurves.thickness
 

--- a/src/World.elm
+++ b/src/World.elm
@@ -14,8 +14,8 @@ import RasterShapes
 import Set exposing (Set)
 import Types.Distance as Distance exposing (Distance)
 import Types.Speed as Speed exposing (Speed)
-import Types.Thickness as Thickness
-import Types.Tickrate as Tickrate
+import Types.Thickness as Thickness exposing (Thickness)
+import Types.Tickrate as Tickrate exposing (Tickrate)
 
 
 type alias Position =
@@ -30,7 +30,7 @@ type alias Pixel =
     ( Int, Int )
 
 
-distanceToTicks : Tickrate.Tickrate -> Speed -> Distance -> Int
+distanceToTicks : Tickrate -> Speed -> Distance -> Int
 distanceToTicks tickrate speed distance =
     round <| Tickrate.toFloat tickrate * Distance.toFloat distance / Speed.toFloat speed
 
@@ -45,17 +45,17 @@ fromBresenham { x, y } =
     { leftEdge = x, topEdge = y }
 
 
-drawingPosition : Thickness.Thickness -> Position -> DrawingPosition
+drawingPosition : Thickness -> Position -> DrawingPosition
 drawingPosition thickness ( x, y ) =
     { leftEdge = edgeOfSquare thickness x, topEdge = edgeOfSquare thickness y }
 
 
-edgeOfSquare : Thickness.Thickness -> Float -> Int
+edgeOfSquare : Thickness -> Float -> Int
 edgeOfSquare thickness xOrY =
     round (xOrY - (toFloat (Thickness.toInt thickness) / 2))
 
 
-pixelsToOccupy : Thickness.Thickness -> DrawingPosition -> Set Pixel
+pixelsToOccupy : Thickness -> DrawingPosition -> Set Pixel
 pixelsToOccupy thickness { leftEdge, topEdge } =
     let
         rangeFrom : Int -> List Int
@@ -74,7 +74,7 @@ pixelsToOccupy thickness { leftEdge, topEdge } =
         |> Set.fromList
 
 
-desiredDrawingPositions : Thickness.Thickness -> Position -> Position -> List DrawingPosition
+desiredDrawingPositions : Thickness -> Position -> Position -> List DrawingPosition
 desiredDrawingPositions thickness position1 position2 =
     RasterShapes.line
         (drawingPosition thickness position1 |> toBresenham)
@@ -86,7 +86,7 @@ desiredDrawingPositions thickness position1 position2 =
         |> List.map fromBresenham
 
 
-hitbox : Thickness.Thickness -> DrawingPosition -> DrawingPosition -> Set Pixel
+hitbox : Thickness -> DrawingPosition -> DrawingPosition -> Set Pixel
 hitbox thickness oldPosition newPosition =
     let
         is45DegreeDraw : Bool


### PR DESCRIPTION
This PR replaces type references of the form `Foo.Foo` with just `Foo`. We did this to find them:

    git grep -P '([A-Z]\w+)\.\1'

💡 `git show --color-words=.`