### PR TITLE
Add confirmation dialog when quitting

### DIFF
--- a/src/Dialog.elm
+++ b/src/Dialog.elm
@@ -1,0 +1,11 @@
+module Dialog exposing (Option(..), State(..))
+
+
+type State
+    = Open Option
+    | NotOpen
+
+
+type Option
+    = Confirm
+    | Cancel

--- a/src/GUI/ConfirmQuitDialog.elm
+++ b/src/GUI/ConfirmQuitDialog.elm
@@ -1,4 +1,4 @@
-module GUI.Dialogs exposing (overlay)
+module GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 
 import Color
 import Dialog
@@ -9,23 +9,23 @@ import Html.Attributes as Attr
 import Html.Events exposing (onClick)
 
 
-overlay : (Dialog.Option -> msg) -> GameState -> Html msg
-overlay makeMsg gameState =
+confirmQuitDialog : (Dialog.Option -> msg) -> GameState -> Html msg
+confirmQuitDialog makeMsg gameState =
     case gameState of
         RoundOver _ (Dialog.Open selectedOption) ->
             div
                 [ Attr.class "overlay"
                 , Attr.class "dialogOverlay"
                 ]
-                [ confirm makeMsg "Really quit?" selectedOption
+                [ dialogBox makeMsg "Really quit?" selectedOption
                 ]
 
         _ ->
             Html.text ""
 
 
-confirm : (Dialog.Option -> msg) -> String -> Dialog.Option -> Html msg
-confirm makeMsg question selectedOption =
+dialogBox : (Dialog.Option -> msg) -> String -> Dialog.Option -> Html msg
+dialogBox makeMsg question selectedOption =
     let
         optionButton : Dialog.Option -> String -> Html msg
         optionButton option label =

--- a/src/GUI/Dialogs.elm
+++ b/src/GUI/Dialogs.elm
@@ -11,13 +11,17 @@ import Html.Events exposing (onClick)
 
 overlay : (Dialog.Option -> msg) -> GameState -> Html msg
 overlay makeMsg gameState =
-    div [ Attr.class "overlay", Attr.class "dialogOverlay" ] <|
-        case gameState of
-            RoundOver _ (Dialog.Open selectedOption) ->
-                List.singleton <| confirm makeMsg "Really quit?" selectedOption
+    case gameState of
+        RoundOver _ (Dialog.Open selectedOption) ->
+            div
+                [ Attr.class "overlay"
+                , Attr.class "dialogOverlay"
+                ]
+                [ confirm makeMsg "Really quit?" selectedOption
+                ]
 
-            _ ->
-                []
+        _ ->
+            Html.text ""
 
 
 confirm : (Dialog.Option -> msg) -> String -> Dialog.Option -> Html msg

--- a/src/GUI/Dialogs.elm
+++ b/src/GUI/Dialogs.elm
@@ -1,0 +1,48 @@
+module GUI.Dialogs exposing (overlay)
+
+import Color
+import Dialog
+import GUI.Text
+import Game exposing (GameState(..))
+import Html exposing (Attribute, Html, button, div, p)
+import Html.Attributes as Attr
+import Html.Events exposing (onClick)
+
+
+overlay : (Dialog.Option -> msg) -> GameState -> Html msg
+overlay makeMsg gameState =
+    div [ Attr.class "overlay", Attr.class "dialogOverlay" ] <|
+        case gameState of
+            PostRound _ (Dialog.Open selectedOption) ->
+                List.singleton <| confirm makeMsg "Really quit?" selectedOption
+
+            _ ->
+                []
+
+
+confirm : (Dialog.Option -> msg) -> String -> Dialog.Option -> Html msg
+confirm makeMsg question selectedOption =
+    let
+        optionButton : Dialog.Option -> String -> Html msg
+        optionButton option label =
+            button (onClick (makeMsg option) :: focusedIf selectedOption option) (smallWhiteText label)
+    in
+    div [ Attr.class "dialog" ]
+        [ p [] (smallWhiteText question)
+        , optionButton Dialog.Confirm "Yes"
+        , optionButton Dialog.Cancel "No"
+        ]
+
+
+focusedIf : Dialog.Option -> Dialog.Option -> List (Attribute msg)
+focusedIf a b =
+    if a == b then
+        [ Attr.class "focused" ]
+
+    else
+        []
+
+
+smallWhiteText : String -> List (Html msg)
+smallWhiteText =
+    GUI.Text.string (GUI.Text.Size 1) Color.white

--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -25,7 +25,7 @@ scoreboard gameState players =
             MidRound _ ( _, round ) ->
                 content players round
 
-            PostRound round ->
+            PostRound round _ ->
                 content players round
         )
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -2,6 +2,7 @@ module Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), Sp
 
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
+import Dialog
 import Players exposing (ParticipatingPlayers)
 import Random
 import Round exposing (Kurves, Round, RoundInitialState, modifyAlive, modifyDead)
@@ -21,7 +22,7 @@ import World exposing (DrawingPosition, Pixel, Position, distanceToTicks)
 
 type GameState
     = MidRound Tick MidRoundState
-    | PostRound Round
+    | PostRound Round Dialog.State
     | PreRound SpawnState MidRoundState
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -395,8 +395,8 @@ view model =
                             , Attr.class "overlay"
                             ]
                             []
-                        , GUI.Dialogs.overlay DialogChoiceMade gameState
                         , pauseOverlay gameState
