### PR TITLE
Fix broken GUI text in Webkit browsers

### DIFF
--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -124,7 +124,9 @@ $minWidthForCenteredCanvas: (
     display: inline-block;
     -webkit-mask-image: url("../resources/fonts/bgi-default-8x8.png");
     mask-image: url("../resources/fonts/bgi-default-8x8.png");
+    -webkit-mask-repeat: no-repeat;
     mask-repeat: no-repeat; // Prevents unsupported characters from wrapping around and being displayed as some seemingly arbitrary supported character.
+    -webkit-mask-size: auto 100%;
     mask-size: auto 100%;
 }
 


### PR DESCRIPTION
Turns out the "READY" text in the lobby is utterly broken in Chrome: it shows up as `$%      23`, and the characters are 8 × 8 instead of 16 × 16 and repeated in a visually weird fashion. The same goes for the "Press Space to continue" text and the end-screen scoreboard.

The root cause is missing `mask-size` support – adding a `-webkit-` fallback makes everything render correctly. According to https://caniuse.com, this should be enough to support all major browsers at least back to 2017. (I'm also adding a fallback for `mask-repeat`, of course, but that doesn't have any visible effect as long as we only try to render supported characters.)