### PR TITLE
Make it easier to visualize test cases in-game

### DIFF
--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -1,0 +1,84 @@
+module TestScenarioHelpers exposing
+    ( CumulativeInteraction
+    , makeUserInteractions
+    , makeZombieKurve
+    , roundWith
+    , tickNumber
+    )
+
+import Color
+import Random
+import Round exposing (RoundInitialState)
+import Set
+import Types.Angle exposing (Angle(..))
+import Types.Kurve as Kurve exposing (HoleStatus(..), Kurve, UserInteraction(..))
+import Types.PlayerId exposing (PlayerId)
+import Types.Tick as Tick exposing (Tick)
+import Types.TurningState exposing (TurningState)
+
+
+{-| Creates a Kurve that just moves forward.
+-}
+makeZombieKurve : { color : Color.Color, id : PlayerId, state : Kurve.State } -> Kurve
+makeZombieKurve { color, id, state } =
+    { color = color
+    , id = id
+    , controls = ( Set.empty, Set.empty )
+    , state = state
+    , stateAtSpawn =
+        { position = ( 0, 0 )
+        , direction = Angle 0
+        , holeStatus = Unholy 0
+        }
+    , reversedInteractions = []
+    }
+
+
+roundWith : List Kurve -> RoundInitialState
+roundWith spawnedKurves =
+    { seedAfterSpawn = Random.initialSeed 0
+    , spawnedKurves = spawnedKurves
+    }
+
+
+{-| How many ticks to wait before performing some action, and that action.
+
+The number of ticks to wait is counted from the previous action (or, for the first action, from the beginning of the round).
+
+-}
+type alias CumulativeInteraction =
+    ( Int, TurningState )
+
+
+{-| Makes it easy for a human to "program" a Kurve.
+
+The input is a chronologically ordered list representing how a human will typically think about a Kurve's actions.
+
+-}
+makeUserInteractions : List CumulativeInteraction -> List UserInteraction
+makeUserInteractions cumulativeInteractions =
+    let
+        accumulate : CumulativeInteraction -> ( List CumulativeInteraction, Int ) -> ( List CumulativeInteraction, Int )
+        accumulate ( ticksBeforeAction, turningState ) ( soFar, previousTickNumber ) =
+            let
+                thisTickNumber : Int
+                thisTickNumber =
+                    previousTickNumber + ticksBeforeAction
+            in
+            ( ( thisTickNumber, turningState ) :: soFar, thisTickNumber )
+
+        toUserInteraction : CumulativeInteraction -> UserInteraction
+        toUserInteraction ( n, turningState ) =
+            HappenedBefore (tickNumber n) turningState
+    in
+    List.foldl accumulate ( [], 0 ) cumulativeInteractions |> Tuple.first |> List.map toUserInteraction
+
+
+tickNumber : Int -> Tick
+tickNumber n =
+    case Tick.fromInt n of
+        Nothing ->
+            Tick.genesis
+
+        Just tick ->
+            tick

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -1,0 +1,41 @@
+module TestScenarios.AroundTheWorld exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeUserInteractions, makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+import Types.TurningState exposing (TurningState(..))
+
+
+greenZombie : Kurve
+greenZombie =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 4.5, 1.5 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    { greenZombie
+        | reversedInteractions =
+            makeUserInteractions
+                -- Intended to make the Kurve touch each of the four walls on its way around the world.
+                [ ( 526, TurningRight )
+                , ( 45, NotTurning )
+                , ( 420, TurningRight )
+                , ( 45, NotTurning )
+                , ( 491, TurningRight )
+                , ( 44, NotTurning )
+                ]
+    }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -1,0 +1,37 @@
+module TestScenarios.CrashIntoTailEnd90Degrees exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+red : Kurve
+red =
+    makeZombieKurve
+        { color = Color.red
+        , id = 0
+        , state =
+            { position = ( 100.5, 100.5 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 98.5, 110.5 )
+            , direction = Angle (pi / 2)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ red, green ]

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -1,0 +1,37 @@
+module TestScenarios.CrashIntoTipOfTailEnd exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+red : Kurve
+red =
+    makeZombieKurve
+        { color = Color.red
+        , id = 0
+        , state =
+            { position = ( 60.5, 60.5 )
+            , direction = Angle (-pi / 4)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 30.5, 30.5 )
+            , direction = Angle (-pi / 4)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ red, green ]

--- a/src/TestScenarios/CrashIntoWallBasic.elm
+++ b/src/TestScenarios/CrashIntoWallBasic.elm
@@ -1,0 +1,24 @@
+module TestScenarios.CrashIntoWallBasic exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 2.5, 100 )
+            , direction = Angle pi
+            , holeStatus = Unholy 60
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -1,0 +1,24 @@
+module TestScenarios.CrashIntoWallExactTiming exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 100, 3.5 )
+            , direction = Angle 0.01
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -1,0 +1,37 @@
+module TestScenarios.CuttingCornersBasic exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+red : Kurve
+red =
+    makeZombieKurve
+        { color = Color.red
+        , id = 0
+        , state =
+            { position = ( 200.5, 100.5 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 100.5, 196.5 )
+            , direction = Angle (pi / 4)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ red, green ]

--- a/src/TestScenarios/CuttingCornersPerfectOverpaintingTheoretical.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpaintingTheoretical.elm
@@ -1,0 +1,50 @@
+module TestScenarios.CuttingCornersPerfectOverpaintingTheoretical exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+red : Kurve
+red =
+    makeZombieKurve
+        { color = Color.red
+        , id = 0
+        , state =
+            { position = ( 30.5, 30.5 )
+            , direction = Angle (-pi / 4)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+yellow : Kurve
+yellow =
+    makeZombieKurve
+        { color = Color.yellow
+        , id = 1
+        , state =
+            { position = ( 60.5, 60.5 )
+            , direction = Angle (-pi / 4)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 19.5, 98.5 )
+            , direction = Angle (pi / 4)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ red, green, yellow ]

--- a/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
+++ b/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
@@ -1,0 +1,37 @@
+module TestScenarios.CuttingCornersThreePixelsRealExample exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+red : Kurve
+red =
+    makeZombieKurve
+        { color = Color.red
+        , id = 0
+        , state =
+            { position = ( 299.5, 302.5 )
+            , direction = Angle (-71 * (2 * pi / 360))
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 319, 269 )
+            , direction = Angle (-123 * (2 * pi / 360))
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ red, green ]

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -1,0 +1,24 @@
+module TestScenarios.SpeedEffectOnGame exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 108, 100 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -1,0 +1,48 @@
+module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (CumulativeInteraction, makeUserInteractions, makeZombieKurve)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+import Types.TurningState exposing (TurningState(..))
+
+
+greenZombie : Kurve
+greenZombie =
+    makeZombieKurve
+        { color = Color.green
+        , id = 3
+        , state =
+            { position = ( 32.5, 3.5 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+green : Kurve
+green =
+    { greenZombie
+        | reversedInteractions =
+            List.range 1 20
+                |> List.concatMap makeLap
+                |> makeUserInteractions
+    }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]
+
+
+makeLap : Int -> List CumulativeInteraction
+makeLap i =
+    [ ( 510 - 20 * i, TurningRight )
+    , ( 45, NotTurning )
+    , ( 430 - 20 * i, TurningRight )
+    , ( 45, NotTurning )
+    , ( 495 - 20 * i, TurningRight )
+    , ( 44, NotTurning )
+    , ( 414 - 20 * i, TurningRight )
+    , ( 45, NotTurning )
+    ]

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -6,17 +6,21 @@ import Expect
 import String
 import Test exposing (Test, describe, test)
 import TestHelpers exposing (defaultConfigWithSpeed, expectRoundOutcome)
-import TestScenarioHelpers exposing (CumulativeInteraction, makeUserInteractions, makeZombieKurve, roundWith, tickNumber)
+import TestScenarioHelpers exposing (makeZombieKurve, roundWith, tickNumber)
 import TestScenarios.AroundTheWorld
 import TestScenarios.CrashIntoTailEnd90Degrees
 import TestScenarios.CrashIntoTipOfTailEnd
 import TestScenarios.CrashIntoWallBasic
 import TestScenarios.CrashIntoWallExactTiming
+import TestScenarios.CuttingCornersBasic
+import TestScenarios.CuttingCornersPerfectOverpaintingTheoretical
+import TestScenarios.CuttingCornersThreePixelsRealExample
+import TestScenarios.SpeedEffectOnGame
+import TestScenarios.StressTestRealisticTurtleSurvivalRound
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.Speed as Speed exposing (Speed(..))
 import Types.Tick exposing (Tick)
-import Types.TurningState exposing (TurningState(..))
 import World
 
 
@@ -357,32 +361,7 @@ cuttingCornersTests =
     describe "Cutting corners (by painting over them)"
         [ test "It is possible to cut the corner of a Kurve's tail end" <|
             \_ ->
-                let
-                    red : Kurve
-                    red =
-                        makeZombieKurve
-                            { color = Color.red
-                            , id = 0
-                            , state =
-                                { position = ( 200.5, 100.5 )
-                                , direction = Angle 0
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 100.5, 196.5 )
-                                , direction = Angle (pi / 4)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-                in
-                roundWith [ red, green ]
+                roundWith TestScenarios.CuttingCornersBasic.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 277
@@ -410,32 +389,7 @@ cuttingCornersTests =
                         }
         , test "It is possible to paint over three pixels when cutting a corner (real example from original game)" <|
             \_ ->
-                let
-                    red : Kurve
-                    red =
-                        makeZombieKurve
-                            { color = Color.red
-                            , id = 0
-                            , state =
-                                { position = ( 299.5, 302.5 )
-                                , direction = Angle (-71 * (2 * pi / 360))
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 319, 269 )
-                                , direction = Angle (-123 * (2 * pi / 360))
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-                in
-                roundWith [ red, green ]
+                roundWith TestScenarios.CuttingCornersThreePixelsRealExample.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 40
@@ -463,44 +417,7 @@ cuttingCornersTests =
                         }
         , test "The perfect overpainting (squeezing through a non-existent gap)" <|
             \_ ->
-                let
-                    red : Kurve
-                    red =
-                        makeZombieKurve
-                            { color = Color.red
-                            , id = 0
-                            , state =
-                                { position = ( 30.5, 30.5 )
-                                , direction = Angle (-pi / 4)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    yellow : Kurve
-                    yellow =
-                        makeZombieKurve
-                            { color = Color.yellow
-                            , id = 1
-                            , state =
-                                { position = ( 60.5, 60.5 )
-                                , direction = Angle (-pi / 4)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 19.5, 98.5 )
-                                , direction = Angle (pi / 4)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-                in
-                roundWith [ red, yellow, green ]
+                roundWith TestScenarios.CuttingCornersPerfectOverpaintingTheoretical.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 138
@@ -540,20 +457,7 @@ speedTests =
                 (\( speed, expectedEndTick ) ->
                     test ("Round ends as expected when speed is " ++ String.fromFloat (Speed.toFloat speed)) <|
                         \_ ->
-                            let
-                                green : Kurve
-                                green =
-                                    makeZombieKurve
-                                        { color = Color.green
-                                        , id = 3
-                                        , state =
-                                            { position = ( 108, 100 )
-                                            , direction = Angle 0
-                                            , holeStatus = Unholy 60000
-                                            }
-                                        }
-                            in
-                            roundWith [ green ]
+                            roundWith TestScenarios.SpeedEffectOnGame.spawnedKurves
                                 |> expectRoundOutcome
                                     (defaultConfigWithSpeed speed)
                                     { tickThatShouldEndIt = expectedEndTick
@@ -581,41 +485,7 @@ stressTests =
     describe "Stress tests"
         [ test "Realistic single-player turtle survival round" <|
             \_ ->
-                let
-                    greenZombie : Kurve
-                    greenZombie =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 32.5, 3.5 )
-                                , direction = Angle 0
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        { greenZombie
-                            | reversedInteractions =
-                                List.range 1 20
-                                    |> List.concatMap makeLap
-                                    |> makeUserInteractions
-                        }
-
-                    makeLap : Int -> List CumulativeInteraction
-                    makeLap i =
-                        [ ( 510 - 20 * i, TurningRight )
-                        , ( 45, NotTurning )
-                        , ( 430 - 20 * i, TurningRight )
-                        , ( 45, NotTurning )
-                        , ( 495 - 20 * i, TurningRight )
-                        , ( 44, NotTurning )
-                        , ( 414 - 20 * i, TurningRight )
-                        , ( 45, NotTurning )
-                        ]
-                in
-                roundWith [ green ]
+                roundWith TestScenarios.StressTestRealisticTurtleSurvivalRound.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 23875

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -5,7 +5,13 @@ import Config
 import Expect
 import String
 import Test exposing (Test, describe, test)
-import TestHelpers exposing (CumulativeInteraction, defaultConfigWithSpeed, expectRoundOutcome, makeUserInteractions, makeZombieKurve, roundWith, tickNumber)
+import TestHelpers exposing (defaultConfigWithSpeed, expectRoundOutcome)
+import TestScenarioHelpers exposing (CumulativeInteraction, makeUserInteractions, makeZombieKurve, roundWith, tickNumber)
+import TestScenarios.AroundTheWorld
+import TestScenarios.CrashIntoTailEnd90Degrees
+import TestScenarios.CrashIntoTipOfTailEnd
+import TestScenarios.CrashIntoWallBasic
+import TestScenarios.CrashIntoWallExactTiming
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.Speed as Speed exposing (Speed(..))
@@ -32,20 +38,7 @@ basicTests =
     describe "Basic tests"
         [ test "A Kurve that crashes into the wall dies" <|
             \_ ->
-                let
-                    green : Kurve
-                    green =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 2.5, 100 )
-                                , direction = Angle pi
-                                , holeStatus = Unholy 60
-                                }
-                            }
-                in
-                roundWith [ green ]
+                roundWith TestScenarios.CrashIntoWallBasic.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 2
@@ -61,35 +54,7 @@ basicTests =
                         }
         , test "Around the world, touching each wall" <|
             \_ ->
-                let
-                    greenZombie : Kurve
-                    greenZombie =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 4.5, 1.5 )
-                                , direction = Angle 0
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        { greenZombie
-                            | reversedInteractions =
-                                makeUserInteractions
-                                    -- Intended to make the Kurve touch each of the four walls on its way around the world.
-                                    [ ( 526, TurningRight )
-                                    , ( 45, NotTurning )
-                                    , ( 420, TurningRight )
-                                    , ( 45, NotTurning )
-                                    , ( 491, TurningRight )
-                                    , ( 44, NotTurning )
-                                    ]
-                        }
-                in
-                roundWith [ green ]
+                roundWith TestScenarios.AroundTheWorld.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 2011
@@ -116,32 +81,7 @@ crashingIntoKurveTests =
     describe "Crashing into a Kurve"
         [ test "Hitting a Kurve's tail end is a crash" <|
             \_ ->
-                let
-                    red : Kurve
-                    red =
-                        makeZombieKurve
-                            { color = Color.red
-                            , id = 0
-                            , state =
-                                { position = ( 100.5, 100.5 )
-                                , direction = Angle 0
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 98.5, 110.5 )
-                                , direction = Angle (pi / 2)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-                in
-                roundWith [ red, green ]
+                roundWith TestScenarios.CrashIntoTailEnd90Degrees.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 8
@@ -169,32 +109,7 @@ crashingIntoKurveTests =
                         }
         , test "Hitting a Kurve's tail end at a 45-degree angle is a crash" <|
             \_ ->
-                let
-                    red : Kurve
-                    red =
-                        makeZombieKurve
-                            { color = Color.red
-                            , id = 0
-                            , state =
-                                { position = ( 60.5, 60.5 )
-                                , direction = Angle (-pi / 4)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-
-                    green : Kurve
-                    green =
-                        makeZombieKurve
-                            { color = Color.green
-                            , id = 3
-                            , state =
-                                { position = ( 30.5, 30.5 )
-                                , direction = Angle (-pi / 4)
-                                , holeStatus = Unholy 60000
-                                }
-                            }
-                in
-                roundWith [ red, green ]
+                roundWith TestScenarios.CrashIntoTipOfTailEnd.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 39
@@ -346,20 +261,7 @@ crashingIntoWallTimingTest : Test
 crashingIntoWallTimingTest =
     test "The exact timing of a crash into the wall is predictable for the player" <|
         \_ ->
-            let
-                green : Kurve
-                green =
-                    makeZombieKurve
-                        { color = Color.green
-                        , id = 3
-                        , state =
-                            { position = ( 100, 3.5 )
-                            , direction = Angle 0.01
-                            , holeStatus = Unholy 60000
-                            }
-                        }
-            in
-            roundWith [ green ]
+            roundWith TestScenarios.CrashIntoWallExactTiming.spawnedKurves
                 |> expectRoundOutcome
                     Config.default
                     { tickThatShouldEndIt = tickNumber 251

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -1,26 +1,14 @@
 module TestHelpers exposing
-    ( CumulativeInteraction
-    , defaultConfigWithSpeed
+    ( defaultConfigWithSpeed
     , expectRoundOutcome
-    , makeUserInteractions
-    , makeZombieKurve
-    , roundWith
-    , tickNumber
     )
 
-import Color
 import Config exposing (Config, KurveConfig)
 import Expect
 import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundFromKnownInitialState, reactToTick)
-import Random
 import Round exposing (Round, RoundInitialState)
-import Set
-import Types.Angle exposing (Angle(..))
-import Types.Kurve as Kurve exposing (HoleStatus(..), Kurve, UserInteraction(..))
-import Types.PlayerId exposing (PlayerId)
 import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
-import Types.TurningState exposing (TurningState)
 
 
 {-| A description of when and how a round should end.
@@ -83,16 +71,6 @@ showTick =
     Tick.toInt >> String.fromInt
 
 
-tickNumber : Int -> Tick
-tickNumber n =
-    case Tick.fromInt n of
-        Nothing ->
-            Debug.todo <| "Tick cannot be negative (was " ++ String.fromInt n ++ ")."
-
-        Just tick ->
-            tick
-
-
 defaultConfigWithSpeed : Speed -> Config
 defaultConfigWithSpeed speed =
     let
@@ -110,60 +88,3 @@ defaultConfigWithSpeed speed =
                 | speed = speed
             }
     }
-
-
-{-| Creates a Kurve that just moves forward.
--}
-makeZombieKurve : { color : Color.Color, id : PlayerId, state : Kurve.State } -> Kurve
-makeZombieKurve { color, id, state } =
-    { color = color
-    , id = id
-    , controls = ( Set.empty, Set.empty )
-    , state = state
-    , stateAtSpawn =
-        { position = ( 0, 0 )
-        , direction = Angle 0
-        , holeStatus = Unholy 0
-        }
-    , reversedInteractions = []
-    }
-
-
-roundWith : List Kurve -> RoundInitialState
-roundWith spawnedKurves =
-    { seedAfterSpawn = Random.initialSeed 0
-    , spawnedKurves = spawnedKurves
-    }
-
-
-{-| How many ticks to wait before performing some action, and that action.
-
-The number of ticks to wait is counted from the previous action (or, for the first action, from the beginning of the round).
-
--}
-type alias CumulativeInteraction =
-    ( Int, TurningState )
-
-
-{-| Makes it easy for a human to "program" a Kurve.
-
-The input is a chronologically ordered list representing how a human will typically think about a Kurve's actions.
-
--}
-makeUserInteractions : List CumulativeInteraction -> List UserInteraction
-makeUserInteractions cumulativeInteractions =
-    let
-        accumulate : CumulativeInteraction -> ( List CumulativeInteraction, Int ) -> ( List CumulativeInteraction, Int )
-        accumulate ( ticksBeforeAction, turningState ) ( soFar, previousTickNumber ) =
-            let
-                thisTickNumber : Int
-                thisTickNumber =
-                    previousTickNumber + ticksBeforeAction
-            in
-            ( ( thisTickNumber, turningState ) :: soFar, thisTickNumber )
-
-        toUserInteraction : CumulativeInteraction -> UserInteraction
-        toUserInteraction ( n, turningState ) =
-            HappenedBefore (tickNumber n) turningState
-    in
-    List.foldl accumulate ( [], 0 ) cumulativeInteractions |> Tuple.first |> List.map toUserInteraction


### PR DESCRIPTION
When writing test cases or trying to figure out why a test case is failing, it's usually very helpful to visualize the test case in the game.

This PR takes all test cases that don't involve multiple dynamically created sub-tests, and moves their initial states into their own modules in `src/TestScenarios/`, thereby enabling visualization with minimal changes in `src/Main.elm`:

```elm
import TestScenarios.CrashIntoWallExactTiming

init : () -> ( Model, Cmd Msg )
init _ =
    let
        ( gameState, cmd ) =
            { seedAfterSpawn = Random.initialSeed 0
            , spawnedKurves = TestScenarios.CrashIntoWallExactTiming.spawnedKurves
            }
                |> prepareReplayRound
                |> newRoundGameStateAndCmd Config.default
    in
    ( { pressedButtons = Set.empty
      , appState = InGame gameState
      , config = Config.default
      , players = initialPlayers
      }
    , cmd
    )
```

Moving `tickNumber` into `src/` means that it cannot use `Debug.todo` anymore (because `npm run build` would then fail), so I went with `Tick.genesis` because it seemed like the most reasonable option. I guess `tickNumber n` would also make sense in principle, but it would cause `npm test` to hang indefinitely should a negative number be passed to `tickNumber`.

For the record, one can short-circuit `update` to speed up the visualization:

```diff
--- b/src/Main.elm
+++ a/src/Main.elm
@@ -98,6 +98,6 @@ stepSpawnState config { kurvesLeft, ticksLeft } =


-update : Msg -> Model -> ( Model, Cmd Msg )
-update msg ({ config, pressedButtons } as model) =
+update : Cmd Msg -> Msg -> Model -> ( Model, Cmd Msg )
+update cmdSoFar msg ({ config, pressedButtons } as model) =
     case msg of
         FocusLost ->
@@ -117,8 +117,21 @@ update msg ({ config, pressedButtons } as model) =
                 ( tickResult, cmd ) =
                     Game.reactToTick config tick midRoundState
+
+                newModel =
+                    { model | appState = InGame (tickResultToGameState tickResult) }
+
+                newCmd =
+                    Cmd.batch [ cmdSoFar, cmd ]
             in
-            ( { model | appState = InGame (tickResultToGameState tickResult) }
-            , cmd
-            )
+            case tickResult of
+                RoundKeepsGoing _ newMidRoundState ->
+                    if modBy 100 (Tick.toInt tick) == 0 then
+                        ( newModel, newCmd )
+
+                    else
+                        update newCmd (GameTick (Tick.succ tick) newMidRoundState) newModel
+
+                RoundEnds _ ->
+                    ( newModel, newCmd )

         ButtonUsed Down button ->
```

(Without the `modBy 100` check, the `StressTestRealisticTurtleSurvivalRound` scenario would crash with `InternalError: too much recursion`.)

💡 `git show --color-moved=plain --color-moved-ws=allow-indentation-change`