### PR TITLE
Reorganize test suite slightly

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -17,7 +17,17 @@ import World
 
 tests : Test
 tests =
-    describe "Achtung, die Kurve!"
+    Test.concat
+        [ basicTests
+        , crashTests
+        , crashTimingTests
+        , cuttingCornersTests
+        ]
+
+
+basicTests : Test
+basicTests =
+    describe "Basic tests"
         [ test
             "Kurves move forward by default when game is active"
             (\_ ->
@@ -107,9 +117,6 @@ tests =
                                         Expect.fail "Expected exactly one dead Kurve and no alive ones"
                         }
             )
-        , crashTests
-        , crashTimingTests
-        , cuttingCornersTests
         ]
 
 


### PR DESCRIPTION
Today, most test failures contain a redundant "Achtung, die Kurve!" line:

    ↓ AchtungTest
    ↓ Achtung, die Kurve!
    ↓ Crashing into a Kurve
    ✗ Hitting a Kurve's tail end is a crash

This PR makes it look like this instead:

    ↓ AchtungTest
    ↓ Crashing into a Kurve
    ✗ Hitting a Kurve's tail end is a crash

It also makes it easier to get an overview of the test suite by listing the four sub-suites together without any inlined test cases.

💡 `git show --color-moved`