### PR TITLE
Add game-over condition and basic end screen

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,7 +1,10 @@
-module Config exposing (Config, HoleConfig, KurveConfig, SpawnConfig, WorldConfig, default)
+module Config exposing (Config, GameConfig, HoleConfig, KurveConfig, SpawnConfig, WorldConfig, default)
 
+import Dict
+import Players exposing (ParticipatingPlayers)
 import Types.Distance exposing (Distance(..))
 import Types.Radius exposing (Radius(..))
+import Types.Score exposing (Score(..), isAtLeast)
 import Types.Speed exposing (Speed(..))
 import Types.Thickness exposing (Thickness(..))
 import Types.Tickrate exposing (Tickrate(..))
@@ -33,13 +36,37 @@ default =
         { width = 559
         , height = 480
         }
+    , game =
+        { isGameOver = defaultGameOverCondition
+        }
     }
+
+
+defaultGameOverCondition : ParticipatingPlayers -> Bool
+defaultGameOverCondition participatingPlayers =
+    let
+        numberOfPlayers : Int
+        numberOfPlayers =
+            Dict.size participatingPlayers
+
+        targetScore : Score
+        targetScore =
+            Score ((numberOfPlayers - 1) * 10)
+
+        someoneHasReachedTargetScore : Bool
+        someoneHasReachedTargetScore =
+            not <|
+                Dict.isEmpty <|
+                    Dict.filter (always (Tuple.second >> isAtLeast targetScore)) participatingPlayers
+    in
+    numberOfPlayers > 1 && someoneHasReachedTargetScore
 
 
 type alias Config =
     { kurves : KurveConfig
     , spawn : SpawnConfig
     , world : WorldConfig
+    , game : GameConfig
     }
 
 
@@ -65,6 +92,11 @@ type alias SpawnConfig =
 type alias WorldConfig =
     { width : Int
     , height : Int
+    }
+
+
+type alias GameConfig =
+    { isGameOver : ParticipatingPlayers -> Bool
     }
 
 

--- a/src/GUI/EndScreen.elm
+++ b/src/GUI/EndScreen.elm
@@ -1,0 +1,13 @@
+module GUI.EndScreen exposing (endScreen)
+
+import Html exposing (Html, div)
+import Html.Attributes as Attr
+
+
+endScreen : Html msg
+endScreen =
+    div
+        [ Attr.id "endScreen"
+        ]
+        [ Html.text "KONEC HRY"
+        ]

--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -30,6 +30,9 @@ scoreboard gameState players =
 
             PostRound round ->
                 content players round
+
+            GameOver _ ->
+                []
         )
 
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -24,6 +24,7 @@ type GameState
     | PostRound Round
     | PreRound SpawnState MidRoundState
     | Lobby Random.Seed
+    | GameOver Random.Seed
 
 
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -1,4 +1,4 @@
-module Players exposing (AllPlayers, ParticipatingPlayers, atLeastOneIsParticipating, handlePlayerJoiningOrLeaving, includeResultsFrom, initialPlayers, participating)
+module Players exposing (AllPlayers, ParticipatingPlayers, atLeastOneIsParticipating, everyoneLeaves, handlePlayerJoiningOrLeaving, includeResultsFrom, initialPlayers, participating)
 
 import Color exposing (Color)
 import Dict exposing (Dict)
@@ -41,6 +41,11 @@ handlePlayerJoiningOrLeaving button =
             in
             ( player, newStatus )
         )
+
+
+everyoneLeaves : AllPlayers -> AllPlayers
+everyoneLeaves =
+    Dict.map (always (Tuple.mapSecond (always NotParticipating)))
 
 
 participating : AllPlayers -> ParticipatingPlayers

--- a/src/Types/Score.elm
+++ b/src/Types/Score.elm
@@ -1,5 +1,10 @@
-module Types.Score exposing (Score(..))
+module Types.Score exposing (Score(..), isAtLeast)
 
 
 type Score
     = Score Int
+
+
+isAtLeast : Score -> Score -> Bool
+isAtLeast (Score threshold) (Score s) =
+    s >= threshold

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -129,6 +129,15 @@ $scoreboardWidth: 77px;
     }
 }
 
+#endScreen {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
 #canvas_main {
     background-color: black;
     overflow: hidden;


### PR DESCRIPTION
As in the original game, the game ends as soon as at least one player has accumulated (𝑛 − 1) × 10 points, where 𝑛 is the number of participating players. When that happens, a placeholder end screen (similar to the placeholder lobby added in #44) is shown, where pressing Space returns to the lobby. The real end screen, including the final results, will be added later.

💡 `git show --color-words=.`