### PR TITLE
Remove unused pressedButtons field

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -84,7 +84,7 @@ prepareLiveRound config seed players pressedButtons =
         ( theKurves, seedAfterSpawn ) =
             Random.step (generateKurves config players) seed |> Tuple.mapFirst recordInitialInteractions
     in
-    ( Live, prepareRoundHelper config { seedAfterSpawn = seedAfterSpawn, spawnedKurves = theKurves, pressedButtons = pressedButtons } )
+    ( Live, prepareRoundHelper config { seedAfterSpawn = seedAfterSpawn, spawnedKurves = theKurves } )
 
 
 prepareReplayRound : Config -> RoundInitialState -> MidRoundState

--- a/src/Round.elm
+++ b/src/Round.elm
@@ -31,7 +31,6 @@ type alias RoundHistory =
 type alias RoundInitialState =
     { seedAfterSpawn : Random.Seed
     , spawnedKurves : List Kurve
-    , pressedButtons : Set String
     }
 
 

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -52,7 +52,6 @@ tests =
                             { initialState =
                                 { seedAfterSpawn = Random.initialSeed 0
                                 , spawnedKurves = []
-                                , pressedButtons = Set.empty
                                 }
                             }
                         , seed = Random.initialSeed 0
@@ -121,7 +120,6 @@ tests =
                             { initialState =
                                 { seedAfterSpawn = Random.initialSeed 0
                                 , spawnedKurves = []
-                                , pressedButtons = Set.empty
                                 }
                             }
                         , seed = Random.initialSeed 0


### PR DESCRIPTION
The `pressedButtons` field in the `RoundInitialState` type has been unused since 7890b9e68dddd1a992e3ff72816a03248a2bf966 ("Refactor and unify input handling").

It was originally added in a9eec802731850406b8b9d7c0fbf64d4e039b201 ("Make R replay the previous round"), under the name `pressedKeys`. I did a `git bisect` with that commit as the last known good one, saying `git bisect bad` if and only if I could remove the field in the type definition without the compiler pointing out any locations where it was read. (It has been written to all along, but that doesn't count as used.)

Unfortunately, [there doesn't seem to exist an `elm-review` rule for unused fields][issue].

[issue]: https://github.com/jfmengels/elm-review-unused/issues/15

💡 `git show --color-words=.`