### PR TITLE
Show players' actual controls in lobby

### DIFF
--- a/src/GUI/Buttons/Keyboard.elm
+++ b/src/GUI/Buttons/Keyboard.elm
@@ -79,36 +79,9 @@ Note: No button description in the original game exceeds 7 characters in length,
 misc : String -> Interpretation
 misc keyCode =
     case keyCode of
-        "AltLeft" ->
-            Named "L.Alt"
-
-        "AltRight" ->
-            -- Could have been "AltGr", but this is nicely dual to "L.Alt"; they are in turn analogous to "L.Ctrl" (from the original game) and "R.Ctrl".
-            Named "R.Alt"
-
-        "ArrowDown" ->
-            -- From the original game.
-            Named "D.Arrow"
-
-        "ArrowLeft" ->
-            -- From the original game.
-            Named "L.Arrow"
-
-        "ArrowRight" ->
-            Named "R.Arrow"
-
-        "ArrowUp" ->
-            Named "U.Arrow"
-
-        "AudioVolumeDown" ->
-            Named "VolDn"
-
-        "AudioVolumeMute" ->
-            Named "Mute"
-
-        "AudioVolumeUp" ->
-            Named "VolUp"
-
+        {- Alphanumeric Section
+           https://www.w3.org/TR/uievents-code/#key-alphanumeric-section
+        -}
         "Backquote" ->
             Character '`'
 
@@ -124,12 +97,44 @@ misc keyCode =
         "BracketRight" ->
             Character ']'
 
-        "CapsLock" ->
-            Named "CapsLk"
-
         "Comma" ->
             -- From the original game.
             Character ','
+
+        "Equal" ->
+            Character '='
+
+        "IntlBackslash" ->
+            -- Unclear what this key can be said to represent, but it produces a '\' in the English (UK) layout.
+            Character '\\'
+
+        "Minus" ->
+            Character '-'
+
+        "Period" ->
+            Character '.'
+
+        "Quote" ->
+            Character '\''
+
+        "Semicolon" ->
+            Character ';'
+
+        "Slash" ->
+            Character '/'
+
+        {- Functional Keys
+           https://www.w3.org/TR/uievents-code/#key-alphanumeric-functional
+        -}
+        "AltLeft" ->
+            Named "L.Alt"
+
+        "AltRight" ->
+            -- Could have been "AltGr", but this is nicely dual to "L.Alt"; they are in turn analogous to "L.Ctrl" (from the original game) and "R.Ctrl".
+            Named "R.Alt"
+
+        "CapsLock" ->
+            Named "CapsLk"
 
         "ContextMenu" ->
             Named "Menu"
@@ -140,20 +145,29 @@ misc keyCode =
         "ControlRight" ->
             Named "R.Ctrl"
 
+        "Enter" ->
+            Named "Enter"
+
+        "ShiftLeft" ->
+            Named "L.Shift"
+
+        "ShiftRight" ->
+            Named "R.Shift"
+
+        "Space" ->
+            Named "Space"
+
+        "Tab" ->
+            Named "Tab"
+
+        {- Control Pad Section
+           https://www.w3.org/TR/uievents-code/#key-controlpad-section
+        -}
         "Delete" ->
             Named "Del"
 
         "End" ->
             Named "End"
-
-        "Enter" ->
-            Named "Enter"
-
-        "Equal" ->
-            Character '='
-
-        "Escape" ->
-            Named "Esc"
 
         "Home" ->
             Named "Home"
@@ -161,13 +175,32 @@ misc keyCode =
         "Insert" ->
             Named "Ins"
 
-        "IntlBackslash" ->
-            -- Unclear what this key can be said to represent, but it produces a '\' in the English (UK) layout.
-            Character '\\'
+        "PageDown" ->
+            Named "PgDn"
 
-        "Minus" ->
-            Character '-'
+        "PageUp" ->
+            Named "PgUp"
 
+        {- Arrow Pad Section
+           https://www.w3.org/TR/uievents-code/#key-arrowpad-section
+        -}
+        "ArrowDown" ->
+            -- From the original game.
+            Named "D.Arrow"
+
+        "ArrowLeft" ->
+            -- From the original game.
+            Named "L.Arrow"
+
+        "ArrowRight" ->
+            Named "R.Arrow"
+
+        "ArrowUp" ->
+            Named "U.Arrow"
+
+        {- Numpad Section
+           https://www.w3.org/TR/uievents-code/#key-numpad-section
+        -}
         "NumLock" ->
             Named "NumLk"
 
