### PR TITLE
Rename `watch` script to `start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The aim of this project is to create an Elm remake of the original *Achtung, die
 
 ```shell
 npm ci
-npm run watch
+npm start
 ```
 
 Then visit <http://localhost:8000> in your browser.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sass-build": "sass --source-map src/css/:css/",
     "build": "elm-watch make --optimize",
     "lint": "elm-format --validate src/ && elm-review",
-    "watch": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
+    "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
     "deploy": "git checkout master && git merge --no-ff -m \"Merge branch 'develop'\" develop && npm run build && git add -f js css && git commit -m \"Deploy\""
   },
   "author": "Simon Alling",


### PR DESCRIPTION
I prefer `npm start` over `npm run watch`.

💡 `git show --color-words='\w+|.'`