### PR TITLE
Reorder type variants

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -6,8 +6,8 @@ import Random
 
 
 type AppState
-    = InGame GameState
-    | InMenu MenuState Random.Seed
+    = InMenu MenuState Random.Seed
+    | InGame GameState
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -20,9 +20,9 @@ import World exposing (DrawingPosition, Pixel, Position, distanceToTicks)
 
 
 type GameState
-    = MidRound Tick MidRoundState
+    = PreRound SpawnState MidRoundState
+    | MidRound Tick MidRoundState
     | PostRound Round
-    | PreRound SpawnState MidRoundState
 
 
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -63,9 +63,9 @@ newRoundGameStateAndCmd config plannedMidRoundState =
 
 
 type Msg
-    = GameTick Tick MidRoundState
+    = SpawnTick SpawnState MidRoundState
+    | GameTick Tick MidRoundState
     | ButtonUsed ButtonDirection Button
-    | SpawnTick SpawnState MidRoundState
 
 
 stepSpawnState : Config -> SpawnState -> ( MidRoundState -> GameState, Cmd msg )
@@ -220,11 +220,11 @@ handleUserInteraction direction button model =
         howToModifyRound : Round -> Round
         howToModifyRound =
             case model.appState of
-                InGame (MidRound lastTick ( Live, _ )) ->
-                    recordInteractionBefore (Tick.succ lastTick)
-
                 InGame (PreRound _ ( Live, _ )) ->
                     recordInteractionBefore firstUpdateTick
+
+                InGame (MidRound lastTick ( Live, _ )) ->
+                    recordInteractionBefore (Tick.succ lastTick)
 
                 _ ->
                     identity
@@ -249,14 +249,14 @@ subscriptions model =
             InMenu Lobby _ ->
                 Sub.none
 
-            InGame (PostRound _) ->
-                Sub.none
-
             InGame (PreRound spawnState plannedMidRoundState) ->
                 Time.every (1000 / model.config.spawn.flickerTicksPerSecond) (always <| SpawnTick spawnState plannedMidRoundState)
 
             InGame (MidRound lastTick midRoundState) ->
                 Time.every (1000 / Tickrate.toFloat model.config.kurves.tickrate) (always <| GameTick (Tick.succ lastTick) midRoundState)
+
+            InGame (PostRound _) ->
+                Sub.none
 
             InMenu GameOver _ ->
                 Sub.none

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -43,8 +43,8 @@ type Fate
 {-| In both cases, the integer represent the number of ticks left in the current state.
 -}
 type HoleStatus
-    = Unholy Int
-    | Holy Int
+    = Holy Int
+    | Unholy Int
 
 
 reset : Kurve -> Kurve


### PR DESCRIPTION
This PR reorders some type variants that I feel are unintuitively ordered. (They have ended up that way mainly because they were just appended to their respective type definitions when they were introduced.) It also reorders the corresponding cases in `case` expressions where that makes sense.

For `Msg`, `AppState` and `GameState`, I've tried to make the syntactical order reflect the chronological one.

💡 `git show --color-words`