### PR TITLE
Rename Player to Kurve

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,7 +1,7 @@
 port module Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
 
 import Color exposing (Color)
-import Types.Player exposing (Player)
+import Types.Kurve exposing (Kurve)
 import Types.Thickness as Thickness exposing (Thickness)
 import World exposing (DrawingPosition)
 
@@ -27,14 +27,14 @@ bodyDrawingCmd thickness =
             )
 
 
-headDrawingCmd : Thickness -> List Player -> Cmd msg
+headDrawingCmd : Thickness -> List Kurve -> Cmd msg
 headDrawingCmd thickness =
     renderOverlay
         << List.map
-            (\player ->
-                { position = World.drawingPosition thickness player.state.position
+            (\kurve ->
+                { position = World.drawingPosition thickness kurve.state.position
                 , thickness = Thickness.toInt thickness
-                , color = Color.toCssString player.color
+                , color = Color.toCssString kurve.color
                 }
             )
 
@@ -47,8 +47,8 @@ clearEverything ( worldWidth, worldHeight ) =
         ]
 
 
-drawSpawnIfAndOnlyIf : Bool -> Player -> Thickness -> Cmd msg
-drawSpawnIfAndOnlyIf shouldBeVisible player thickness =
+drawSpawnIfAndOnlyIf : Bool -> Kurve -> Thickness -> Cmd msg
+drawSpawnIfAndOnlyIf shouldBeVisible kurve thickness =
     let
         thicknessAsInt : Int
         thicknessAsInt =
@@ -56,14 +56,14 @@ drawSpawnIfAndOnlyIf shouldBeVisible player thickness =
 
         drawingPosition : DrawingPosition
         drawingPosition =
-            World.drawingPosition thickness player.state.position
+            World.drawingPosition thickness kurve.state.position
     in
     if shouldBeVisible then
         render <|
             List.singleton
                 { position = drawingPosition
                 , thickness = thicknessAsInt
-                , color = Color.toCssString player.color
+                , color = Color.toCssString kurve.color
                 }
 
     else

--- a/src/Config.elm
+++ b/src/Config.elm
@@ -24,10 +24,10 @@ default =
             }
         }
     , spawn =
