### PR TITLE
Always play out rounds in test suite

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -461,18 +461,15 @@ expectRoundOutcome config { tickThatShouldEndIt, howItShouldEnd } initialState =
     let
         ( actualEndTick, actualRoundResult ) =
             playOutRound config initialState
-
-        expectationOnEndTick : Expect.Expectation
-        expectationOnEndTick =
+    in
+    Expect.all
+        [ always <| howItShouldEnd actualRoundResult
+        , always <|
             if actualEndTick == tickThatShouldEndIt then
                 Expect.pass
 
             else
                 Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
-    in
-    Expect.all
-        [ always <| howItShouldEnd actualRoundResult
-        , always <| expectationOnEndTick
         ]
         ()
 

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -462,16 +462,11 @@ expectRoundOutcome config { tickThatShouldEndIt, howItShouldEnd } initialState =
         ( actualEndTick, actualRoundResult ) =
             playOutRound config initialState
     in
-    Expect.all
-        [ always <| howItShouldEnd actualRoundResult
-        , always <|
-            if actualEndTick == tickThatShouldEndIt then
-                Expect.pass
+    if actualEndTick == tickThatShouldEndIt then
+        howItShouldEnd actualRoundResult
 
-            else
-                Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
-        ]
-        ()
+    else
+        Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
 
 
 playOutRound : Config -> RoundInitialState -> ( Tick, Round )

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -461,10 +461,18 @@ expectRoundOutcome config { tickThatShouldEndIt, howItShouldEnd } initialState =
     let
         ( actualEndTick, actualRoundResult ) =
             playOutRound config initialState
+
+        expectationOnEndTick : Expect.Expectation
+        expectationOnEndTick =
+            if actualEndTick == tickThatShouldEndIt then
+                Expect.pass
+
+            else
+                Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
     in
     Expect.all
         [ always <| howItShouldEnd actualRoundResult
-        , always <| expectationOnEndTick tickThatShouldEndIt actualEndTick
+        , always <| expectationOnEndTick
         ]
         ()
 
@@ -496,15 +504,6 @@ playOutRound config initialState =
             prepareRoundFromKnownInitialState initialState
     in
     recurse Tick.genesis ( Live, round )
-
-
-expectationOnEndTick : Tick -> Tick -> Expect.Expectation
-expectationOnEndTick tickThatShouldEndIt actualEndTick =
-    if actualEndTick == tickThatShouldEndIt then
-        Expect.pass
-
-    else
-        Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
 
 
 showTick : Tick -> String


### PR DESCRIPTION
Today, `expectRoundOutcome` short-circuits if the round didn't end on the expected tick. This PR makes it always evaluate the entire round, for two reasons:

  * It simplifies the code by separating the evaluation of a round from the expectations on its outcome.

  * It sets the stage for future improvements: a) making it clear _how_ the round ended, even if it did so on the wrong tick, and b) making it possible to ignore on what tick a round ends.

💡 `git show --ignore-space-change --color-moved --color-moved-ws=allow-indentation-change`