@@ -206,44 +239,32 @@ misc keyCode =
             -- Just the character without any prefix to maintain consistency between the mathematical operators; 'NumpadMultiply' is rendered as '*' in the original game.
             Character '-'
 
-        "PageDown" ->
-            Named "PgDn"
-
-        "PageUp" ->
-            Named "PgUp"
+        {- Function Section
+           https://www.w3.org/TR/uievents-code/#key-function-section
+        -}
+        "Escape" ->
+            Named "Esc"
 
         "Pause" ->
             Named "Pause"
 
-        "Period" ->
-            Character '.'
-
         "PrintScreen" ->
             Named "PrtSc"
-
-        "Quote" ->
-            Character '\''
 
         "ScrollLock" ->
             Named "ScrLk"
 
-        "Semicolon" ->
-            Character ';'
+        {- Media Keys
+           https://www.w3.org/TR/uievents-code/#key-media
+        -}
+        "AudioVolumeDown" ->
+            Named "VolDn"
 
-        "ShiftLeft" ->
-            Named "L.Shift"
+        "AudioVolumeMute" ->
+            Named "Mute"
 
-        "ShiftRight" ->
-            Named "R.Shift"
-
-        "Slash" ->
-            Character '/'
-
-        "Space" ->
-            Named "Space"
-
-        "Tab" ->
-            Named "Tab"
+        "AudioVolumeUp" ->
+            Named "VolUp"
 
         "VolumeDown" ->
             Named "VolDn"

--- a/src/GUI/Buttons/Keyboard.elm
+++ b/src/GUI/Buttons/Keyboard.elm
@@ -83,7 +83,7 @@ misc keyCode =
             Named "L.Alt"
 
         "AltRight" ->
-            -- Nicely dual to "L.Alt"; they are in turn dual to "L.Ctrl" (from the original game) and "R.Ctrl".
+            -- Could have been "AltGr", but this is nicely dual to "L.Alt"; they are in turn analogous to "L.Ctrl" (from the original game) and "R.Ctrl".
             Named "R.Alt"
 
         "ArrowDown" ->

--- a/src/GUI/Buttons/Keyboard.elm
+++ b/src/GUI/Buttons/Keyboard.elm
@@ -172,7 +172,7 @@ misc keyCode =
             Named "NumLk"
 
         "NumpadAdd" ->
-            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            -- Just the character without any prefix to maintain consistency between the mathematical operators; 'NumpadMultiply' is rendered as '*' in the original game.
             Character '+'
 
         "NumpadComma" ->
@@ -182,14 +182,14 @@ misc keyCode =
             NumpadChar '.'
 
         "NumpadDivide" ->
-            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            -- Just the character without any prefix to maintain consistency between the mathematical operators; 'NumpadMultiply' is rendered as '*' in the original game.
             Character '/'
 
         "NumpadEnter" ->
             Named "Enter"
 
         "NumpadEqual" ->
-            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            -- Just the character without any prefix to maintain consistency between the mathematical operators; 'NumpadMultiply' is rendered as '*' in the original game.
             Character '='
 
         "NumpadMultiply" ->
@@ -203,7 +203,7 @@ misc keyCode =
             NumpadChar ')'
 
         "NumpadSubtract" ->
-            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            -- Just the character without any prefix to maintain consistency between the mathematical operators; 'NumpadMultiply' is rendered as '*' in the original game.
             Character '-'
 
         "PageDown" ->

