### PR TITLE
Rename GameState variants

### DIFF
--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -19,13 +19,13 @@ scoreboard gameState players =
         , Attr.class "canvasHeight"
         ]
         (case gameState of
-            PreRound _ ( _, round ) ->
+            Spawning _ ( _, round ) ->
                 content players round
 
-            MidRound _ ( _, round ) ->
+            Moving _ ( _, round ) ->
                 content players round
 
-            PostRound round ->
+            RoundOver round ->
                 content players round
         )
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -20,19 +20,19 @@ import World exposing (DrawingPosition, Pixel, Position, distanceToTicks)
 
 
 type GameState
-    = PreRound SpawnState MidRoundState
-    | MidRound Tick MidRoundState
-    | PostRound Round
+    = Spawning SpawnState MidRoundState
+    | Moving Tick MidRoundState
+    | RoundOver Round
 
 
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState
 modifyMidRoundState f gameState =
     case gameState of
-        MidRound t midRoundState ->
-            MidRound t <| f midRoundState
+        Moving t midRoundState ->
+            Moving t <| f midRoundState
 
-        PreRound s midRoundState ->
-            PreRound s <| f midRoundState
+        Spawning s midRoundState ->
+            Spawning s <| f midRoundState
 
         _ ->
             gameState


### PR DESCRIPTION
This PR renames `PreRound`, `MidRound` and `PostRound` to `Spawning`, `Moving` and `RoundOver`, respectively, in an attempt to clarify their meaning.

💡 `git show --color-words='\w+|.'`