### PR TITLE
Prefer List.foldl over List.foldr

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -125,7 +125,7 @@ prepareRoundFromKnownInitialState initialState =
         round : Round
         round =
             { kurves = { alive = theKurves, dead = [] }
-            , occupiedPixels = List.foldr (.state >> .position >> World.drawingPosition >> World.pixelsToOccupy >> Set.union) Set.empty theKurves
+            , occupiedPixels = List.foldl (.state >> .position >> World.drawingPosition >> World.pixelsToOccupy >> Set.union) Set.empty theKurves
             , initialState = initialState
             , seed = initialState.seedAfterSpawn
             }
@@ -213,7 +213,7 @@ checkIndividualKurve config tick kurve ( checkedKurvesGenerator, occupiedPixels,
 
         occupiedPixelsAfterCheckingThisKurve : Set Pixel
         occupiedPixelsAfterCheckingThisKurve =
-            List.foldr
+            List.foldl
                 (World.pixelsToOccupy >> Set.union)
                 occupiedPixels
                 newKurveDrawingPositions


### PR DESCRIPTION
My tendency to default to `foldr` is probably a Haskellism (if it even makes sense there; I don't really know). [The implementation of `foldl`][foldl] is much simpler than [that of `foldr`][foldr], and I've never heard anyone saying that `foldr` should be preferred in Elm when the combining function is associative.

The two folds modified in this PR use associative combining functions, so changing them to `foldl` doesn't affect the result. The two remaining `foldr` folds (in `reactToTick` and `generateKurves`) don't.

[foldl]: https://github.com/elm/core/blob/65cea00afa0de03d7dda0487d964a305fc3d58e3/src/List.elm#L150:L157
[foldr]: https://github.com/elm/core/blob/65cea00afa0de03d7dda0487d964a305fc3d58e3/src/List.elm#L172:L206

💡 `git show --color-words='\w+|.'`