### PR TITLE
Refactor game-tick update logic

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -11,7 +11,7 @@ import GUI.Lobby exposing (lobby)
 import GUI.PauseOverlay exposing (pauseOverlay)
 import GUI.Scoreboard exposing (scoreboard)
 import GUI.SplashScreen exposing (splashScreen)
-import Game exposing (ActiveGameState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), Paused(..), SpawnState, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction)
+import Game exposing (ActiveGameState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), Paused(..), SpawnState, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction, tickResultToGameState)
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
 import Input exposing (Button(..), ButtonDirection(..), inputSubscriptions, updatePressedButtons)
@@ -114,10 +114,10 @@ update msg ({ config, pressedButtons } as model) =
 
         GameTick tick midRoundState ->
             let
-                ( newGameState, cmd ) =
+                ( tickResult, cmd ) =
                     Game.reactToTick config tick midRoundState
             in
-            ( { model | appState = InGame newGameState }
+            ( { model | appState = InGame (tickResultToGameState tickResult) }
             , cmd
             )
 


### PR DESCRIPTION
The `Spawning _ _ ` case in `expectRoundOutcome` is weird. It can never happen™, so why do we have to consider it?

In the spirit of Making Impossible States Impossible™, this PR makes the return type of `reactToTick` more specific, so that it's statically known exactly what the result of a game tick can be.

💡 `git show --ignore-space-change --color-words='Expected [^"]+|\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>