### PR TITLE
Use properly initialized rounds in tests

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -11,7 +11,7 @@ module Game exposing
     , modifyRound
     , prepareLiveRound
     , prepareReplayRound
-    , prepareRoundHelper
+    , prepareRoundFromKnownInitialState
     , reactToTick
     , recordUserInteraction
     , tickResultToGameState
@@ -107,16 +107,16 @@ prepareLiveRound config seed players pressedButtons =
         ( theKurves, seedAfterSpawn ) =
             Random.step (generateKurves config players) seed |> Tuple.mapFirst recordInitialInteractions
     in
-    ( Live, prepareRoundHelper { seedAfterSpawn = seedAfterSpawn, spawnedKurves = theKurves } )
+    ( Live, prepareRoundFromKnownInitialState { seedAfterSpawn = seedAfterSpawn, spawnedKurves = theKurves } )
 
 
 prepareReplayRound : RoundInitialState -> MidRoundState
 prepareReplayRound initialState =
-    ( Replay, prepareRoundHelper initialState )
+    ( Replay, prepareRoundFromKnownInitialState initialState )
 
 
-prepareRoundHelper : RoundInitialState -> Round
-prepareRoundHelper initialState =
+prepareRoundFromKnownInitialState : RoundInitialState -> Round
+prepareRoundFromKnownInitialState initialState =
     let
         theKurves : List Kurve
         theKurves =

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -11,6 +11,7 @@ module Game exposing
     , modifyRound
     , prepareLiveRound
     , prepareReplayRound
+    , prepareRoundHelper
     , reactToTick
     , recordUserInteraction
     , tickResultToGameState

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -3,9 +3,9 @@ module AchtungTest exposing (tests)
 import Color
 import Config
 import Expect
-import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), reactToTick)
+import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundHelper, reactToTick)
 import Random
-import Round exposing (Round)
+import Round exposing (Round, RoundInitialState)
 import Set
 import String
 import Test exposing (Test, describe, test)
@@ -41,17 +41,10 @@ tests =
 
                     currentRound : Round
                     currentRound =
-                        { kurves =
-                            { alive = [ currentKurve ]
-                            , dead = []
-                            }
-                        , occupiedPixels = Set.empty
-                        , initialState =
+                        prepareRoundHelper
                             { seedAfterSpawn = Random.initialSeed 0
-                            , spawnedKurves = []
+                            , spawnedKurves = [ currentKurve ]
                             }
-                        , seed = Random.initialSeed 0
-                        }
 
                     tickResult : TickResult
                     tickResult =
@@ -92,21 +85,13 @@ tests =
                         , reversedInteractions = []
                         }
 
-                    currentRound : Round
-                    currentRound =
-                        { kurves =
-                            { alive = [ currentKurve ]
-                            , dead = []
-                            }
-                        , occupiedPixels = Set.empty
-                        , initialState =
-                            { seedAfterSpawn = Random.initialSeed 0
-                            , spawnedKurves = []
-                            }
-                        , seed = Random.initialSeed 0
+                    initialState : RoundInitialState
+                    initialState =
+                        { seedAfterSpawn = Random.initialSeed 0
+                        , spawnedKurves = [ currentKurve ]
                         }
                 in
-                currentRound
+                initialState
                     |> expectRoundOutcome
                         { tickThatShouldEndIt = tickNumber 2
                         , howItShouldEnd =
@@ -131,8 +116,8 @@ type alias RoundOutcome =
     }
 
 
-expectRoundOutcome : RoundOutcome -> Round -> Expect.Expectation
-expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
+expectRoundOutcome : RoundOutcome -> RoundInitialState -> Expect.Expectation
+expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } initialState =
     let
         recurse : Tick -> MidRoundState -> Expect.Expectation
         recurse tick midRoundState =
@@ -160,6 +145,10 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } round =
 
                     else
                         Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
+
+        round : Round
+        round =
+            prepareRoundHelper initialState
     in
     recurse Tick.genesis ( Live, round )
 

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -3,7 +3,7 @@ module AchtungTest exposing (tests)
 import Color
 import Config
 import Expect
-import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundHelper, reactToTick)
+import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundFromKnownInitialState, reactToTick)
 import Random
 import Round exposing (Round, RoundInitialState)
 import Set
@@ -41,7 +41,7 @@ tests =
 
                     currentRound : Round
                     currentRound =
-                        prepareRoundHelper
+                        prepareRoundFromKnownInitialState
                             { seedAfterSpawn = Random.initialSeed 0
                             , spawnedKurves = [ currentKurve ]
                             }
@@ -148,7 +148,7 @@ expectRoundOutcome { tickThatShouldEndIt, howItShouldEnd } initialState =
 
         round : Round
         round =
-            prepareRoundHelper initialState
+            prepareRoundFromKnownInitialState initialState
     in
     recurse Tick.genesis ( Live, round )
 


### PR DESCRIPTION
Manually constructing `Round`s like we do in test cases can result in really confusing situations. For example, consider this test case (without the changes in this PR):

```elm
myTest : Test
myTest =
    test
        "A Kurve that crashes into another Kurve's tail dies"
        (\_ ->
            let
                round : Round
                round =
                    { kurves =
                        { alive = [ red, green ]
                        , dead = []
                        }
                    , occupiedPixels = Set.empty
                    , initialState =
                        { seedAfterSpawn = Random.initialSeed 0
                        , spawnedKurves = [ red, green ]
                        }
                    , seed = Random.initialSeed 0
                    }
            in
            round
                |> expectRoundOutcome
                    { tickThatShouldEndIt = tickNumber 8
                    , howItShouldEnd = always Expect.pass
                    }
        )


red : Kurve
red =
    let
        kurveState =
            { position = ( 100, 100 )
            , direction = Angle 0
            , holeStatus = Unholy 60
            }
    in
    { color = Color.red
    , id = 0
    , controls = ( Set.empty, Set.empty )
    , state = kurveState
    , stateAtSpawn = kurveState
    , reversedInteractions = []
    }


green : Kurve
green =
    let
        kurveState =
            { position = ( 98, 110 )
            , direction = Angle (pi / 2)
            , holeStatus = Unholy 60
            }
    in
    { color = Color.green
    , id = 3
    , controls = ( Set.empty, Set.empty )
    , state = kurveState
    , stateAtSpawn = kurveState
    , reversedInteractions = []
    }
```

It seems to describe a round in which Red spawns at (100, 100) and Green spawns at (98, 110). One would expect Green to crash into Red's tail end, so the test should pass. But it fails.

Turns out the pixels that one would expect to be occupied by Red's tail end are _not_ occupied, so Green just keeps going. This happens because we set `occupiedPixels` to `Set.empty`, i.e. it doesn't include the pixels representing Red's tail end.

In a real game, `occupiedPixels` is always initialized based on the Kurves' spawn positions; see `prepareRoundHelper`. This PR makes the test suite use that function as well, and renames it to the not-so-internal name `prepareRoundFromKnownInitialState`.

💡 `git show --color-words='[A-Z]?[a-z]+|.'`