### PR TITLE
Only render canvases when in-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,8 @@
         const app = Elm.Main.init({ node: document.getElementById("elm-node") })
 
         function getCanvasContext(id) {
-            return document.getElementById(id).getContext("2d")
+            const canvas = document.getElementById(id)
+            return canvas === null ? null : canvas.getContext("2d")
         }
 
         function drawSquare(context, { position: { leftEdge, topEdge }, thickness, color }) {
@@ -55,8 +56,10 @@
             context.fillRect(leftEdge, topEdge, thickness, thickness)
         }
 
-        function clearRectangle(context, { x, y, width, height }) {
-            context.clearRect(x, y, width, height)
+        function clearRectangleIfCanvasExists(context, { x, y, width, height }) {
+            if (context !== null) {
+                context.clearRect(x, y, width, height)
+            }
         }
 
         app.ports.render.subscribe(squares => {
@@ -68,12 +71,12 @@
 
         app.ports.clear.subscribe(rectangle => {
             const context_main = getCanvasContext("canvas_main")
-            clearRectangle(context_main, rectangle)
+            clearRectangleIfCanvasExists(context_main, rectangle)
         })
 
         app.ports.renderOverlay.subscribe(squares => {
             const context_overlay = getCanvasContext("canvas_overlay")
-            clearRectangle(context_overlay, { x: 0, y: 0, width: Number.MAX_SAFE_INTEGER, height: Number.MAX_SAFE_INTEGER })
+            clearRectangleIfCanvasExists(context_overlay, { x: 0, y: 0, width: Number.MAX_SAFE_INTEGER, height: Number.MAX_SAFE_INTEGER })
             for (const square of squares) {
                 drawSquare(context_overlay, square)
             }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -251,29 +251,29 @@ view model =
         [ div
             [ Attr.id "border"
             ]
-            [ canvas
-                [ Attr.id "canvas_main"
-                , Attr.width 559
-                , Attr.height 480
-                ]
-                []
-            , canvas
-                [ Attr.id "canvas_overlay"
-                , Attr.width 559
-                , Attr.height 480
-                , Attr.class "overlay"
-                ]
-                []
-            , case model.appState of
+            (case model.appState of
                 InMenu Lobby _ ->
-                    lobby model.players
+                    [ lobby model.players ]
 
                 InMenu GameOver _ ->
-                    endScreen model.players
+                    [ endScreen model.players ]
 
                 _ ->
-                    Html.text ""
-            ]
+                    [ canvas
+                        [ Attr.id "canvas_main"
+                        , Attr.width 559
+                        , Attr.height 480
+                        ]
+                        []
+                    , canvas
+                        [ Attr.id "canvas_overlay"
+                        , Attr.width 559
+                        , Attr.height 480
+                        , Attr.class "overlay"
+                        ]
+                        []
+                    ]
+            )
         , scoreboard model.appState model.players
         ]
 

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -49,6 +49,9 @@ $leftMargin: (
 );
 
 #border {
+    width: $canvasWidth;
+    height: 480px;
+    background-color: black;
     display: flex; /* to prevent weird extra space at the bottom */
     position: relative; /* to allow absolute positioning of descendants*/
     box-shadow: (
@@ -101,7 +104,6 @@ $minWidthForCenteredCanvas: (
 }
 
 #lobby {
-    position: absolute;
     width: 100%;
     height: 100%;
     padding-top: 50px;
@@ -147,7 +149,7 @@ $minWidthForCenteredCanvas: (
 }
 
 #endScreen {
-    position: absolute;
+    position: relative;
     width: 100%;
     height: 100%;
 


### PR DESCRIPTION
This PR decouples the overall view of the application from the canvases, which are only really needed when in-game (not e.g. in the lobby). 

Without the changes in `index.html`, the application immediately crashes when the first round is started:

    Uncaught TypeError: Cannot read properties of null (reading 'getContext')

This happens because we clear the canvases at the start of every round, including the first round, when, as of this PR, they don't yet exist. "Why isn't `drawSquare` modified then?" Because it's only used when the canvases do exist, and should we ever try to draw on a canvas that doesn't exist, we probably don't want that to fail silently. _Clearing_ a canvas that doesn't exist, however, probably isn't that big of an issue, because it's probably about to be created/replaced, so it'll end up empty anyway.