### PR TITLE
Pin exact versions of dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,11 @@
       "name": "zatacka",
       "hasInstallScript": true,
       "devDependencies": {
-        "elm-review": "^2.8.2",
-        "elm-tooling": "^1.6.0",
-        "elm-watch": "^1.1.0",
-        "esbuild": "^0.15.12",
-        "sass": "^1.43.3"
+        "elm-review": "2.8.2",
+        "elm-tooling": "1.6.0",
+        "elm-watch": "1.1.0",
+        "esbuild": "0.15.12",
+        "sass": "1.43.3"
       },
       "optionalDependencies": {
         "run-pty": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   },
   "author": "Simon Alling",
   "devDependencies": {
-    "elm-review": "^2.8.2",
-    "elm-tooling": "^1.6.0",
-    "elm-watch": "^1.1.0",
-    "esbuild": "^0.15.12",
-    "sass": "^1.43.3"
+    "elm-review": "2.8.2",
+    "elm-tooling": "1.6.0",
+    "elm-watch": "1.1.0",
+    "esbuild": "0.15.12",
+    "sass": "1.43.3"
   },
   "optionalDependencies": {
     "run-pty": "^4.0.3"


### PR DESCRIPTION
The main reason for using version ranges like `^1.2.3` is to enable deduplication, but that's not really important for development dependencies.

I did this to check which versions I had:

```bash
for package in "elm-review" "elm-tooling" "elm-watch" "esbuild" "sass"; do
  npm why $package
done
```

Then I did this:

    npm install --save-dev --save-exact elm-review@2.8.2 elm-tooling@1.6.0 elm-watch@1.1.0 esbuild@0.15.12 sass@1.43.3

Also, from now on, we won't be hard-wrapping commit messages at 72 characters anymore.