### PR TITLE
Remove redundant RoundHistory type

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -107,9 +107,7 @@ prepareRoundHelper config initialState =
         round =
             { kurves = { alive = theKurves, dead = [] }
             , occupiedPixels = List.foldr (.state >> .position >> World.drawingPosition thickness >> World.pixelsToOccupy thickness >> Set.union) Set.empty theKurves
-            , history =
-                { initialState = initialState
-                }
+            , initialState = initialState
             , seed = initialState.seedAfterSpawn
             }
     in

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -133,7 +133,7 @@ update msg ({ pressedButtons } as model) =
                 newCurrentRound =
                     { kurves = newKurves
                     , occupiedPixels = newOccupiedPixels
-                    , history = currentRound.history
+                    , initialState = currentRound.initialState
                     , seed = newSeed
                     }
 

--- a/src/Round.elm
+++ b/src/Round.elm
@@ -1,4 +1,4 @@
-module Round exposing (Kurves, Round, RoundHistory, RoundInitialState, initialStateForReplaying, modifyAlive, modifyDead, modifyKurves, roundIsOver, scores)
+module Round exposing (Kurves, Round, RoundInitialState, initialStateForReplaying, modifyAlive, modifyDead, modifyKurves, roundIsOver, scores)
 
 import Dict exposing (Dict)
 import Random
@@ -12,7 +12,7 @@ import World exposing (Pixel)
 type alias Round =
     { kurves : Kurves
     , occupiedPixels : Set Pixel
-    , history : RoundHistory
+    , initialState : RoundInitialState
     , seed : Random.Seed
     }
 
@@ -20,11 +20,6 @@ type alias Round =
 type alias Kurves =
     { alive : List Kurve
     , dead : List Kurve
-    }
-
-
-type alias RoundHistory =
-    { initialState : RoundInitialState
     }
 
 
@@ -68,7 +63,7 @@ initialStateForReplaying round =
     let
         initialState : RoundInitialState
         initialState =
-            round.history.initialState
+            round.initialState
 
         theKurves : List Kurve
         theKurves =

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -48,11 +48,9 @@ tests =
                             , dead = []
                             }
                         , occupiedPixels = Set.empty
-                        , history =
-                            { initialState =
-                                { seedAfterSpawn = Random.initialSeed 0
-                                , spawnedKurves = []
-                                }
+                        , initialState =
+                            { seedAfterSpawn = Random.initialSeed 0
+                            , spawnedKurves = []
                             }
                         , seed = Random.initialSeed 0
                         }
@@ -116,11 +114,9 @@ tests =
                             , dead = []
                             }
                         , occupiedPixels = Set.empty
-                        , history =
-                            { initialState =
-                                { seedAfterSpawn = Random.initialSeed 0
-                                , spawnedKurves = []
-                                }
+                        , initialState =
+                            { seedAfterSpawn = Random.initialSeed 0
+                            , spawnedKurves = []
                             }
                         , seed = Random.initialSeed 0
                         }


### PR DESCRIPTION
It has been isomorphic to `RoundInitialState` since 79038128 ("Track input history per player"), which removed the `reversedUserInteractions` field.

💡 `git show --color-words='\w+|.'`