### PR TITLE
Wrap module declaration lines

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -27,6 +27,7 @@ import NoUnused.Variables
 import Review.Rule exposing (Rule)
 import Simplify
 
+
 config : List Rule
 config =
     [ NoConfusingPrefixOperator.rule

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -27,7 +27,6 @@ import NoUnused.Variables
 import Review.Rule exposing (Rule)
 import Simplify
 
-
 config : List Rule
 config =
     [ NoConfusingPrefixOperator.rule

--- a/src/App.elm
+++ b/src/App.elm
@@ -1,4 +1,7 @@
-module App exposing (AppState(..), modifyGameState)
+module App exposing
+    ( AppState(..)
+    , modifyGameState
+    )
 
 import Game exposing (GameState)
 import Menu exposing (MenuState)

--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,4 +1,12 @@
-module Config exposing (Config, GameConfig, HoleConfig, KurveConfig, SpawnConfig, WorldConfig, default)
+module Config exposing
+    ( Config
+    , GameConfig
+    , HoleConfig
+    , KurveConfig
+    , SpawnConfig
+    , WorldConfig
+    , default
+    )
 
 import Dict
 import Players exposing (ParticipatingPlayers)

--- a/src/Dialog.elm
+++ b/src/Dialog.elm
@@ -1,4 +1,7 @@
-module Dialog exposing (Option(..), State(..))
+module Dialog exposing
+    ( Option(..)
+    , State(..)
+    )
 
 
 type State

--- a/src/GUI/Digits.elm
+++ b/src/GUI/Digits.elm
@@ -1,4 +1,7 @@
-module GUI.Digits exposing (large, small)
+module GUI.Digits exposing
+    ( large
+    , small
+    )
 
 import Color exposing (Color)
 import GUI.Text as Text

--- a/src/GUI/Text.elm
+++ b/src/GUI/Text.elm
@@ -1,4 +1,7 @@
-module GUI.Text exposing (Size(..), string)
+module GUI.Text exposing
+    ( Size(..)
+    , string
+    )
 
 import Color exposing (Color)
 import Html exposing (Html, span)

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,4 +1,18 @@
-module Game exposing (ActiveGameState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), Paused(..), SpawnState, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, reactToTick, recordUserInteraction)
+module Game exposing
+    ( ActiveGameState(..)
+    , GameState(..)
+    , MidRoundState
+    , MidRoundStateVariant(..)
+    , Paused(..)
+    , SpawnState
+    , firstUpdateTick
+    , modifyMidRoundState
+    , modifyRound
+    , prepareLiveRound
+    , prepareReplayRound
+    , reactToTick
+    , recordUserInteraction
+    )
 
 import Canvas exposing (bodyDrawingCmd, headDrawingCmd)
 import Color exposing (Color)

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -1,4 +1,13 @@
-module Players exposing (AllPlayers, ParticipatingPlayers, atLeastOneIsParticipating, everyoneLeaves, handlePlayerJoiningOrLeaving, includeResultsFrom, initialPlayers, participating)
+module Players exposing
+    ( AllPlayers
+    , ParticipatingPlayers
+    , atLeastOneIsParticipating
+    , everyoneLeaves
+    , handlePlayerJoiningOrLeaving
+    , includeResultsFrom
+    , initialPlayers
+    , participating
+    )
 
 import Color exposing (Color)
 import Dict exposing (Dict)

--- a/src/Round.elm
+++ b/src/Round.elm
@@ -1,4 +1,14 @@
-module Round exposing (Kurves, Round, RoundInitialState, initialStateForReplaying, modifyAlive, modifyDead, modifyKurves, roundIsOver, scores)
+module Round exposing
+    ( Kurves
+    , Round
+    , RoundInitialState
+    , initialStateForReplaying
+    , modifyAlive
+    , modifyDead
+    , modifyKurves
+    , roundIsOver
+    , scores
+    )
 
 import Dict exposing (Dict)
 import Random

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -1,4 +1,8 @@
-module Spawn exposing (generateHoleSize, generateHoleSpacing, generateKurves)
+module Spawn exposing
+    ( generateHoleSize
+    , generateHoleSpacing
+    , generateKurves
+    )
 
 import Config exposing (Config, HoleConfig, KurveConfig, SpawnConfig, WorldConfig)
 import Dict

--- a/src/Turning.elm
+++ b/src/Turning.elm
@@ -1,4 +1,8 @@
-module Turning exposing (computeAngleChange, computeTurningState, turningStateFromHistory)
+module Turning exposing
+    ( computeAngleChange
+    , computeTurningState
+    , turningStateFromHistory
+    )
 
 import Config exposing (KurveConfig)
 import Set exposing (Set)

--- a/src/Types/Angle.elm
+++ b/src/Types/Angle.elm
@@ -1,4 +1,10 @@
-module Types.Angle exposing (Angle(..), add, cos, negate, sin)
+module Types.Angle exposing
+    ( Angle(..)
+    , add
+    , cos
+    , negate
+    , sin
+    )
 
 {-| Angles are measured in radians.
 -}

--- a/src/Types/Distance.elm
+++ b/src/Types/Distance.elm
@@ -1,4 +1,8 @@
-module Types.Distance exposing (Distance(..), generate, toFloat)
+module Types.Distance exposing
+    ( Distance(..)
+    , generate
+    , toFloat
+    )
 
 import Random
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -1,4 +1,12 @@
-module Types.Kurve exposing (Fate(..), HoleStatus(..), Kurve, State, UserInteraction(..), modifyReversedInteractions, reset)
+module Types.Kurve exposing
+    ( Fate(..)
+    , HoleStatus(..)
+    , Kurve
+    , State
+    , UserInteraction(..)
+    , modifyReversedInteractions
+    , reset
+    )
 
 import Color exposing (Color)
 import Set exposing (Set)

--- a/src/Types/Radius.elm
+++ b/src/Types/Radius.elm
@@ -1,4 +1,7 @@
-module Types.Radius exposing (Radius(..), toFloat)
+module Types.Radius exposing
+    ( Radius(..)
+    , toFloat
+    )
 
 {-| A (turning) radius in Kurve is traditionally measured in pixels.
 -}

--- a/src/Types/Score.elm
+++ b/src/Types/Score.elm
@@ -1,4 +1,7 @@
-module Types.Score exposing (Score(..), isAtLeast)
+module Types.Score exposing
+    ( Score(..)
+    , isAtLeast
+    )
 
 
 type Score

--- a/src/Types/Speed.elm
+++ b/src/Types/Speed.elm
@@ -1,4 +1,7 @@
-module Types.Speed exposing (Speed(..), toFloat)
+module Types.Speed exposing
+    ( Speed(..)
+    , toFloat
+    )
 
 {-| Speeds in Kurve are traditionally measured in pixels per second.
 -}

--- a/src/Types/Thickness.elm
+++ b/src/Types/Thickness.elm
@@ -1,4 +1,7 @@
-module Types.Thickness exposing (Thickness(..), toInt)
+module Types.Thickness exposing
+    ( Thickness(..)
+    , toInt
+    )
 
 {-| A thickness in Kurve is traditionally measured in whole pixels.
 -}

--- a/src/Types/Tick.elm
+++ b/src/Types/Tick.elm
@@ -1,4 +1,9 @@
-module Types.Tick exposing (Tick, genesis, succ, toInt)
+module Types.Tick exposing
+    ( Tick
+    , genesis
+    , succ
+    , toInt
+    )
 
 
 type Tick

--- a/src/Types/Tickrate.elm
+++ b/src/Types/Tickrate.elm
@@ -1,4 +1,7 @@
-module Types.Tickrate exposing (Tickrate(..), toFloat)
+module Types.Tickrate exposing
+    ( Tickrate(..)
+    , toFloat
+    )
 
 {-| Kurve runs at a fixed tickrate measured in ticks per second (Hz).
 -}

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,4 +1,7 @@
-module Util exposing (curry, isEven)
+module Util exposing
+    ( curry
+    , isEven
+    )
 
 
 curry : (( a, b ) -> c) -> a -> b -> c


### PR DESCRIPTION
I find it easier to read and edit module declarations with one exposed definition per line.

The changes were made like this:

```bash
for f in $(git ls-files src/); do
  sed -i -E 's/^(module .+ exposing \()/\1\n/' $f
done

npx elm-format --yes src/
```