### PR TITLE
Render unsupported characters sanely (not at all)

### DIFF
--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -114,6 +114,7 @@ $minWidthForCenteredCanvas: (
     display: inline-block;
     -webkit-mask-image: url("../resources/fonts/bgi-default-8x8.png");
     mask-image: url("../resources/fonts/bgi-default-8x8.png");
+    mask-repeat: no-repeat; // Prevents unsupported characters from wrapping around and being displayed as some seemingly arbitrary supported character.
     mask-size: auto 100%;
 }
 


### PR DESCRIPTION
It makes absolutely no sense for e.g. 'Ä' to be rendered as 'D', just because 196 modulo 128 happens to equal 68.

Compared to rendering all non-ASCII characters as '?' or similar, this solution is easier to implement and completely forward-compatible, should we ever support ISO-8859-1 or something in the future.