### PR TITLE
Remove startNewRoundIfSpacePressed

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -129,27 +129,25 @@ update msg ({ pressedButtons } as model) =
             )
 
         ButtonUsed Down button ->
-            let
-                startNewRoundIfSpacePressed : Random.Seed -> ( Model, Cmd msg )
-                startNewRoundIfSpacePressed seed =
+            case model.gameState of
+                Lobby seed ->
                     case button of
                         Key "Space" ->
                             startRound model <| prepareLiveRound model.config seed model.playerConfigs pressedButtons
 
                         _ ->
                             ( handleUserInteraction Down button model, Cmd.none )
-            in
-            case model.gameState of
-                Lobby seed ->
-                    startNewRoundIfSpacePressed seed
 
                 PostRound finishedRound ->
                     case button of
                         Key "KeyR" ->
                             startRound model <| prepareReplayRound model.config (initialStateForReplaying finishedRound)
 
+                        Key "Space" ->
+                            startRound model <| prepareLiveRound model.config finishedRound.seed model.playerConfigs pressedButtons
+
                         _ ->
-                            startNewRoundIfSpacePressed finishedRound.seed
+                            ( handleUserInteraction Down button model, Cmd.none )
 
                 _ ->
                     ( handleUserInteraction Down button model, Cmd.none )


### PR DESCRIPTION
When we started working on the lobby, scoring etc, the abstraction captured by `startNewRoundIfSpacePressed` broke down.

💡 `git show --color-moved`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>