### PR TITLE
Group in-game states together

### DIFF
--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -2,7 +2,7 @@ module GUI.Scoreboard exposing (scoreboard)
 
 import Dict
 import GUI.Digits
-import Game exposing (GameState(..))
+import Game exposing (AppState(..), GameState(..))
 import Html exposing (Html, div)
 import Html.Attributes as Attr
 import Players exposing (AllPlayers, includeResultsFrom, participating)
@@ -12,23 +12,23 @@ import Types.PlayerStatus exposing (PlayerStatus(..))
 import Types.Score exposing (Score(..))
 
 
-scoreboard : GameState -> AllPlayers -> Html msg
-scoreboard gameState players =
+scoreboard : AppState -> AllPlayers -> Html msg
+scoreboard appState players =
     div
         [ Attr.id "scoreboard"
         , Attr.class "canvasHeight"
         ]
-        (case gameState of
+        (case appState of
             Lobby _ ->
                 []
 
-            PreRound _ ( _, round ) ->
+            InGame (PreRound _ ( _, round )) ->
                 content players round
 
-            MidRound _ ( _, round ) ->
+            InGame (MidRound _ ( _, round )) ->
                 content players round
 
-            PostRound round ->
+            InGame (PostRound round) ->
                 content players round
 
             GameOver _ ->

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,4 +1,4 @@
-module Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualKurve, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
+module Game exposing (AppState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualKurve, firstUpdateTick, modifyGameState, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
@@ -19,12 +19,26 @@ import Types.TurningState exposing (TurningState)
 import World exposing (DrawingPosition, Pixel, Position, distanceToTicks)
 
 
+type AppState
+    = InGame GameState
+    | Lobby Random.Seed
+    | GameOver Random.Seed
+
+
+modifyGameState : (GameState -> GameState) -> AppState -> AppState
+modifyGameState f appState =
+    case appState of
+        InGame gameState ->
+            InGame <| f gameState
+
+        _ ->
+            appState
+
+
 type GameState
     = MidRound Tick MidRoundState
     | PostRound Round
     | PreRound SpawnState MidRoundState
-    | Lobby Random.Seed
-    | GameOver Random.Seed
 
 
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState


### PR DESCRIPTION
This PR lifts the `Lobby` and `GameOver` states out of the `GameState` type into a new `AppState` type, where the three in-game states (`PreRound`, `MidRound`, and `PostRound`) are grouped under an `InGame` umbrella. That is, the `GameState` type is essentially split into two "layers".

💡 `git show --color-words='\w+|.'`