### PR TITLE
Enable non-participating players internally

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -2,6 +2,7 @@ module Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), Sp
 
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
+import Players exposing (ParticipatingPlayers)
 import Random
 import Round exposing (Kurves, Round, RoundInitialState, modifyAlive, modifyDead)
 import Set exposing (Set)
@@ -10,7 +11,6 @@ import Turning exposing (computeAngleChange, computeTurningState, turningStateFr
 import Types.Angle as Angle exposing (Angle)
 import Types.Distance as Distance exposing (Distance(..))
 import Types.Kurve as Kurve exposing (Kurve, UserInteraction(..), modifyReversedInteractions)
-import Types.Player exposing (Player)
 import Types.Speed as Speed
 import Types.Thickness as Thickness exposing (Thickness)
 import Types.Tick as Tick exposing (Tick)
@@ -65,7 +65,7 @@ firstUpdateTick =
     Tick.succ Tick.genesis
 
 
-prepareLiveRound : Config -> Random.Seed -> List Player -> Set String -> MidRoundState
+prepareLiveRound : Config -> Random.Seed -> ParticipatingPlayers -> Set String -> MidRoundState
 prepareLiveRound config seed players pressedButtons =
     let
         recordInitialInteractions : List Kurve -> List Kurve

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -8,7 +8,7 @@ import Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), Sp
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
 import Input exposing (Button(..), ButtonDirection(..), inputSubscriptions, updatePressedButtons)
-import Players exposing (AllPlayers, handlePlayerJoiningOrLeaving, initialPlayers, participating)
+import Players exposing (AllPlayers, initialPlayers, participating)
 import Random
 import Round exposing (Round, initialStateForReplaying, modifyAlive, modifyKurves, roundIsOver)
 import Set exposing (Set)
@@ -138,7 +138,7 @@ update msg ({ pressedButtons } as model) =
                             startRound model <| prepareLiveRound model.config seed (participating model.players) pressedButtons
 
                         _ ->
-                            ( handleUserInteraction Down button { model | players = handlePlayerJoiningOrLeaving button model.players }, Cmd.none )
+                            ( handleUserInteraction Down button model, Cmd.none )
 
                 PostRound finishedRound ->
                     case button of

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -1,34 +1,22 @@
 module Players exposing (AllPlayers, ParticipatingPlayers, initialPlayers, participating)
 
 import Color exposing (Color)
-import Dict exposing (Dict)
 import Input exposing (Button(..))
 import Types.Player exposing (Player)
-import Types.PlayerId exposing (PlayerId)
 import Types.PlayerStatus exposing (PlayerStatus(..))
 
 
 type alias AllPlayers =
-    Dict PlayerId ( Player, PlayerStatus )
+    List ( Player, PlayerStatus )
 
 
 type alias ParticipatingPlayers =
-    Dict PlayerId Player
+    List Player
 
 
 participating : AllPlayers -> ParticipatingPlayers
 participating =
-    let
-        includeIfParticipating : PlayerId -> ( Player, PlayerStatus ) -> ParticipatingPlayers -> ParticipatingPlayers
-        includeIfParticipating id ( player, status ) =
-            case status of
-                Participating ->
-                    Dict.insert id player
-
-                NotParticipating ->
-                    identity
-    in
-    Dict.foldl includeIfParticipating Dict.empty
+    List.filter (Tuple.second >> (==) Participating) >> List.map Tuple.first
 
 
 initialPlayers : AllPlayers
@@ -43,7 +31,7 @@ initialPlayers =
             else
                 NotParticipating
     in
-    players |> List.indexedMap (\id player -> ( id, ( player, status id ) )) |> Dict.fromList
+    players |> List.indexedMap (\id player -> ( player, status id ))
 
 
 players : List Player

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -1,4 +1,4 @@
-module Players exposing (AllPlayers, ParticipatingPlayers, handlePlayerJoiningOrLeaving, initialPlayers, participating)
+module Players exposing (AllPlayers, ParticipatingPlayers, initialPlayers, participating)
 
 import Color exposing (Color)
 import Dict exposing (Dict)
@@ -14,31 +14,6 @@ type alias AllPlayers =
 
 type alias ParticipatingPlayers =
     Dict PlayerId Player
