### PR TITLE
Remove redundant canvas clearing commands

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -184,12 +184,12 @@ update msg ({ pressedButtons } as model) =
 
 gameOver : Random.Seed -> Model -> ( Model, Cmd msg )
 gameOver seed model =
-    ( { model | appState = InMenu GameOver seed }, clearEverything )
+    ( { model | appState = InMenu GameOver seed }, Cmd.none )
 
 
 returnToLobby : Random.Seed -> Model -> ( Model, Cmd msg )
 returnToLobby seed model =
-    ( { model | appState = InMenu Lobby seed, players = everyoneLeaves model.players }, clearEverything )
+    ( { model | appState = InMenu Lobby seed, players = everyoneLeaves model.players }, Cmd.none )
 
 
 handleUserInteraction : ButtonDirection -> Button -> Model -> Model


### PR DESCRIPTION
Since #74, the canvas isn't the background of the menu screens anymore, so there's no reason to clear it when switching to them.