--- a/src/GUI/Buttons/Keyboard.elm
+++ b/src/GUI/Buttons/Keyboard.elm
@@ -1,0 +1,258 @@
+module GUI.Buttons.Keyboard exposing (keyCodeRepresentation)
+
+{-| This module contains logic for representing a key code (the `code` property of a `KeyboardEvent`) in a human-readable way.
+
+There are three major aspects that make this non-trivial:
+
+  - The `code` property represents a physical key, without any keyboard layout settings taken into consideration. For example, we cannot distinguish between "[" on an English keyboard, "Å" on a Swedish keyboard, and "Ü" on a German keyboard – all of them appear as `BracketLeft` to us.
+  - There are differences between operating systems and browsers. For example, `OSLeft`/`MetaLeft` (depending on browser) is typically referred to as "Win" on Windows, "Super" on Linux and "Cmd" on macOS.
+  - We can only render ASCII characters using the current GUI text implementation.
+
+👉 <https://www.w3.org/TR/uievents-code>
+👉 <https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values>
+
+-}
+
+
+keyCodeRepresentation : String -> String
+keyCodeRepresentation keyCode =
+    case interpret keyCode of
+        Character c ->
+            String.fromChar c
+
+        NumpadChar c ->
+            "Num " ++ String.fromChar c
+
+        FKey n ->
+            "F" ++ String.fromInt n
+
+        Named name ->
+            name
+
+        Unknown ->
+            keyCode
+
+
+type Interpretation
+    = Character Char
+    | NumpadChar Char
+    | FKey Int
+    | Named String
+    | Unknown
+
+
+interpret : String -> Interpretation
+interpret keyCode =
+    case String.toList keyCode of
+        'D' :: 'i' :: 'g' :: 'i' :: 't' :: c :: [] ->
+            -- DigitX
+            Character c
+
+        'K' :: 'e' :: 'y' :: c :: [] ->
+            -- KeyX
+            Character c
+
+        'N' :: 'u' :: 'm' :: 'p' :: 'a' :: 'd' :: c :: [] ->
+            -- NumpadX, where X is presumably a digit
+            NumpadChar c
+
+        _ ->
+            parseFKey keyCode |> Maybe.withDefault (misc keyCode)
+
+
+parseFKey : String -> Maybe Interpretation
+parseFKey keyCode =
+    case String.uncons keyCode of
+        Just ( 'F', n ) ->
+            -- FX, where X is a presumably positive integer
+            String.toInt n |> Maybe.map FKey
+
+        _ ->
+            Nothing
+
+
+{-| Miscellaneous keys.
+
+Note: No button description in the original game exceeds 7 characters in length, and 8 is the maximum that's guaranteed to fit to the left of "READY".
+
+-}
+misc : String -> Interpretation
+misc keyCode =
+    case keyCode of
+        "AltLeft" ->
+            Named "L.Alt"
+
+        "AltRight" ->
+            -- Nicely dual to "L.Alt"; they are in turn dual to "L.Ctrl" (from the original game) and "R.Ctrl".
+            Named "R.Alt"
+
+        "ArrowDown" ->
+            -- From the original game.
+            Named "D.Arrow"
+
+        "ArrowLeft" ->
+            -- From the original game.
+            Named "L.Arrow"
+
+        "ArrowRight" ->
+            Named "R.Arrow"
+
+        "ArrowUp" ->
+            Named "U.Arrow"
+
+        "AudioVolumeDown" ->
+            Named "VolDn"
+
+        "AudioVolumeMute" ->
+            Named "Mute"
+
+        "AudioVolumeUp" ->
+            Named "VolUp"
+
+        "Backquote" ->
+            Character '`'
+
+        "Backslash" ->
+            Character '\\'
+
+        "Backspace" ->
+            Named "Bksp"
+
+        "BracketLeft" ->
+            Character '['
+
+        "BracketRight" ->
+            Character ']'
+
+        "CapsLock" ->
+            Named "CapsLk"
+
+        "Comma" ->
+            -- From the original game.
+            Character ','
+
+        "ContextMenu" ->
+            Named "Menu"
+
+        "ControlLeft" ->
+            Named "L.Ctrl"
+
+        "ControlRight" ->
+            Named "R.Ctrl"
+
+        "Delete" ->
+            Named "Del"
+
+        "End" ->
+            Named "End"
+
+        "Enter" ->
+            Named "Enter"
+
+        "Equal" ->
+            Character '='
+
+        "Escape" ->
+            Named "Esc"
+
+        "Home" ->
+            Named "Home"
+
+        "Insert" ->
+            Named "Ins"
+
+        "IntlBackslash" ->
+            -- Unclear what this key can be said to represent, but it produces a '\' in the English (UK) layout.
+            Character '\\'
+
+        "Minus" ->
+            Character '-'
+
+        "NumLock" ->
+            Named "NumLk"
+
+        "NumpadAdd" ->
+            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            Character '+'
+
+        "NumpadComma" ->
+            NumpadChar ','
+
+        "NumpadDecimal" ->
+            NumpadChar '.'
+
+        "NumpadDivide" ->
+            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            Character '/'
+
+        "NumpadEnter" ->
+            Named "Enter"
+
+        "NumpadEqual" ->
+            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            Character '='
+
+        "NumpadMultiply" ->
+            -- From the original game.
+            Character '*'
+
+        "NumpadParenLeft" ->
+            NumpadChar '('
+
+        "NumpadParenRight" ->
+            NumpadChar ')'
+
+        "NumpadSubtract" ->
+            -- 'NumpadMultiply' is rendered as '*' in the original game.
+            Character '-'
+
+        "PageDown" ->
+            Named "PgDn"
+
+        "PageUp" ->
+            Named "PgUp"
+
+        "Pause" ->
+            Named "Pause"
+
+        "Period" ->
+            Character '.'
+
+        "PrintScreen" ->
+            Named "PrtSc"
+
+        "Quote" ->
+            Character '\''
+
+        "ScrollLock" ->
+            Named "ScrLk"
+
+        "Semicolon" ->
+            Character ';'
+
+        "ShiftLeft" ->
+            Named "L.Shift"
+
+        "ShiftRight" ->
+            Named "R.Shift"
+
+        "Slash" ->
+            Character '/'
+
+        "Space" ->
+            Named "Space"
+
+        "Tab" ->
+            Named "Tab"
+
+        "VolumeDown" ->
+            Named "VolDn"
+
+        "VolumeMute" ->
+            Named "Mute"
+
+        "VolumeUp" ->
+            Named "VolUp"
+
+        _ ->
+            Unknown

