### PR TITLE
Simplify test cases

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,4 +1,4 @@
-port module Main exposing (Model, Msg(..), main, update)
+port module Main exposing (Model, Msg(..), main)
 
 import App exposing (AppState(..), modifyGameState)
 import Browser


### PR DESCRIPTION
Thanks to #103, we don't have to take the detour via `update` and a dummy model anymore.

💡 `git show --ignore-space-change --color-words='currentModel : .+|reactToTick \S+|\w+|.'`