### PR TITLE
Install hooks in 'postinstall' instead of 'start'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Achtung, die Kurve! in JavaScript",
   "scripts": {
     "postinstall": "elm-tooling install",
-    "install-hooks": "cp hooks/* .git/hooks",
+    "install-hooks": "[ -d .git/ ] && cp hooks/* .git/hooks",
     "sass-build": "sass --source-map src/css/:css/",
     "build": "elm-watch make --optimize",
     "check-formatting": "elm-format --validate src/",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "zatacka",
   "description": "Achtung, die Kurve! in JavaScript",
   "scripts": {
-    "postinstall": "elm-tooling install",
+    "postinstall": "elm-tooling install && npm run install-hooks",
     "install-hooks": "cp hooks/* .git/hooks",
     "sass-build": "sass --source-map src/css/:css/",
     "build": "elm-watch make --optimize",
     "check-formatting": "elm-format --validate src/",
     "review": "elm-review",
     "test": "elm-test",
-    "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
+    "start": "run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
     "deploy": "git checkout master && git merge --no-ff -m \"Merge branch 'develop'\" develop && npm run build && git add -f js css && git commit -m \"Deploy\""
   },
   "author": "Simon Alling",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "zatacka",
   "description": "Achtung, die Kurve! in JavaScript",
   "scripts": {
-    "postinstall": "elm-tooling install && npm run install-hooks",
+    "postinstall": "elm-tooling install",
     "install-hooks": "cp hooks/* .git/hooks",
     "sass-build": "sass --source-map src/css/:css/",
     "build": "elm-watch make --optimize",
     "check-formatting": "elm-format --validate src/",
     "review": "elm-review",
     "test": "elm-test",
-    "start": "run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
+    "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
     "deploy": "git checkout master && git merge --no-ff -m \"Merge branch 'develop'\" develop && npm run build && git add -f js css && git commit -m \"Deploy\""
   },
   "author": "Simon Alling",


### PR DESCRIPTION
`npm start` currently doesn't work in a linked worktree:

    $ git worktree add --detach ../kurve-alternative
    $ cd ../kurve-alternative
    $ npm ci
    $ npm start
    
    […]
    
    > install-hooks
    > cp hooks/* .git/hooks
    
    cp: failed to access '.git/hooks': Not a directory

More generally, the codebase itself isn't enough to run `npm start`. The Git repo is also required, which isn't exactly ideal.

I first tried installing hooks in the `postinstall` script instead, but then `docker build .` would fail with `cp: can't stat 'hooks/*': No such file or directory` because `.git/` doesn't (and shouldn't) exist in the Docker image.

I decided to keep the hook installation in `npm start` to maximize the likelihood that our hooks are installed and kept up to date for developers (who will typically run `npm start` regularly).

💡 `git show --color-words=.`