### PR TITLE
Simplify writing tests for how rounds should end

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -137,8 +137,9 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
         recurse : ( Tick, MidRoundState ) -> Expect.Expectation
         recurse ( tick, midRoundState ) =
             let
-                ( nextGameState, _ ) =
-                    reactToTick Config.default (Tick.succ tick) midRoundState
+                nextGameState : GameState
+                nextGameState =
+                    reactToTick Config.default (Tick.succ tick) midRoundState |> Tuple.first
             in
             case nextGameState of
                 Active _ activeGameState ->

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -134,8 +134,8 @@ type alias RoundOutcome =
 expectRoundOutcome : RoundOutcome -> Round -> Expect.Expectation
 expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
     let
-        recurse : ( Tick, MidRoundState ) -> Expect.Expectation
-        recurse ( tick, midRoundState ) =
+        recurse : Tick -> MidRoundState -> Expect.Expectation
+        recurse tick midRoundState =
             let
                 nextGameState : GameState
                 nextGameState =
@@ -149,7 +149,7 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
                                 Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it did not."
 
                             else
-                                recurse ( nextTick, nextMidRoundState )
+                                recurse nextTick nextMidRoundState
 
                         Spawning _ _ ->
                             Expect.fail <| "Did not expect players to be spawning as a result of tick " ++ showTick tick ++ "."
@@ -166,7 +166,7 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
                     else
                         Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
     in
-    recurse ( Tick.genesis, ( Live, round ) )
+    recurse Tick.genesis ( Live, round )
 
 
 showTick : Tick -> String

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -138,7 +138,7 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
         recurse ( tick, midRoundState ) =
             let
                 ( nextGameState, _ ) =
-                    Game.reactToTick Config.default (Tick.succ tick) midRoundState
+                    reactToTick Config.default (Tick.succ tick) midRoundState
             in
             case nextGameState of
                 Active _ activeGameState ->

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -3,14 +3,15 @@ module AchtungTest exposing (tests)
 import Color
 import Config
 import Expect
-import Game exposing (ActiveGameState(..), GameState(..), MidRoundStateVariant(..), reactToTick)
+import Game exposing (ActiveGameState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), reactToTick)
 import Random
 import Round exposing (Round)
 import Set
+import String
 import Test exposing (Test, describe, test)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
-import Types.Tick as Tick
+import Types.Tick as Tick exposing (Tick)
 
 
 tests : Test
@@ -104,22 +105,69 @@ tests =
                             }
                         , seed = Random.initialSeed 0
                         }
-
-                    newGameState : GameState
-                    newGameState =
-                        reactToTick Config.default (Tick.succ Tick.genesis) ( Live, currentRound ) |> Tuple.first
                 in
-                case newGameState of
-                    RoundOver round _ ->
-                        case ( round.kurves.alive, round.kurves.dead ) of
-                            ( [], kurve :: [] ) ->
-                                Expect.equal kurve.state.position
-                                    ( 0, 100 )
+                currentRound
+                    |> expectRoundOutcome
+                        { tickThatShouldEndIt = Tick.succ Tick.genesis
+                        , howItShouldEnd =
+                            \round ->
+                                case ( round.kurves.alive, round.kurves.dead ) of
+                                    ( [], kurve :: [] ) ->
+                                        Expect.equal kurve.state.position
+                                            ( 0, 100 )
 
-                            _ ->
-                                Expect.fail "Expected exactly one dead Kurve and no alive ones"
-
-                    _ ->
-                        Expect.fail "Expected round to be over"
+                                    _ ->
+                                        Expect.fail "Expected exactly one dead Kurve and no alive ones"
+                        }
             )
         ]
+
+
+{-| A description of when and how a round should end.
+-}
+type alias RoundOutcome =
+    { tickThatShouldEndIt : Tick
+    , howItShouldEnd : Round -> Expect.Expectation
+    }
+
+
+expectRoundOutcome : RoundOutcome -> Round -> Expect.Expectation
+expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
+    let
+        recurse : ( Tick, MidRoundState ) -> Expect.Expectation
+        recurse ( tick, midRoundState ) =
+            let
+                ( nextGameState, _ ) =
+                    Game.reactToTick Config.default (Tick.succ tick) midRoundState
+            in
+            case nextGameState of
+                Active _ activeGameState ->
+                    case activeGameState of
+                        Moving nextTick nextMidRoundState ->
+                            if nextTick == tickThatShouldEndIt then
+                                Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it did not."
+
+                            else
+                                recurse ( nextTick, nextMidRoundState )
+
+                        Spawning _ _ ->
+                            Expect.fail <| "Did not expect players to be spawning as a result of tick " ++ showTick tick ++ "."
+
+                RoundOver actualRoundResult _ ->
+                    let
+                        actualEndTick : Tick
+                        actualEndTick =
+                            Tick.succ tick
+                    in
+                    if actualEndTick == tickThatShouldEndIt then
+                        howItShouldEnd actualRoundResult
+
+                    else
+                        Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
+    in
+    recurse ( Tick.genesis, ( Live, round ) )
+
+
+showTick : Tick -> String
+showTick =
+    Tick.toInt >> String.fromInt


### PR DESCRIPTION
I think we're going to want to write quite a few test cases about how a round should end given some state. This PR adds an `expectRoundOutcome` function that takes care of advancing the round until the expected final tick and then expect it to end in the specified way.

The new `Spawning _ _` case (which is implicitly covered by the deleted `_` case) is a bit weird: a round should never re-enter that state, so why do we even have to consider it as a possible outcome of a tick? Maybe something to improve going forward.

💡 `git show --ignore-space-change`