+                        , GUI.Dialogs.overlay DialogChoiceMade gameState
                         ]
                     , scoreboard gameState model.players
                     ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -289,6 +289,7 @@ update msg ({ pressedButtons } as model) =
                             ( { model | appState = InGame (RoundOver finishedRound Dialog.NotOpen) }, Cmd.none )
 
                 _ ->
+                    -- Not expected to ever happen.
                     ( model, Cmd.none )
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,7 +5,7 @@ import Browser
 import Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
 import Config exposing (Config)
 import Dialog
-import GUI.Dialogs
+import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
 import GUI.PauseOverlay exposing (pauseOverlay)
@@ -396,7 +396,7 @@ view model =
                             ]
                             []
                         , pauseOverlay gameState
-                        , GUI.Dialogs.overlay DialogChoiceMade gameState
+                        , confirmQuitDialog DialogChoiceMade gameState
                         ]
                     , scoreboard gameState model.players
                     ]

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -139,7 +139,7 @@ $minWidthForCenteredCanvas: (
 
 .dialog {
     border: 1px solid white;
-    $padding: 8px;
+    $padding: 12px;
     padding: $padding;
     background-color: black;
 

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -144,7 +144,7 @@ $minWidthForCenteredCanvas: (
     background-color: black;
 
     p {
-        line-height: 1em;
+        line-height: 12px;
         margin-bottom: 8px;
     }
 

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -134,6 +134,7 @@ $minWidthForCenteredCanvas: (
     display: flex;
     align-items: center;
     justify-content: center;
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 .dialog {

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -100,6 +100,8 @@ $minWidthForCenteredCanvas: (
     left: 0;
     position: absolute;
     top: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .largeDigit {
@@ -116,6 +118,45 @@ $minWidthForCenteredCanvas: (
     mask-image: url("../resources/fonts/bgi-default-8x8.png");
     mask-repeat: no-repeat; // Prevents unsupported characters from wrapping around and being displayed as some seemingly arbitrary supported character.
     mask-size: auto 100%;
+}
+
+.dialogOverlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dialog {
+    border: 1px solid white;
+    $padding: 8px;
+    padding: $padding;
+    background-color: black;
+
+    button {
+        width: calc(50% - $padding/2);
+        min-width: 64px;
+    }
+
+    button:not(:last-child) {
+        margin-right: 8px;
+    }
+}
+
+button {
+    background-color: black;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: white;
+    height: 32px;
+    cursor: pointer;
+
+    &.focused {
+        border-color: white;
+    }
+
+    &:hover {
+        border-color: white;
+        background-color: rgba(255, 255, 255, 0.1);
+    }
 }
 
 #splashScreen {

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -145,7 +145,7 @@ $minWidthForCenteredCanvas: (
 
     p {
         line-height: 12px;
-        margin-bottom: 8px;
+        margin-bottom: 16px;
     }
 
     button {

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -150,7 +150,7 @@ $minWidthForCenteredCanvas: (
 
     button {
         width: calc(50% - $padding/2);
-        min-width: 64px;
+        min-width: 96px;
     }
 
     button:not(:last-child) {

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -143,6 +143,11 @@ $minWidthForCenteredCanvas: (
     padding: $padding;
     background-color: black;
 
+    p {
+        line-height: 1em;
+        margin-bottom: 8px;
+    }
+
     button {
         width: calc(50% - $padding/2);
         min-width: 64px;


### PR DESCRIPTION
In the original MS-DOS game, when Escape is pressed between rounds, the game immediately exits to the splash screen. In 83ca2595037f462f6467d196d15ae146aaeec5b9, the legacy JavaScript version introduced an optional confirmation dialog (enabled by default), because accidentally quitting in the middle of a game _sucks_. Unlike in the original game, "quitting" in the legacy JavaScript version means going to the lobby, not the splash screen, because that's almost always more useful.

This PR brings a similar confirmation dialog to the Elm version. Since we don't have any user-facing preferences (yet), it's always enabled.

Having experimented with various approaches, I've decided to go with this one, which implements keyboard interaction entirely in Elm, instead of relying on the browser's native behavior.

Neither solution is without its flaws. The browser approach has these disadvantages:

  * The arrow keys don't work for moving focus between the buttons.
  * Pressing Tab (or Shift + Tab) cycles through _all focusable elements_ in the page, and even the browser chrome, so the dialog doesn't feel modal.
  * When the dialog is opened, the "No" button must be focused with `Browser.Dom.focus` and `Task.attempt`. That is, we must look it up by ID and handle the possibility that it doesn't exist, even though we know that it does.
  * We have to control in Elm whether we should call the `preventDefault` method in JavaScript or not (for example by conditionally setting an attribute in Elm and check for it in JavaScript).

The Elm approach has these:

  * We're reinventing the wheel when it comes to moving focus between input elements and interacting with them.
  * Supporting more than two input elements would require a more general implementation for the complexity to stay reasonable.
  * Since we use `event.code` (the physical key), not `event.key` (the meaning of the key), the dialog may not behave as expected with non-QWERTY layouts.

While we suspect that the Elm approach may not cut it if/when we introduce more input elements down the road, I think this implementation is good enough for now. I also believe there's value in documenting in the Git history that we initially did it this way and why.

I decided to go with `<div>` rather than `<dialog>` because [the latter isn't supported in relatively new versions of Firefox (97) and Safari (15.3)](https://caniuse.com/dialog).

💡 `git show --color-words='goToLobby .+|\w+|.' --ignore-space-change`
