### PR TITLE
Store config in model

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,4 +1,4 @@
-module Config exposing (Config, HoleConfig, KurveConfig, PlayerConfig, SpawnConfig, WorldConfig, config)
+module Config exposing (Config, HoleConfig, KurveConfig, PlayerConfig, SpawnConfig, WorldConfig, default)
 
 import Color exposing (Color)
 import Input exposing (Button(..))
@@ -9,8 +9,8 @@ import Types.Thickness exposing (Thickness(..))
 import Types.Tickrate exposing (Tickrate(..))
 
 
-config : Config
-config =
+default : Config
+default =
     { kurves =
         { tickrate = Tickrate 60
         , turningRadius = Radius 28.5


### PR DESCRIPTION
We think this will enable future improvements, including configurable players and settings.

💡 `git show --color-words='\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>