--- a/src/GUI/Buttons/Mouse.elm
+++ b/src/GUI/Buttons/Mouse.elm
@@ -1,0 +1,19 @@
+module GUI.Buttons.Mouse exposing (mouseButtonRepresentation)
+
+
+mouseButtonRepresentation : Int -> String
+mouseButtonRepresentation n =
+    case n of
+        0 ->
+            -- From the original game.
+            "L.Mouse"
+
+        1 ->
+            "M.Mouse"
+
+        2 ->
+            -- From the original game.
+            "R.Mouse"
+
+        _ ->
+            "Mouse " ++ String.fromInt n

--- a/src/GUI/Controls.elm
+++ b/src/GUI/Controls.elm
@@ -37,10 +37,10 @@ showButton button =
 
 {-| The purpose of this limit is to prevent unexpected layout breakage caused either by
 
-  - an explicitly defined representation for some button, or
+  - an explicitly defined representation, or
   - a key code that we don't have a human-readable representation for.
 
-7 characters is the maximum in the original game (L.Mouse, R.Mouse, L.Arrow, D.Arrow).
+7 characters is the maximum in the original game (L.Arrow, D.Arrow, L.Mouse, R.Mouse).
 
 8 characters is the maximum that is guaranteed to fit to the left of "READY" in the lobby of the original game.
 

--- a/src/GUI/Controls.elm
+++ b/src/GUI/Controls.elm
@@ -1,0 +1,50 @@
+module GUI.Controls exposing (showControls)
+
+import GUI.Buttons.Keyboard exposing (keyCodeRepresentation)
+import GUI.Buttons.Mouse exposing (mouseButtonRepresentation)
+import Input exposing (Button)
+import Types.Player exposing (Player)
+
+
+showControls : Player -> ( String, String )
+showControls { controls } =
+    let
+        showFirst : List Button -> String
+        showFirst =
+            List.head >> Maybe.map showButton >> Maybe.withDefault "N/A"
+    in
+    Tuple.mapBoth showFirst showFirst controls
+
+
+showButton : Button -> String
+showButton button =
+    let
+        representation : String
+        representation =
+            case button of
+                Input.Mouse n ->
+                    mouseButtonRepresentation n
+
+                Input.Key keyCode ->
+                    keyCodeRepresentation keyCode
+
+        charsToDrop : Int
+        charsToDrop =
+            String.length representation - maxLength
+    in
+    String.dropRight charsToDrop representation
+
+
+{-| The purpose of this limit is to prevent unexpected layout breakage caused either by
+
+  - an explicitly defined representation for some button, or
+  - a key code that we don't have a human-readable representation for.
+
+7 characters is the maximum in the original game (L.Mouse, R.Mouse, L.Arrow, D.Arrow).
+
+8 characters is the maximum that is guaranteed to fit to the left of "READY" in the lobby of the original game.
+
+-}
+maxLength : Int
+maxLength =
+    8

--- a/src/GUI/Lobby.elm
+++ b/src/GUI/Lobby.elm
@@ -1,12 +1,12 @@
 module GUI.Lobby exposing (lobby)
 
 import Dict
+import GUI.Controls
 import GUI.Text as Text
 import Html exposing (Html, div)
 import Html.Attributes as Attr
 import Players exposing (AllPlayers)
 import Types.Player exposing (Player)
-import Types.PlayerId exposing (PlayerId)
 import Types.PlayerStatus exposing (PlayerStatus(..))
 
 
@@ -15,14 +15,14 @@ lobby players =
     div
         [ Attr.id "lobby"
         ]
-        (Dict.toList players |> List.map playerEntry)
+        (Dict.values players |> List.map playerEntry)
 
 
-playerEntry : ( PlayerId, ( Player, PlayerStatus ) ) -> Html msg
-playerEntry ( id, ( player, status ) ) =
+playerEntry : ( Player, PlayerStatus ) -> Html msg
+playerEntry ( player, status ) =
     let
         ( left, right ) =
-            controls id
+            GUI.Controls.showControls player
     in
     Html.div
         [ Attr.class "playerEntry" ]
@@ -42,28 +42,3 @@ playerEntry ( id, ( player, status ) ) =
             ]
             (Text.string (Text.Size 2) player.color "READY")
         ]
