### PR TITLE
Pause game when window focus is lost

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,9 @@
         document.addEventListener("contextmenu", event => {
             event.preventDefault()
         });
+        window.addEventListener("blur", () => {
+            app.ports.focusLost.send(null)
+        })
     </script>
 
 </body>

--- a/src/GUI/PauseOverlay.elm
+++ b/src/GUI/PauseOverlay.elm
@@ -1,0 +1,28 @@
+module GUI.PauseOverlay exposing (..)
+
+import Color
+import GUI.Text
+import Game exposing (GameState(..), Paused(..))
+import Html exposing (Html, div, p)
+import Html.Attributes as Attr
+
+
+pauseOverlay : GameState -> Html msg
+pauseOverlay gameState =
+    div
+        [ Attr.class "overlay"
+        , Attr.class "pauseOverlay"
+        , Attr.style "visibility" (visibility gameState)
+        ]
+        [ p [] <| GUI.Text.string (GUI.Text.Size 2) Color.white "Press Space to continue"
+        ]
+
+
+visibility : GameState -> String
+visibility gameState =
+    case gameState of
+        Active Paused _ ->
+            "visible"
+
+        _ ->
+            "hidden"

--- a/src/GUI/PauseOverlay.elm
+++ b/src/GUI/PauseOverlay.elm
@@ -1,4 +1,4 @@
-module GUI.PauseOverlay exposing (..)
+module GUI.PauseOverlay exposing (pauseOverlay)
 
 import Color
 import GUI.Text

--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -2,7 +2,7 @@ module GUI.Scoreboard exposing (scoreboard)
 
 import Dict
 import GUI.Digits
-import Game exposing (GameState(..))
+import Game exposing (ActiveGameState(..), GameState(..))
 import Html exposing (Html, div)
 import Html.Attributes as Attr
 import Players exposing (AllPlayers, includeResultsFrom, participating)
@@ -19,10 +19,10 @@ scoreboard gameState players =
         , Attr.class "canvasHeight"
         ]
         (case gameState of
-            Spawning _ ( _, round ) ->
+            Active _ (Spawning _ ( _, round )) ->
                 content players round
 
-            Moving _ ( _, round ) ->
+            Active _ (Moving _ ( _, round )) ->
                 content players round
 
             RoundOver round ->

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,4 +1,4 @@
-module Game exposing (GameState(..), MidRoundState, MidRoundStateVariant(..), SpawnState, checkIndividualKurve, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
+module Game exposing (ActiveGameState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), Paused(..), SpawnState, checkIndividualKurve, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
 
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
@@ -20,19 +20,28 @@ import World exposing (DrawingPosition, Pixel, Position, distanceToTicks)
 
 
 type GameState
+    = Active Paused ActiveGameState
+    | RoundOver Round
+
+
+type Paused
+    = Paused
+    | NotPaused
+
+
+type ActiveGameState
     = Spawning SpawnState MidRoundState
     | Moving Tick MidRoundState
-    | RoundOver Round
 
 
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState
 modifyMidRoundState f gameState =
     case gameState of
-        Moving t midRoundState ->
-            Moving t <| f midRoundState
+        Active p (Moving t midRoundState) ->
+            Active p <| Moving t <| f midRoundState
 
-        Spawning s midRoundState ->
-            Spawning s <| f midRoundState
+        Active p (Spawning s midRoundState) ->
+            Active p <| Spawning s <| f midRoundState
 
         _ ->
             gameState

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -100,6 +100,16 @@ $minWidthForCenteredCanvas: (
     left: 0;
     position: absolute;
     top: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.pauseOverlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    opacity: 0.5;
 }
 
 .largeDigit {


### PR DESCRIPTION
It's fairly easy to accidentally switch tabs or similar in the middle of a round. The legacy JavaScript version automatically pauses the game when that happens, but it doesn't indicate in any way that the game is paused or how to continue, so it feels like it has frozen.

This PR ports the feature to Elm, this time with the text "Press Space to continue" being shown when the game is paused. The text is semi-transparent because players must be able to see in what direction they are moving and what's going on in their immediate vicinity, in order to be as prepared as possible when the game is resumed.

💡 `git show --color-words=.`