### PR TITLE
Move player definitions out of Config module

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,7 +1,5 @@
-module Config exposing (Config, HoleConfig, KurveConfig, Player, SpawnConfig, WorldConfig, default, players)
+module Config exposing (Config, HoleConfig, KurveConfig, SpawnConfig, WorldConfig, default)
 
-import Color exposing (Color)
-import Input exposing (Button(..))
 import Types.Distance exposing (Distance(..))
 import Types.Radius exposing (Radius(..))
 import Types.Speed exposing (Speed(..))
@@ -38,34 +36,6 @@ default =
     }
 
 
-players : List Player
-players =
-    let
-        rgb : Int -> Int -> Int -> Color
-        rgb =
-            Color.rgb255
-    in
-    [ { color = rgb 255 40 0
-      , controls = ( [ Key "Digit1" ], [ Key "KeyQ" ] )
-      }
-    , { color = rgb 195 195 0
-      , controls = ( [ Key "ControlLeft", Key "KeyZ" ], [ Key "AltLeft", Key "KeyX" ] )
-      }
-    , { color = rgb 255 121 0
-      , controls = ( [ Key "KeyM" ], [ Key "Comma" ] )
-      }
-    , { color = rgb 0 203 0
-      , controls = ( [ Key "ArrowLeft" ], [ Key "ArrowDown" ] )
-      }
-    , { color = rgb 223 81 182
-      , controls = ( [ Key "NumpadDivide", Key "End", Key "PageDown" ], [ Key "NumpadMultiply", Key "PageUp" ] )
-      }
-    , { color = rgb 0 162 203
-      , controls = ( [ Mouse 0 ], [ Mouse 2 ] )
-      }
-    ]
-
-
 type alias Config =
     { kurves : KurveConfig
     , spawn : SpawnConfig
@@ -95,12 +65,6 @@ type alias SpawnConfig =
 type alias WorldConfig =
     { width : Int
     , height : Int
-    }
-
-
-type alias Player =
-    { color : Color
-    , controls : ( List Button, List Button )
     }
 
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,7 +1,7 @@
 module Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualKurve, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 
 import Color exposing (Color)
-import Config exposing (Config, KurveConfig, Player)
+import Config exposing (Config, KurveConfig)
 import Random
 import Round exposing (Kurves, Round, RoundInitialState, modifyAlive, modifyDead)
 import Set exposing (Set)
@@ -10,6 +10,7 @@ import Turning exposing (computeAngleChange, computeTurningState, turningStateFr
 import Types.Angle as Angle exposing (Angle)
 import Types.Distance as Distance exposing (Distance(..))
 import Types.Kurve as Kurve exposing (Kurve, UserInteraction(..), modifyReversedInteractions)
+import Types.Player exposing (Player)
 import Types.Speed as Speed
 import Types.Thickness as Thickness exposing (Thickness)
 import Types.Tick as Tick exposing (Tick)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,15 +2,17 @@ module Main exposing (main)
 
 import Browser
 import Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
-import Config exposing (Config, Player)
+import Config exposing (Config)
 import Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualKurve, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
 import Input exposing (Button(..), ButtonDirection(..), inputSubscriptions, updatePressedButtons)
+import Players exposing (players)
 import Random
 import Round exposing (Round, initialStateForReplaying, modifyAlive, modifyKurves, roundIsOver)
 import Set exposing (Set)
 import Time
+import Types.Player exposing (Player)
 import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 import Util exposing (isEven)
@@ -29,7 +31,7 @@ init _ =
     ( { pressedButtons = Set.empty
       , gameState = Lobby (Random.initialSeed 1337)
       , config = Config.default
-      , players = Config.players
+      , players = players
       }
     , Cmd.none
     )

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -1,0 +1,33 @@
+module Players exposing (players)
+
+import Color exposing (Color)
+import Input exposing (Button(..))
+import Types.Player exposing (Player)
+
+
+players : List Player
+players =
+    let
+        rgb : Int -> Int -> Int -> Color
+        rgb =
+            Color.rgb255
+    in
+    [ { color = rgb 255 40 0
+      , controls = ( [ Key "Digit1" ], [ Key "KeyQ" ] )
+      }
+    , { color = rgb 195 195 0
+      , controls = ( [ Key "ControlLeft", Key "KeyZ" ], [ Key "AltLeft", Key "KeyX" ] )
+      }
+    , { color = rgb 255 121 0
+      , controls = ( [ Key "KeyM" ], [ Key "Comma" ] )
+      }
+    , { color = rgb 0 203 0
+      , controls = ( [ Key "ArrowLeft" ], [ Key "ArrowDown" ] )
+      }
+    , { color = rgb 223 81 182
+      , controls = ( [ Key "NumpadDivide", Key "End", Key "PageDown" ], [ Key "NumpadMultiply", Key "PageUp" ] )
+      }
+    , { color = rgb 0 162 203
+      , controls = ( [ Mouse 0 ], [ Mouse 2 ] )
+      }
+    ]

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -1,12 +1,13 @@
 module Spawn exposing (generateHoleSize, generateHoleSpacing, generateKurves)
 
-import Config exposing (Config, HoleConfig, KurveConfig, Player, SpawnConfig, WorldConfig)
+import Config exposing (Config, HoleConfig, KurveConfig, SpawnConfig, WorldConfig)
 import Input exposing (toStringSetControls)
 import Random
 import Random.Extra as Random
 import Types.Angle exposing (Angle(..))
 import Types.Distance as Distance exposing (Distance(..))
 import Types.Kurve as Kurve exposing (Kurve)
+import Types.Player exposing (Player)
 import Types.PlayerId exposing (PlayerId)
 import Types.Radius as Radius
 import Types.Thickness as Thickness
@@ -20,7 +21,7 @@ generateKurves config players =
         numberOfPlayers =
             List.length players
 
-        generateNewAndPrepend : Config.Player -> List Kurve -> Random.Generator (List Kurve)
+        generateNewAndPrepend : Player -> List Kurve -> Random.Generator (List Kurve)
         generateNewAndPrepend player precedingKurves =
             let
                 id : PlayerId

--- a/src/Types/Player.elm
+++ b/src/Types/Player.elm
@@ -1,0 +1,10 @@
+module Types.Player exposing (Player)
+
+import Color exposing (Color)
+import Input exposing (Button)
+
+
+type alias Player =
+    { color : Color
+    , controls : ( List Button, List Button )
+    }


### PR DESCRIPTION
Since #47, players are not part of the config anymore.

💡 `git show --color-moved=plain`

💡 `git show --color-words=.`