### PR TITLE
Slim down pre-push hook

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -8,4 +8,4 @@ if ! output=$(git status --porcelain) || [ -n "$output" ]; then
     exit 1
 fi
 
-docker build .
+npm run review && npm test


### PR DESCRIPTION
`RUN npm run review` alone takes about 30 seconds, since it runs without any cache. That's simply too long to wait when pushing, so both @lydell and I always end up canceling the push and doing `git push --no-verify` instead.

This PR changes the pre-push hook to simply `elm-review` plus the test suite, which should catch most mistakes likely to be left at push time without being unreasonably slow (2–3 seconds).