### PR TITLE
Make Elm root node cover entire viewport

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -245,37 +245,44 @@ subscriptions model =
 
 view : Model -> Html Msg
 view model =
-    div
-        [ Attr.id "wrapper"
-        ]
+    elmRoot
         [ div
-            [ Attr.id "border"
+            [ Attr.id "wrapper"
             ]
-            (case model.appState of
-                InMenu Lobby _ ->
-                    [ lobby model.players ]
+            [ div
+                [ Attr.id "border"
+                ]
+                (case model.appState of
+                    InMenu Lobby _ ->
+                        [ lobby model.players ]
 
-                InMenu GameOver _ ->
-                    [ endScreen model.players ]
+                    InMenu GameOver _ ->
+                        [ endScreen model.players ]
 
-                _ ->
-                    [ canvas
-                        [ Attr.id "canvas_main"
-                        , Attr.width 559
-                        , Attr.height 480
+                    _ ->
+                        [ canvas
+                            [ Attr.id "canvas_main"
+                            , Attr.width 559
+                            , Attr.height 480
+                            ]
+                            []
+                        , canvas
+                            [ Attr.id "canvas_overlay"
+                            , Attr.width 559
+                            , Attr.height 480
+                            , Attr.class "overlay"
+                            ]
+                            []
                         ]
-                        []
-                    , canvas
-                        [ Attr.id "canvas_overlay"
-                        , Attr.width 559
-                        , Attr.height 480
-                        , Attr.class "overlay"
-                        ]
-                        []
-                    ]
-            )
+                )
+            ]
         , scoreboard model.appState model.players
         ]
+
+
+elmRoot : List (Html msg) -> Html msg
+elmRoot =
+    div [ Attr.id "elm-root" ]
 
 
 main : Program () Model Msg

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -12,11 +12,16 @@ html, body {
 
 body {
     background-color: #3C3C3C;
-    display: flex;
-    align-items: center;
     overflow: hidden;
     color: white;
     font-size: 12px;
+}
+
+#elm-root {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
 }
 
 h1 {
@@ -70,13 +75,13 @@ $minWidthForCenteredCanvas: (
 );
 
 @media (max-width: $minWidthForCenteredCanvas) {
-    body {
+    #elm-root {
         justify-content: flex-end; // Prioritizes visible scoreboard over centered canvas.
     }
 }
 
 @media (min-width: $minWidthForCenteredCanvas) {
-    body {
+    #elm-root {
         justify-content: center;
     }
 }


### PR DESCRIPTION
This PR adds an Elm-defined div acting as a de-facto body, since the real body cannot be modified from within Elm.

💡 `git show --ignore-space-change --color-moved`