### PR TITLE
Use document.getElementById to get canvases

### DIFF
--- a/ZATACKA.html
+++ b/ZATACKA.html
@@ -45,8 +45,8 @@
     <script src="./build/ZATACKA.js"></script>
     <script>
         const app = Elm.Main.init({ node: document.getElementById("elm-node") })
-        const context_main = canvas_main.getContext("2d")
-        const context_overlay = canvas_overlay.getContext("2d")
+        const context_main = document.getElementById("canvas_main").getContext("2d")
+        const context_overlay = document.getElementById("canvas_overlay").getContext("2d")
 
         function drawSquare(context, { position: { leftEdge, topEdge }, thickness, color }) {
             context.fillStyle = color


### PR DESCRIPTION
Implicitly defined ID-based global variables don't communicate the programmer's intention very well, and may make the behavior of the code hard to reason about, especially if, in some potential scenario where canvases may need to be acquired more than once, the `canvas` elements are replaced by Elm.

💡 `git show --color-words=.`