### PR TITLE
Group menu states together

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -1,13 +1,13 @@
 module App exposing (AppState(..), modifyGameState)
 
 import Game exposing (GameState)
+import Menu exposing (MenuState)
 import Random
 
 
 type AppState
     = InGame GameState
-    | Lobby Random.Seed
-    | GameOver Random.Seed
+    | InMenu MenuState Random.Seed
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState

--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -6,6 +6,7 @@ import GUI.Digits
 import Game exposing (GameState(..))
 import Html exposing (Html, div)
 import Html.Attributes as Attr
+import Menu exposing (MenuState(..))
 import Players exposing (AllPlayers, includeResultsFrom, participating)
 import Round exposing (Round)
 import Types.Player exposing (Player)
@@ -20,7 +21,7 @@ scoreboard appState players =
         , Attr.class "canvasHeight"
         ]
         (case appState of
-            Lobby _ ->
+            InMenu Lobby _ ->
                 []
 
             InGame (PreRound _ ( _, round )) ->
@@ -32,7 +33,7 @@ scoreboard appState players =
             InGame (PostRound round) ->
                 content players round
 
-            GameOver _ ->
+            InMenu GameOver _ ->
                 []
         )
 

--- a/src/Menu.elm
+++ b/src/Menu.elm
@@ -1,0 +1,6 @@
+module Menu exposing (MenuState(..))
+
+
+type MenuState
+    = Lobby
+    | GameOver


### PR DESCRIPTION
This PR improves on #62 by grouping the non-in-game states under an `InMenu` umbrella.

💡 `git show --color-words='InMenu MenuState|.'`