-        { margin = 100 -- The minimum distance from the wall that a player can spawn.
+        { margin = 100 -- The minimum distance from the wall that a Kurve can spawn.
         , desiredMinimumDistanceTurningRadiusFactor = 1
         , protectionAudacity = 0.25 -- Closer to 1 ⇔ less risk of spawn kills but higher risk of no solution
-        , flickerTicksPerSecond = 20 -- At each tick, the spawning player is toggled between visible and invisible.
+        , flickerTicksPerSecond = 20 -- At each tick, the spawning Kurve is toggled between visible and invisible.
         , numberOfFlickerTicks = 5
         , angleInterval = ( -pi / 2, pi / 2 )
         }

--- a/src/Round.elm
+++ b/src/Round.elm
@@ -1,22 +1,22 @@
-module Round exposing (Players, Round, RoundHistory, RoundInitialState, initialStateForReplaying, modifyAlive, modifyDead, modifyPlayers, roundIsOver)
+module Round exposing (Kurves, Round, RoundHistory, RoundInitialState, initialStateForReplaying, modifyAlive, modifyDead, modifyKurves, roundIsOver)
 
 import Random
 import Set exposing (Set)
-import Types.Player as Player exposing (Player)
+import Types.Kurve as Kurve exposing (Kurve)
 import World exposing (Pixel)
 
 
 type alias Round =
-    { players : Players
+    { kurves : Kurves
     , occupiedPixels : Set Pixel
     , history : RoundHistory
     , seed : Random.Seed
     }
 
 
-type alias Players =
-    { alive : List Player
-    , dead : List Player
+type alias Kurves =
+    { alive : List Kurve
+    , dead : List Kurve
     }
 
 
@@ -27,36 +27,36 @@ type alias RoundHistory =
 
 type alias RoundInitialState =
     { seedAfterSpawn : Random.Seed
-    , spawnedPlayers : List Player
+    , spawnedKurves : List Kurve
     , pressedButtons : Set String
     }
 
 
-modifyPlayers : (Players -> Players) -> Round -> Round
-modifyPlayers f round =
-    { round | players = f round.players }
+modifyKurves : (Kurves -> Kurves) -> Round -> Round
+modifyKurves f round =
+    { round | kurves = f round.kurves }
 
 
-modifyAlive : (List Player -> List Player) -> Players -> Players
-modifyAlive f players =
-    { players | alive = f players.alive }
+modifyAlive : (List Kurve -> List Kurve) -> Kurves -> Kurves
+modifyAlive f kurves =
+    { kurves | alive = f kurves.alive }
 
 
-modifyDead : (List Player -> List Player) -> Players -> Players
-modifyDead f players =
-    { players | dead = f players.dead }
+modifyDead : (List Kurve -> List Kurve) -> Kurves -> Kurves
+modifyDead f kurves =
+    { kurves | dead = f kurves.dead }
 
 
-roundIsOver : Players -> Bool
-roundIsOver players =
+roundIsOver : Kurves -> Bool
+roundIsOver kurves =
     let
         someoneHasWonInMultiPlayer : Bool
         someoneHasWonInMultiPlayer =
-            List.length players.alive == 1 && not (List.isEmpty players.dead)
+            List.length kurves.alive == 1 && not (List.isEmpty kurves.dead)
 
         playerHasDiedInSinglePlayer : Bool
         playerHasDiedInSinglePlayer =
-            List.isEmpty players.alive
+            List.isEmpty kurves.alive
     in
     someoneHasWonInMultiPlayer || playerHasDiedInSinglePlayer
 
@@ -68,13 +68,13 @@ initialStateForReplaying round =
         initialState =
             round.history.initialState
 
-        thePlayers : List Player
-        thePlayers =
-            round.players.alive ++ round.players.dead
+        theKurves : List Kurve
+        theKurves =
+            round.kurves.alive ++ round.kurves.dead
     in
-    { initialState | spawnedPlayers = thePlayers |> List.map Player.reset |> sortPlayers }
+    { initialState | spawnedKurves = theKurves |> List.map Kurve.reset |> sortKurves }
 
 
-sortPlayers : List Player -> List Player
-sortPlayers =
+sortKurves : List Kurve -> List Kurve
+sortKurves =
     List.sortBy .id

--- a/src/Turning.elm
+++ b/src/Turning.elm
@@ -3,7 +3,7 @@ module Turning exposing (computeAngleChange, computeTurningState, turningStateFr
 import Config exposing (KurveConfig)
 import Set exposing (Set)
 import Types.Angle as Angle exposing (Angle(..))
-import Types.Player exposing (Player, UserInteraction(..))
+import Types.Kurve exposing (Kurve, UserInteraction(..))
 import Types.Radius as Radius
 import Types.Speed as Speed
 import Types.Tick as Tick exposing (Tick)
@@ -24,11 +24,11 @@ computeAngleChange kurveConfig turningState =
             Angle 0
 
 
-computeTurningState : Set String -> Player -> TurningState
-computeTurningState pressedButtons player =
+computeTurningState : Set String -> Kurve -> TurningState
+computeTurningState pressedButtons kurve =
     let
         ( leftButtons, rightButtons ) =
-            player.controls
+            kurve.controls
 
         someIsPressed : Set String -> Bool
         someIsPressed =
@@ -51,9 +51,9 @@ computedAngleChange { tickrate, turningRadius, speed } =
     Angle (Speed.toFloat speed / (Tickrate.toFloat tickrate * Radius.toFloat turningRadius))
 
 
-turningStateFromHistory : Tick -> Player -> TurningState
-turningStateFromHistory currentTick player =
-    newestFromBefore currentTick player.reversedInteractions
+turningStateFromHistory : Tick -> Kurve -> TurningState
+turningStateFromHistory currentTick kurve =
+    newestFromBefore currentTick kurve.reversedInteractions
 
 
 newestFromBefore : Tick -> List UserInteraction -> TurningState

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -1,4 +1,4 @@
-module Types.Player exposing (Fate(..), HoleStatus(..), Player, State, UserInteraction(..), modifyReversedInteractions, reset)
+module Types.Kurve exposing (Fate(..), HoleStatus(..), Kurve, State, UserInteraction(..), modifyReversedInteractions, reset)
 
 import Color exposing (Color)
 import Set exposing (Set)
@@ -9,7 +9,7 @@ import Types.TurningState exposing (TurningState)
 import World exposing (Position)
 
 
-type alias Player =
+type alias Kurve =
     { color : Color
     , id : PlayerId
     , controls : ( Set String, Set String ) -- `Set` is exactly what we want here; `String` is not, but since Elm doesn't support user-defined typeclass instances, we have to make do with a type that already is `comparable`.
@@ -23,9 +23,9 @@ type UserInteraction
     = HappenedBefore Tick TurningState
 
 
-modifyReversedInteractions : (List UserInteraction -> List UserInteraction) -> Player -> Player
-modifyReversedInteractions f player =
-    { player | reversedInteractions = f player.reversedInteractions }
+modifyReversedInteractions : (List UserInteraction -> List UserInteraction) -> Kurve -> Kurve
+modifyReversedInteractions f kurve =
+    { kurve | reversedInteractions = f kurve.reversedInteractions }
 
 
 type alias State =
@@ -47,6 +47,6 @@ type HoleStatus
     | Holy Int
 
 
-reset : Player -> Player
-reset player =
-    { player | state = player.stateAtSpawn }
+reset : Kurve -> Kurve
+reset kurve =
+    { kurve | state = kurve.stateAtSpawn }


### PR DESCRIPTION
The need for a clear distinction between a _player_ (a person playing the game) and a _Kurve_ (a colored snake, typically but not necessarily controlled by a player) has grown more and more apparent. This PR renames the `Player` type to `Kurve`, because that's what it actually represents, and updates all related variables and comments accordingly.

💡 `git show --color-words='[Pp]layer|.'`