### PR TITLE
Add test case for long rounds

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -27,6 +27,7 @@ tests =
         , crashTimingTests
         , cuttingCornersTests
         , speedTests
+        , stressTests
         ]
 
 
@@ -779,6 +780,73 @@ speedTests =
                                     }
                 )
         )
+
+
+stressTests : Test
+stressTests =
+    describe "Stress tests"
+        [ test "Realistic single-player turtle survival round" <|
+            \_ ->
+                let
+                    greenZombie : Kurve
+                    greenZombie =
+                        makeZombieKurve
+                            { color = Color.green
+                            , id = 3
+                            , state =
+                                { position = ( 32.5, 3.5 )
+                                , direction = Angle 0
+                                , holeStatus = Unholy 60000
+                                }
+                            }
+
+                    green : Kurve
+                    green =
+                        { greenZombie
+                            | reversedInteractions =
+                                List.range 1 20
+                                    |> List.concatMap makeLap
+                                    |> makeUserInteractions
+                        }
+
+                    makeLap : Int -> List CumulativeInteraction
+                    makeLap i =
+                        [ ( 510 - 20 * i, TurningRight )
+                        , ( 45, NotTurning )
+                        , ( 430 - 20 * i, TurningRight )
+                        , ( 45, NotTurning )
+                        , ( 495 - 20 * i, TurningRight )
+                        , ( 44, NotTurning )
+                        , ( 414 - 20 * i, TurningRight )
+                        , ( 45, NotTurning )
+                        ]
+
+                    initialState : RoundInitialState
+                    initialState =
+                        { seedAfterSpawn = Random.initialSeed 0
+                        , spawnedKurves = [ green ]
+                        }
+                in
+                initialState
+                    |> expectRoundOutcome
+                        Config.default
+                        { tickThatShouldEndIt = tickNumber 23875
+                        , howItShouldEnd =
+                            \round ->
+                                case round.kurves.dead of
+                                    [ deadKurve ] ->
+                                        let
+                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
+                                            theDrawingPositionItNeverMadeItTo =
+                                                World.drawingPosition deadKurve.state.position
+                                        in
+                                        theDrawingPositionItNeverMadeItTo
+                                            |> Expect.equal { leftEdge = 372, topEdge = 217 }
+
+                                    _ ->
+                                        Expect.fail "Expected exactly one dead Kurve"
+                        }
+        ]
 
 
 {-| A description of when and how a round should end.


### PR DESCRIPTION
This test case is intended as a regression test for problems that only become apparent in lengthy rounds, like stack overflows or certain performance issues.

For example, the following change to the collision handling would be extremely detrimental for the asymptotic performance as the round length increases:

```diff
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -272,5 +272,5 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holeStatus =
                         crashesIntoKurve : Bool
                         crashesIntoKurve =
-                            not <| Set.isEmpty <| Set.intersect theHitbox occupiedPixels
+                            not <| Set.isEmpty <| Set.filter (\pixel -> Set.member pixel theHitbox) occupiedPixels

                         dies : Bool
```

Without this test case, that change only increases the test-suite run time from about half a second to about one and a half second on my laptop (with a Core i7-7500U), so it could quite easily fly under the radar.

With this test case, the change increases the test-suite run time from just over one second to over _two minutes_, making it much more unlikely for it to go unnoticed.