### PR TITLE
Don't include players in config

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,4 +1,4 @@
-module Config exposing (Config, HoleConfig, KurveConfig, PlayerConfig, SpawnConfig, WorldConfig, default)
+module Config exposing (Config, HoleConfig, KurveConfig, PlayerConfig, SpawnConfig, WorldConfig, default, players)
 
 import Color exposing (Color)
 import Input exposing (Button(..))
@@ -35,7 +35,6 @@ default =
         { width = 559
         , height = 480
         }
-    , players = players
     }
 
 
@@ -71,7 +70,6 @@ type alias Config =
     { kurves : KurveConfig
     , spawn : SpawnConfig
     , world : WorldConfig
-    , players : List PlayerConfig
     }
 
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,7 +1,7 @@
 module Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualPlayer, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 
 import Color exposing (Color)
-import Config exposing (Config, KurveConfig)
+import Config exposing (Config, KurveConfig, PlayerConfig)
 import Random
 import Round exposing (Players, Round, RoundInitialState, modifyAlive, modifyDead)
 import Set exposing (Set)
@@ -64,15 +64,15 @@ firstUpdateTick =
     Tick.succ Tick.genesis
 
 
-prepareLiveRound : Config -> Random.Seed -> Set String -> MidRoundState
-prepareLiveRound config seed pressedButtons =
+prepareLiveRound : Config -> Random.Seed -> List PlayerConfig -> Set String -> MidRoundState
+prepareLiveRound config seed playerConfigs pressedButtons =
     let
         recordInitialInteractions : List Player -> List Player
         recordInitialInteractions =
             List.map (recordUserInteraction pressedButtons firstUpdateTick)
 
         ( thePlayers, seedAfterSpawn ) =
-            Random.step (generatePlayers config) seed |> Tuple.mapFirst recordInitialInteractions
+            Random.step (generatePlayers config playerConfigs) seed |> Tuple.mapFirst recordInitialInteractions
     in
     ( Live, prepareRoundHelper config { seedAfterSpawn = seedAfterSpawn, spawnedPlayers = thePlayers, pressedButtons = pressedButtons } )
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,7 @@ module Main exposing (main)
 
 import Browser
 import Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
-import Config exposing (Config)
+import Config exposing (Config, PlayerConfig)
 import Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualPlayer, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
@@ -20,6 +20,7 @@ type alias Model =
     { pressedButtons : Set String
     , gameState : GameState
     , config : Config
+    , playerConfigs : List PlayerConfig
     }
 
 
@@ -28,6 +29,7 @@ init _ =
     ( { pressedButtons = Set.empty
       , gameState = Lobby (Random.initialSeed 1337)
       , config = Config.default
+      , playerConfigs = Config.players
       }
     , Cmd.none
     )
@@ -132,7 +134,7 @@ update msg ({ pressedButtons } as model) =
                 startNewRoundIfSpacePressed seed =
                     case button of
                         Key "Space" ->
-                            startRound model <| prepareLiveRound model.config seed pressedButtons
+                            startRound model <| prepareLiveRound model.config seed model.playerConfigs pressedButtons
 
                         _ ->
                             ( handleUserInteraction Down button model, Cmd.none )

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -13,12 +13,12 @@ import Types.Thickness as Thickness
 import World exposing (Position, distanceToTicks)
 
 
-generatePlayers : Config -> Random.Generator (List Player)
-generatePlayers config =
+generatePlayers : Config -> List PlayerConfig -> Random.Generator (List Player)
+generatePlayers config playerConfigs =
     let
         numberOfPlayers : Int
         numberOfPlayers =
-            List.length config.players
+            List.length playerConfigs
 
         generateNewAndPrepend : Config.PlayerConfig -> List Player -> Random.Generator (List Player)
         generateNewAndPrepend playerConfig precedingPlayers =
@@ -35,7 +35,7 @@ generatePlayers config =
             List.foldl
                 (Random.andThen << generateNewAndPrepend)
                 (Random.constant [])
-                config.players
+                playerConfigs
     in
     generateReversedPlayers |> Random.map List.reverse
 


### PR DESCRIPTION
While working on making the players user-configurable, we realized that they're not about "how the game works", but rather about "who's playing".

💡 `git show --color-words='\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>