### PR TITLE
Clarify crash logic

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -259,8 +259,8 @@ evaluateMove config startingPoint positionsToCheck occupiedPixels holeStatus =
                         thickness =
                             Thickness.toInt config.kurves.thickness
 
-                        drawsOutsideWorld : Bool
-                        drawsOutsideWorld =
+                        crashesIntoWall : Bool
+                        crashesIntoWall =
                             List.member True
                                 [ current.leftEdge < 0
                                 , current.topEdge < 0
@@ -268,9 +268,13 @@ evaluateMove config startingPoint positionsToCheck occupiedPixels holeStatus =
                                 , current.topEdge > config.world.height - thickness
                                 ]
 
+                        crashesIntoKurve : Bool
+                        crashesIntoKurve =
+                            not <| Set.isEmpty <| Set.intersect theHitbox occupiedPixels
+
                         dies : Bool
                         dies =
-                            drawsOutsideWorld || (not <| Set.isEmpty <| Set.intersect theHitbox occupiedPixels)
+                            crashesIntoWall || crashesIntoKurve
                     in
                     if dies then
                         ( checked, Kurve.Dies )


### PR DESCRIPTION
The name `drawsOutsideWorld` alludes a bit too much to implementation details. This PR renames it to `crashesIntoWall` to emphasize the gameplay meaning instead. It also extracts the logic for checking if the Kurve crashes into another Kurve into a variable for clarity.

💡 `git show --color-words='\w+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>