### PR TITLE
Use semicolons in JavaScript code

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,43 +44,43 @@
 
     <script src="./build/ZATACKA.js"></script>
     <script>
-        const app = Elm.Main.init({ node: document.getElementById("elm-node") })
+        const app = Elm.Main.init({ node: document.getElementById("elm-node") });
 
         function getCanvasContext(id) {
-            const canvas = document.getElementById(id)
-            return canvas === null ? null : canvas.getContext("2d")
+            const canvas = document.getElementById(id);
+            return canvas === null ? null : canvas.getContext("2d");
         }
 
         function drawSquare(context, { position: { leftEdge, topEdge }, thickness, color }) {
-            context.fillStyle = color
-            context.fillRect(leftEdge, topEdge, thickness, thickness)
+            context.fillStyle = color;
+            context.fillRect(leftEdge, topEdge, thickness, thickness);
         }
 
         function clearRectangleIfCanvasExists(context, { x, y, width, height }) {
             if (context !== null) {
-                context.clearRect(x, y, width, height)
+                context.clearRect(x, y, width, height);
             }
         }
 
         app.ports.render.subscribe(squares => {
-            const context_main = getCanvasContext("canvas_main")
+            const context_main = getCanvasContext("canvas_main");
             for (const square of squares) {
-                drawSquare(context_main, square)
+                drawSquare(context_main, square);
             }
-        })
+        });
 
         app.ports.clear.subscribe(rectangle => {
-            const context_main = getCanvasContext("canvas_main")
-            clearRectangleIfCanvasExists(context_main, rectangle)
-        })
+            const context_main = getCanvasContext("canvas_main");
+            clearRectangleIfCanvasExists(context_main, rectangle);
+        });
 
         app.ports.renderOverlay.subscribe(squares => {
-            const context_overlay = getCanvasContext("canvas_overlay")
-            clearRectangleIfCanvasExists(context_overlay, { x: 0, y: 0, width: Number.MAX_SAFE_INTEGER, height: Number.MAX_SAFE_INTEGER })
+            const context_overlay = getCanvasContext("canvas_overlay");
+            clearRectangleIfCanvasExists(context_overlay, { x: 0, y: 0, width: Number.MAX_SAFE_INTEGER, height: Number.MAX_SAFE_INTEGER });
             for (const square of squares) {
-                drawSquare(context_overlay, square)
+                drawSquare(context_overlay, square);
             }
-        })
+        });
 
         document.addEventListener("keydown", event => {
             const isDeveloperCommand = (
@@ -89,30 +89,30 @@
                 (event.ctrlKey && event.key === "r") // Ctrl + R
                 ||
                 (event.metaKey && event.key === "r") // Cmd + R on macOS 👀
-            )
+            );
             if (!isDeveloperCommand) {
-                event.preventDefault()
+                event.preventDefault();
             }
             if (!event.repeat) {
-                app.ports.onKeydown.send(event.code)
+                app.ports.onKeydown.send(event.code);
             }
-        })
+        });
         document.addEventListener("keyup", event => {
             // Traditionally we never prevented default on keyup.
-            app.ports.onKeyup.send(event.code)
-        })
+            app.ports.onKeyup.send(event.code);
+        });
         document.addEventListener("mousedown", event => {
-            app.ports.onMousedown.send(event.button)
-        })
+            app.ports.onMousedown.send(event.button);
+        });
         document.addEventListener("mouseup", event => {
-            app.ports.onMouseup.send(event.button)
-        })
+            app.ports.onMouseup.send(event.button);
+        });
         document.addEventListener("contextmenu", event => {
-            event.preventDefault()
+            event.preventDefault();
         });
         window.addEventListener("blur", () => {
-            app.ports.focusLost.send(null)
-        })
+            app.ports.focusLost.send(null);
+        });
     </script>
 
 </body>


### PR DESCRIPTION
I'll probably never settle on an opinion in the "to semicolon or not to semicolon" debate. This time, I think semicolons make it easier to see where statements end, and they objectively protect against some nasty bugs that can occur when relying on ASI.

Possibly relevant observations:

  * The legacy JavaScript version used semicolons.
  * No decision on semicolons seems to be mentioned anywhere in the Git history (see e.g. `git log --grep semi`).
  * The JavaScript code in `index.html` came into existence in aa844b379662bfb3fe35c50dbd7a15350aed9409.

💡 `git show --color-words=.`