### PR TITLE
Enable constructing a Tick from an Int

### DIFF
--- a/src/Types/Tick.elm
+++ b/src/Types/Tick.elm
@@ -1,5 +1,6 @@
 module Types.Tick exposing
     ( Tick
+    , fromInt
     , genesis
     , succ
     , toInt
@@ -25,3 +26,12 @@ succ (Tick n) =
 toInt : Tick -> Int
 toInt (Tick n) =
     n
+
+
+fromInt : Int -> Maybe Tick
+fromInt n =
+    if n < 0 then
+        Nothing
+
+    else
+        Just (Tick n)

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -108,7 +108,7 @@ tests =
                 in
                 currentRound
                     |> expectRoundOutcome
-                        { tickThatShouldEndIt = Tick.succ (Tick.succ Tick.genesis)
+                        { tickThatShouldEndIt = tickNumber 2
                         , howItShouldEnd =
                             \round ->
                                 case ( round.kurves.alive, round.kurves.dead ) of
@@ -167,3 +167,13 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
 showTick : Tick -> String
 showTick =
     Tick.toInt >> String.fromInt
+
+
+tickNumber : Int -> Tick
+tickNumber n =
+    case Tick.fromInt n of
+        Nothing ->
+            Debug.todo <| "Tick cannot be negative (was " ++ String.fromInt n ++ ")."
+
+        Just tick ->
+            tick


### PR DESCRIPTION
In test cases, it's convenient to be able to say `tickNumber 100` instead of `Tick.succ <| Tick.succ <| … <| Tick.genesis`, and of course it's much more readable.

💡 `git show --color-words='\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>