-
-
-controls : PlayerId -> ( String, String )
-controls id =
-    case id of
-        0 ->
-            ( "1", "Q" )
-
-        1 ->
-            ( "L.Ctrl", "L.Alt" )
-
-        2 ->
-            ( "M", "," )
-
-        3 ->
-            ( "L.Arrow", "D.Arrow" )
-
-        4 ->
-            ( "/", "*" )
-
-        5 ->
-            ( "L.Mouse", "R.Mouse" )
-
-        _ ->
-            ( "", "" )


### PR DESCRIPTION
Today, the controls shown in the lobby are hard-coded for each player ID and don't necessarily reflect the controls actually used by the players to control their Kurves. Thanks to #78, we can now show the actual controls.

If a player has multiple buttons bound to the same action, the first one in the list is shown. If no button is bound, "N/A" is shown.

The key codes are taken from W3 and MDN:

  * https://www.w3.org/TR/uievents-code/
  * https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values

These are deliberately omitted:

  * `Hyper`, `Super`, `Turbo`, `Abort`, `Resume`, `Suspend`, `Again`, `Copy`, `Cut`, `Find`, `Open`, `Paste`, `Props`, `Select`, `Undo`

    They are described as legacy keys by W3, and their representations would perfectly match their key codes anyway.

    https://www.w3.org/TR/uievents-code/#key-legacy

  * `BrowserBack`, `BrowserFavorites`, `BrowserForward`, `BrowserHome`, `BrowserRefresh`, `BrowserSearch`, `BrowserStop`, `Eject`, `LaunchApp1`, `LaunchApp2`, `LaunchMail`, `MediaPlayPause`, `MediaSelect`, `MediaStop`, `MediaTrackNext`, `MediaTrackPrevious`, `Power`, `Sleep`, `WakeUp`

    I believe they will rarely be used. (The representations of `Eject` and the last three would perfectly match the key codes, by the way.)

    https://www.w3.org/TR/uievents-code/#key-media

  * `Convert`, `NonConvert`, `IntlRo`, `IntlYen`, `KanaMode`, `Lang1`, `Lang2`, `Lang3`, `Lang4`, `Lang5`

    My understanding is that they are used on Japanese and/or Korean keyboards. I don't know what their (ASCII) representations should be, and I think the key codes themselves are OK.

    https://www.w3.org/TR/uievents-code/#key-alphanumeric-functional

  * `NumpadBackspace`, `NumpadClear`, `NumpadClearEntry`, `NumpadHash`, `NumpadMemoryAdd`, `NumpadMemoryClear`, `NumpadMemoryRecall`, `NumpadMemoryStore`, `NumpadMemorySubtract`, `NumpadStar`

    I believe they will rarely be used.

    https://www.w3.org/TR/uievents-code/#key-numpad-section

  * `MetaLeft`, `MetaLeft`, `MetaRight`, `MetaRight`, `OSLeft`, `OSRight`

    They should be represented differently depending on OS ("Win" on Windows, "Cmd" on macOS, "Super" on Linux); we don't have support for that today.

    https://www.w3.org/TR/uievents-code/#key-alphanumeric-functional

  * `Fn`, `FnLock`, `Help`

    I believe they will rarely be used, and representations would perfectly match key codes anyway.