### PR TITLE
Fix canvas clearing issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 
         app.ports.renderOverlay.subscribe(squares => {
             const canvas_overlay = document.getElementById("canvas_overlay");
-            clearRectangleIfCanvasExists(canvas_overlay, { x: 0, y: 0, width: Number.MAX_SAFE_INTEGER, height: Number.MAX_SAFE_INTEGER });
+            clearRectangleIfCanvasExists(canvas_overlay, { x: 0, y: 0, width: canvas_overlay?.width, height: canvas_overlay?.height }); // Very large numbers don't work; see the commit that added this comment.
             for (const square of squares) {
                 drawSquare(canvas_overlay, square);
             }

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,9 +1,9 @@
 port module Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
 
 import Color exposing (Color)
+import Config exposing (WorldConfig)
 import Types.Kurve exposing (Kurve)
 import Types.Thickness as Thickness exposing (Thickness)
-import Util exposing (maxSafeInteger)
 import World exposing (DrawingPosition)
 
 
@@ -40,11 +40,11 @@ headDrawingCmd thickness =
             )
 
 
-clearEverything : Cmd msg
-clearEverything =
+clearEverything : WorldConfig -> Cmd msg
+clearEverything { width, height } =
     Cmd.batch
         [ renderOverlay []
-        , clear { x = 0, y = 0, width = maxSafeInteger, height = maxSafeInteger }
+        , clear { x = 0, y = 0, width = width, height = height }
         ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -63,7 +63,7 @@ newRoundGameStateAndCmd config plannedMidRoundState =
             , ticksLeft = config.spawn.numberOfFlickerTicks
             }
             plannedMidRoundState
-    , clearEverything
+    , clearEverything config.world
     )
 
 

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,4 +1,4 @@
-module Util exposing (curry, isEven, maxSafeInteger)
+module Util exposing (curry, isEven)
 
 
 curry : (( a, b ) -> c) -> a -> b -> c
@@ -9,10 +9,3 @@ curry f a b =
 isEven : Int -> Bool
 isEven n =
     modBy 2 n == 0
-
-
-{-| JavaScript's `Number.MAX_SAFE_INTEGER`.
--}
-maxSafeInteger : Int
-maxSafeInteger =
-    9007199254740991


### PR DESCRIPTION
In Firefox on Ubuntu on my ThinkPad X1 Carbon 5th Gen, holes are consistently "invisible" (there appears to be no hole, even though there actually is) and Kurves are consistently not cleared when proceeding to the next round. After a confusing debugging session, Kryddan and I concluded that when the `clearRect` method is called with very large values for the width and height, the canvas isn’t cleared. I have reported it as a bug in Firefox:

https://bugzilla.mozilla.org/show_bug.cgi?id=1828137

I have only encountered the issue in Firefox 109–112 (and all the way back to 106 with `mozregression`; see Bugzilla thread) on said ThinkPad with a Core i7-7500U running Ubuntu 20.04.1 with Linux 5.15.0. It doesn't happen in Chrome on Ubuntu, Firefox on Windows 10 (on the same laptop), or Firefox on Ubuntu 20.04.4 with Linux 5.4.0 on my main PC with an RTX 2060 Super.

The reason I haven't noticed such an obvious bug until now is that it didn't manifest itself until I did `sudo apt update && sudo apt upgrade` a week or two ago and (apparently) got a new version of Firefox.

💡 `git show --color-words='[A-Za-z._]+|.'`