### PR TITLE
Fix lobby content alignment

### DIFF
--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -128,7 +128,7 @@ $minWidthForCenteredCanvas: (
     width: $nativeWidth;
     height: $nativeHeight;
     padding-top: 50px;
-    padding-left: 81px;
+    padding-left: 80px;
     box-sizing: border-box;
 
     .playerEntry {


### PR DESCRIPTION
In #57, we deliberately aligned everything exactly as in the legacy JavaScript version, but it turns out the latter (which is live at https://kurve.se at the time of writing) actually has the wrong alignment with respect to the original MS-DOS game. Judging from the Git history, lobby content alignment has been a recurring theme of confusion throughout the years, but I believe this PR should fix it once and for all.

An easy way to confirm the correct alignment is to modify the original game using e.g. `sed -i 's/(L.Ctrl/YL.Ctrl/' ZATACKA.EXE`, run it (`dosbox ZATACKA.EXE`), take a screenshot (Ctrl + F5), and measure the distance from the left edge in a raster graphics editor (e.g. GIMP). The letter `Y` is particularly useful because it occupies the entire 8px maximum glyph width of the Borland Graphics Interface default bitmap font, so – unlike with `(` – there are no doubts regarding where the left edge of the glyph bounding box is.

This PR could have left the `81px` lobby padding untouched and instead modified/removed the mask position of `.controls`, but modifying the lobby padding seems much closer to what we actually mean.