### PR TITLE
Add around-the-world test case

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -759,7 +759,7 @@ makeZombieKurve { color, id, state } =
 
 {-| How many ticks to wait before performing some action, and that action.
 
-The number of ticks to wait is counted from the previous action, not from the beginning of the round.
+The number of ticks to wait is counted from the previous action (or, for the first action, from the beginning of the round).
 
 -}
 type alias CumulativeInteraction =


### PR DESCRIPTION
This PR adds the first test case with a Kurve that actually does something "intentional" – namely goes on a trek around the world, touching each of the four walls as it does so.

The actions of the Kurve are described using a new `makeUserInteractions` helper function that makes it easy to "program" Kurves in test cases.

We don't have any first-class way of visualizing test cases or hardcoded rounds in general, but it can be done ad-hoc like this:

```elm
init : () -> ( Model, Cmd Msg )
init _ =
    let
        model =
            { pressedButtons = Set.empty
            , appState = InMenu SplashScreen (Random.initialSeed 1337)
            , config = Config.default
            , players = initialPlayers
            }
    in
    startRound model <|
        prepareReplayRound <|
            { seedAfterSpawn = Random.initialSeed 0
            , spawnedKurves = [ green ]
            }
```

(`green` should be defined just like in the test case. To build with `--optimize`, `tickNumber` needs to be modified to return a `Tick` even for negative inputs.)

💡 `git show --color-words=.`