-
-
-handlePlayerJoiningOrLeaving : Button -> AllPlayers -> AllPlayers
-handlePlayerJoiningOrLeaving button =
-    Dict.map
-        (\_ ( player, status ) ->
-            let
-                ( leftButtons, rightButtons ) =
-                    player.controls
-
-                newStatus : PlayerStatus
-                newStatus =
-                    case ( List.member button leftButtons, List.member button rightButtons ) of
-                        ( True, False ) ->
-                            Participating
-
-                        ( False, True ) ->
-                            NotParticipating
-
-                        _ ->
-                            -- This case either represents that the pressed button isn't used by the player in question at all, or the absurd scenario that it's used by said player for turning _both_ left and right.
-                            status
-            in
-            ( player, newStatus )
-        )
 
 
 participating : AllPlayers -> ParticipatingPlayers

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -33,7 +33,17 @@ participating =
 
 initialPlayers : AllPlayers
 initialPlayers =
-    players |> List.indexedMap (\id player -> ( id, ( player, Participating ) )) |> Dict.fromList
+    let
+        status : Int -> PlayerStatus
+        status id =
+            -- Dummy conditional expression demonstrating that players could be non-participating.
+            if id >= 0 then
+                Participating
+
+            else
+                NotParticipating
+    in
+    players |> List.indexedMap (\id player -> ( id, ( player, status id ) )) |> Dict.fromList
 
 
 players : List Player

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -1,7 +1,9 @@
 module Spawn exposing (generateHoleSize, generateHoleSpacing, generateKurves)
 
 import Config exposing (Config, HoleConfig, KurveConfig, SpawnConfig, WorldConfig)
+import Dict
 import Input exposing (toStringSetControls)
+import Players exposing (ParticipatingPlayers)
 import Random
 import Random.Extra as Random
 import Types.Angle exposing (Angle(..))
@@ -11,30 +13,26 @@ import Types.Player exposing (Player)
 import Types.PlayerId exposing (PlayerId)
 import Types.Radius as Radius
 import Types.Thickness as Thickness
+import Util exposing (curry)
 import World exposing (Position, distanceToTicks)
 
 
-generateKurves : Config -> List Player -> Random.Generator (List Kurve)
+generateKurves : Config -> ParticipatingPlayers -> Random.Generator (List Kurve)
 generateKurves config players =
     let
         numberOfPlayers : Int
         numberOfPlayers =
-            List.length players
+            Dict.size players
 
-        generateNewAndPrepend : Player -> List Kurve -> Random.Generator (List Kurve)
-        generateNewAndPrepend player precedingKurves =
-            let
-                id : PlayerId
-                id =
-                    List.length precedingKurves
-            in
+        generateNewAndPrepend : ( PlayerId, Player ) -> List Kurve -> Random.Generator (List Kurve)
+        generateNewAndPrepend ( id, player ) precedingKurves =
             generateKurve config id numberOfPlayers (List.map (.state >> .position) precedingKurves) player
                 |> Random.map (\kurve -> kurve :: precedingKurves)
 
         generateReversedKurves : Random.Generator (List Kurve)
         generateReversedKurves =
-            List.foldl
-                (Random.andThen << generateNewAndPrepend)
+            Dict.foldl
+                (curry (Random.andThen << generateNewAndPrepend))
                 (Random.constant [])
                 players
     in

--- a/src/Types/PlayerStatus.elm
+++ b/src/Types/PlayerStatus.elm
@@ -1,0 +1,6 @@
+module Types.PlayerStatus exposing (PlayerStatus(..))
+
+
+type PlayerStatus
+    = Participating
+    | NotParticipating

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,4 +1,9 @@
-module Util exposing (isEven)
+module Util exposing (curry, isEven)
+
+
+curry : (( a, b ) -> c) -> a -> b -> c
+curry f a b =
+    f ( a, b )
 
 
 isEven : Int -> Bool

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,9 +1,4 @@
-module Util exposing (curry, isEven)
-
-
-curry : (( a, b ) -> c) -> a -> b -> c
-curry f a b =
-    f ( a, b )
+module Util exposing (isEven)
 
 
 isEven : Int -> Bool


### PR DESCRIPTION
This PR lays the foundations for a lobby where players can join and leave. All six players automatically participate, so there is no user-noticeable difference.

💡 `git show --color-words='\w+|\S'`