### PR TITLE
Make PlayerId a type alias

### DIFF
--- a/src/Round.elm
+++ b/src/Round.elm
@@ -3,7 +3,6 @@ module Round exposing (Players, Round, RoundHistory, RoundInitialState, initialS
 import Random
 import Set exposing (Set)
 import Types.Player as Player exposing (Player)
-import Types.PlayerId as PlayerId
 import World exposing (Pixel)
 
 
@@ -78,4 +77,4 @@ initialStateForReplaying round =
 
 sortPlayers : List Player -> List Player
 sortPlayers =
-    List.sortBy (.id >> PlayerId.toInt)
+    List.sortBy .id

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -7,7 +7,7 @@ import Random.Extra as Random
 import Types.Angle exposing (Angle(..))
 import Types.Distance as Distance exposing (Distance(..))
 import Types.Player as Player exposing (Player)
-import Types.PlayerId exposing (PlayerId(..))
+import Types.PlayerId exposing (PlayerId)
 import Types.Radius as Radius
 import Types.Thickness as Thickness
 import World exposing (Position, distanceToTicks)
@@ -25,7 +25,7 @@ generatePlayers config playerConfigs =
             let
                 id : PlayerId
                 id =
-                    PlayerId <| List.length precedingPlayers
+                    List.length precedingPlayers
             in
             generatePlayer config id numberOfPlayers (List.map (.state >> .position) precedingPlayers) playerConfig
                 |> Random.map (\player -> player :: precedingPlayers)

--- a/src/Types/PlayerId.elm
+++ b/src/Types/PlayerId.elm
@@ -1,10 +1,5 @@
-module Types.PlayerId exposing (PlayerId(..), toInt)
+module Types.PlayerId exposing (PlayerId)
 
 
-type PlayerId
-    = PlayerId Int
-
-
-toInt : PlayerId -> Int
-toInt (PlayerId n) =
-    n
+type alias PlayerId =
+    Int


### PR DESCRIPTION
We're planning on using player IDs as `Dict` keys, which cannot be custom types.

💡 `git show --color-words='\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>