### PR TITLE
Simplify generateKurves

### DIFF
--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -32,15 +32,11 @@ generateKurves config players =
         generateNewAndPrepend ( id, player ) precedingKurves =
             generateKurve config id numberOfPlayers (List.map (.state >> .position) precedingKurves) player
                 |> Random.map (\kurve -> kurve :: precedingKurves)
-
-        generateReversedKurves : Random.Generator (List Kurve)
-        generateReversedKurves =
-            Dict.foldl
-                (\id ( player, _ ) -> curry (Random.andThen << generateNewAndPrepend) id player)
-                (Random.constant [])
-                players
     in
-    generateReversedKurves |> Random.map List.reverse
+    Dict.foldr
+        (\id ( player, _ ) -> curry (Random.andThen << generateNewAndPrepend) id player)
+        (Random.constant [])
+        players
 
 
 isSafeNewPosition : Config -> Int -> List Position -> Position -> Bool


### PR DESCRIPTION
Instead of generating a reversed list of Kurves and then reversing it, we can just generate them in the right order to begin with.

💡 `git show --ignore-space-change --color-words='\w+|.'`