### PR TITLE
Improve test case for crashing into wall

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -80,7 +80,7 @@ tests =
                         , id = 5
                         , controls = ( Set.empty, Set.empty )
                         , state =
-                            { position = ( 1, 100 )
+                            { position = ( 2.5, 100 )
                             , direction = Angle pi
                             , holeStatus = Unholy 60
                             }
@@ -108,65 +108,16 @@ tests =
                 in
                 currentRound
                     |> expectRoundOutcome
-                        { tickThatShouldEndIt = Tick.succ Tick.genesis
+                        { tickThatShouldEndIt = Tick.succ (Tick.succ Tick.genesis)
                         , howItShouldEnd =
                             \round ->
                                 case ( round.kurves.alive, round.kurves.dead ) of
                                     ( [], kurve :: [] ) ->
                                         Expect.equal kurve.state.position
-                                            ( 0, 100 )
+                                            ( 0.5, 100 )
 
                                     _ ->
                                         Expect.fail "Expected exactly one dead Kurve and no alive ones"
-                        }
-            )
-        , test
-            "A Kurve dies exactly when it crashes into the wall"
-            (\_ ->
-                let
-                    kurve : Kurve
-                    kurve =
-                        { color = Color.white
-                        , id = 1
-                        , controls = ( Set.empty, Set.empty )
-                        , state =
-                            { position = ( 2.5, 100 )
-                            , direction = Angle pi
-                            , holeStatus = Unholy 50
-                            }
-                        , stateAtSpawn =
-                            { position = ( 0, 0 )
-                            , direction = Angle 0
-                            , holeStatus = Unholy 0
-                            }
-                        , reversedInteractions = []
-                        }
-
-                    round : Round
-                    round =
-                        { kurves =
-                            { alive = [ kurve ]
-                            , dead = []
-                            }
-                        , occupiedPixels = Set.empty
-                        , initialState =
-                            { seedAfterSpawn = Random.initialSeed 0
-                            , spawnedKurves = []
-                            }
-                        , seed = Random.initialSeed 0
-                        }
-                in
-                round
-                    |> expectRoundOutcome
-                        { tickThatShouldEndIt = Tick.succ (Tick.succ Tick.genesis)
-                        , howItShouldEnd =
-                            \finishedRound ->
-                                Expect.equal finishedRound.kurves
-                                    { alive = []
-                                    , dead =
-                                        [ { kurve | state = { position = ( 0.5, 100 ), direction = Angle pi, holeStatus = Unholy 48 } }
-                                        ]
-                                    }
                         }
             )
         ]

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -120,6 +120,55 @@ tests =
                                         Expect.fail "Expected exactly one dead Kurve and no alive ones"
                         }
             )
+        , test
+            "A Kurve dies exactly when it crashes into the wall"
+            (\_ ->
+                let
+                    kurve : Kurve
+                    kurve =
+                        { color = Color.white
+                        , id = 1
+                        , controls = ( Set.empty, Set.empty )
+                        , state =
+                            { position = ( 2.5, 100 )
+                            , direction = Angle pi
+                            , holeStatus = Unholy 50
+                            }
+                        , stateAtSpawn =
+                            { position = ( 0, 0 )
+                            , direction = Angle 0
+                            , holeStatus = Unholy 0
+                            }
+                        , reversedInteractions = []
+                        }
+
+                    round : Round
+                    round =
+                        { kurves =
+                            { alive = [ kurve ]
+                            , dead = []
+                            }
+                        , occupiedPixels = Set.empty
+                        , initialState =
+                            { seedAfterSpawn = Random.initialSeed 0
+                            , spawnedKurves = []
+                            }
+                        , seed = Random.initialSeed 0
+                        }
+                in
+                round
+                    |> expectRoundOutcome
+                        { tickThatShouldEndIt = Tick.succ (Tick.succ Tick.genesis)
+                        , howItShouldEnd =
+                            \finishedRound ->
+                                Expect.equal finishedRound.kurves
+                                    { alive = []
+                                    , dead =
+                                        [ { kurve | state = { position = ( 0.5, 100 ), direction = Angle pi, holeStatus = Unholy 48 } }
+                                        ]
+                                    }
+                        }
+            )
         ]
 
 


### PR DESCRIPTION
Today, the test case doesn't verify that death occurs exactly at the time of collision. It would pass even if the implementation had a bug that killed the Kurve too early (so that it wouldn't be alive at the position it has at the start of the test).

This PR makes the test case verify that the Kurve dies exactly when it crashes into the wall.

I chose 2.5 instead of 2 as the x coordinate because then the pixel-aligned head of the Kurve is perfectly centered (along the x axis) around its "actual" position. I think this may become particularly relevant if we get around to redesigning collision handling to not be pixel-based.

💡 `git show --color-words='0.5|.'`