### PR TITLE
Refactor expectRoundOutcome to use Expect.all

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -462,11 +462,16 @@ expectRoundOutcome config { tickThatShouldEndIt, howItShouldEnd } initialState =
         ( actualEndTick, actualRoundResult ) =
             playOutRound config initialState
     in
-    if actualEndTick == tickThatShouldEndIt then
-        howItShouldEnd actualRoundResult
+    Expect.all
+        [ \_ ->
+            if actualEndTick == tickThatShouldEndIt then
+                Expect.pass
 
-    else
-        Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
+            else
+                Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
+        , \_ -> howItShouldEnd actualRoundResult
+        ]
+        ()
 
 
 playOutRound : Config -> RoundInitialState -> ( Tick, Round )


### PR DESCRIPTION
I think this makes it more obvious that there are multiple expectations, and easier to add more or rearrange them.

💡 `git show --ignore-space-change`