### PR TITLE
Split 'lint' script into 'format' and 'review'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY elm-watch.json .
 COPY review review
 COPY tests tests
 COPY src src
-RUN npm run lint
+RUN npm run check-formatting
+RUN npm run review
 RUN npm run build
 RUN npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "install-hooks": "cp hooks/* .git/hooks",
     "sass-build": "sass --source-map src/css/:css/",
     "build": "elm-watch make --optimize",
-    "lint": "elm-format --validate src/ && elm-review",
+    "check-formatting": "elm-format --validate src/",
+    "review": "elm-review",
     "test": "elm-test",
     "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
     "deploy": "git checkout master && git merge --no-ff -m \"Merge branch 'develop'\" develop && npm run build && git add -f js css && git commit -m \"Deploy\""


### PR DESCRIPTION
I've noticed that it takes over 20 seconds to run it as part of `docker build .`, so I think it makes sense to split it up. "Linting" isn't really an Elm-ism anyway, as far as I know.