### PR TITLE
Make menu screens borderless

### DIFF
--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -1,12 +1,10 @@
 module GUI.Scoreboard exposing (scoreboard)
 
-import App exposing (AppState(..))
 import Dict
 import GUI.Digits
 import Game exposing (GameState(..))
 import Html exposing (Html, div)
 import Html.Attributes as Attr
-import Menu exposing (MenuState(..))
 import Players exposing (AllPlayers, includeResultsFrom, participating)
 import Round exposing (Round)
 import Types.Player exposing (Player)
@@ -14,27 +12,21 @@ import Types.PlayerStatus exposing (PlayerStatus(..))
 import Types.Score exposing (Score(..))
 
 
-scoreboard : AppState -> AllPlayers -> Html msg
-scoreboard appState players =
+scoreboard : GameState -> AllPlayers -> Html msg
+scoreboard gameState players =
     div
         [ Attr.id "scoreboard"
         , Attr.class "canvasHeight"
         ]
-        (case appState of
-            InMenu Lobby _ ->
-                []
-
-            InGame (PreRound _ ( _, round )) ->
+        (case gameState of
+            PreRound _ ( _, round ) ->
                 content players round
 
-            InGame (MidRound _ ( _, round )) ->
+            MidRound _ ( _, round ) ->
                 content players round
 
-            InGame (PostRound round) ->
+            PostRound round ->
                 content players round
-
-            InMenu GameOver _ ->
-                []
         )
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -245,21 +245,23 @@ subscriptions model =
 
 view : Model -> Html Msg
 view model =
-    elmRoot
-        [ div
-            [ Attr.id "wrapper"
-            ]
-            [ div
-                [ Attr.id "border"
+    case model.appState of
+        InMenu Lobby _ ->
+            elmRoot [] [ lobby model.players ]
+
+        InMenu GameOver _ ->
+            elmRoot [] [ endScreen model.players ]
+
+        InGame gameState ->
+            elmRoot
+                [ Attr.class "in-game"
                 ]
-                (case model.appState of
-                    InMenu Lobby _ ->
-                        [ lobby model.players ]
-
-                    InMenu GameOver _ ->
-                        [ endScreen model.players ]
-
-                    _ ->
+                [ div
+                    [ Attr.id "wrapper"
+                    ]
+                    [ div
+                        [ Attr.id "border"
+                        ]
                         [ canvas
                             [ Attr.id "canvas_main"
                             , Attr.width 559
@@ -274,15 +276,14 @@ view model =
                             ]
                             []
                         ]
-                )
-            ]
-        , scoreboard model.appState model.players
-        ]
+                    , scoreboard gameState model.players
+                    ]
+                ]
 
 
-elmRoot : List (Html msg) -> Html msg
-elmRoot =
-    div [ Attr.id "elm-root" ]
+elmRoot : List (Html.Attribute msg) -> List (Html msg) -> Html msg
+elmRoot attrs =
+    div (Attr.id "elm-root" :: attrs)
 
 
 main : Program () Model Msg

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -1,3 +1,6 @@
+$nativeWidth: 640px;
+$nativeHeight: 480px;
+
 * {
     margin: 0;
     padding: 0;
@@ -11,17 +14,24 @@ html, body {
 }
 
 body {
-    background-color: #3C3C3C;
+    background-color: black;
     overflow: hidden;
     color: white;
     font-size: 12px;
 }
 
 #elm-root {
+    min-width: $nativeWidth;
+    min-height: $nativeHeight;
     width: 100%;
     height: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
+
+    &.in-game {
+        background-color: #3C3C3C;
+    }
 }
 
 h1 {
@@ -75,13 +85,13 @@ $minWidthForCenteredCanvas: (
 );
 
 @media (max-width: $minWidthForCenteredCanvas) {
-    #elm-root {
+    #elm-root.in-game {
         justify-content: flex-end; // Prioritizes visible scoreboard over centered canvas.
     }
 }
 
 @media (min-width: $minWidthForCenteredCanvas) {
-    #elm-root {
+    #elm-root.in-game {
         justify-content: center;
     }
 }
@@ -109,8 +119,8 @@ $minWidthForCenteredCanvas: (
 }
 
 #lobby {
-    width: 100%;
-    height: 100%;
+    width: $nativeWidth;
+    height: $nativeHeight;
     padding-top: 50px;
     padding-left: 81px;
     box-sizing: border-box;
@@ -155,8 +165,8 @@ $minWidthForCenteredCanvas: (
 
 #endScreen {
     position: relative;
-    width: 100%;
-    height: 100%;
+    width: $nativeWidth;
+    height: $nativeHeight;
 
     #results {
         margin-top: 80px;
@@ -180,7 +190,7 @@ $minWidthForCenteredCanvas: (
 }
 
 .canvasHeight {
-    height: 480px;
+    height: $nativeHeight;
 }
 
 #left {


### PR DESCRIPTION
This PR removes the gray border on the so-called menu screens (i.e. the lobby, the end screen and the not-yet-existing splash screen), making them all black, as in the original MS-DOS game. The scoreboard is refactored accordingly, reflecting the fact that it's now only visible when in-game.

Notably, this PR makes our clone virtually indistinguishable from the original MS-DOS game when run in a 640px × 480px viewport (except that the splash screen doesn't exist yet).

💡 `git show --ignore-space-change --color-words='List \(Html msg\)|\w+|.'`