### PR TITLE
Remove `type="module"` in `script` tag

### DIFF
--- a/ZATACKA.html
+++ b/ZATACKA.html
@@ -43,7 +43,7 @@
     <div id="elm-node"></div>
 
     <script src="./build/ZATACKA.js"></script>
-    <script type="module">
+    <script>
         const app = Elm.Main.init({ node: document.getElementById("elm-node") })
         const context_main = canvas_main.getContext("2d")
         const context_overlay = canvas_overlay.getContext("2d")


### PR DESCRIPTION
It's been obsolete since the `import` statement was removed in #42.

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>