### PR TITLE
Add tests for crashing into the walls

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -13,7 +13,7 @@ import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.Speed as Speed exposing (Speed(..))
 import Types.Tick as Tick exposing (Tick)
-import World exposing (DrawingPosition, Position)
+import World
 
 
 tests : Test
@@ -207,9 +207,9 @@ crashingIntoWallTests =
             testCases :
                 List
                     { wallDescription : String
-                    , startingPosition : Position
+                    , startingPosition : World.Position
                     , direction : Angle
-                    , drawingPositionItShouldNeverMakeItTo : DrawingPosition
+                    , drawingPositionItShouldNeverMakeItTo : World.DrawingPosition
                     }
             testCases =
                 [ { wallDescription = "Top wall"

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -13,7 +13,7 @@ import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.Speed as Speed exposing (Speed(..))
 import Types.Tick as Tick exposing (Tick)
-import World
+import World exposing (DrawingPosition, Position)
 
 
 tests : Test
@@ -21,6 +21,7 @@ tests =
     Test.concat
         [ basicTests
         , crashingIntoKurveTests
+        , crashingIntoWallTests
         , crashTimingTests
         , cuttingCornersTests
         , speedTests
@@ -193,6 +194,97 @@ crashingIntoKurveTests =
                                         Expect.fail "Expected exactly one dead Kurve and one alive one"
                         }
         ]
+
+
+crashingIntoWallTests : Test
+crashingIntoWallTests =
+    describe "Crashing into a wall"
+        (let
+            tickThatShouldEndIt : Tick
+            tickThatShouldEndIt =
+                tickNumber 2
+
+            testCases :
+                List
+                    { wallDescription : String
+                    , startingPosition : Position
+                    , direction : Angle
+                    , drawingPositionItShouldNeverMakeItTo : DrawingPosition
+                    }
+            testCases =
+                [ { wallDescription = "Top wall"
+                  , startingPosition = ( 100, 2.5 )
+                  , direction = Angle (pi / 2)
+                  , drawingPositionItShouldNeverMakeItTo = { leftEdge = 99, topEdge = -1 }
+                  }
+                , { wallDescription = "Right wall"
+                  , startingPosition = ( 556.5, 100 )
+                  , direction = Angle 0
+                  , drawingPositionItShouldNeverMakeItTo = { leftEdge = 557, topEdge = 99 }
+                  }
+                , { wallDescription = "Bottom wall"
+                  , startingPosition = ( 100, 477.5 )
+                  , direction = Angle (-pi / 2)
+                  , drawingPositionItShouldNeverMakeItTo = { leftEdge = 99, topEdge = 478 }
+                  }
+                , { wallDescription = "Left wall"
+                  , startingPosition = ( 2.5, 100 )
+                  , direction = Angle pi
+                  , drawingPositionItShouldNeverMakeItTo = { leftEdge = -1, topEdge = 99 }
+                  }
+                ]
+         in
+         testCases
+            |> List.map
+                (\{ wallDescription, startingPosition, direction, drawingPositionItShouldNeverMakeItTo } ->
+                    test wallDescription <|
+                        \_ ->
+                            let
+                                green : Kurve
+                                green =
+                                    { color = Color.green
+                                    , id = 3
+                                    , controls = ( Set.empty, Set.empty )
+                                    , state =
+                                        { position = startingPosition
+                                        , direction = direction
+                                        , holeStatus = Unholy 60000
+                                        }
+                                    , stateAtSpawn =
+                                        { position = ( 0, 0 )
+                                        , direction = Angle 0
+                                        , holeStatus = Unholy 0
+                                        }
+                                    , reversedInteractions = []
+                                    }
+
+                                initialState : RoundInitialState
+                                initialState =
+                                    { seedAfterSpawn = Random.initialSeed 0
+                                    , spawnedKurves = [ green ]
+                                    }
+                            in
+                            initialState
+                                |> expectRoundOutcome
+                                    Config.default
+                                    { tickThatShouldEndIt = tickThatShouldEndIt
+                                    , howItShouldEnd =
+                                        \round ->
+                                            case ( round.kurves.alive, round.kurves.dead ) of
+                                                ( [], [ deadKurve ] ) ->
+                                                    let
+                                                        theDrawingPositionItNeverMadeItTo : World.DrawingPosition
+                                                        theDrawingPositionItNeverMadeItTo =
+                                                            World.drawingPosition deadKurve.state.position
+                                                    in
+                                                    theDrawingPositionItNeverMadeItTo
+                                                        |> Expect.equal drawingPositionItShouldNeverMakeItTo
+
+                                                _ ->
+                                                    Expect.fail "Expected exactly one dead Kurve and no alive ones"
+                                    }
+                )
+        )
 
 
 {-|


### PR DESCRIPTION
This PR adds basic regression tests/sanity checks for wall collisions. They should hopefully prevent off-by-one errors and the like from making it into the trunk.