### PR TITLE
Upgrade run-pty to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "zatacka",
       "hasInstallScript": true,
+      "dependencies": {
+        "run-pty": "5"
+      },
       "devDependencies": {
         "elm-review": "2.12.0",
         "elm-test": "0.19.1-revision12",
@@ -15,7 +18,7 @@
         "sass": "1.43.3"
       },
       "optionalDependencies": {
-        "run-pty": "^4.0.3"
+        "run-pty": "^5.0.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -122,6 +125,85 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.0.3.tgz",
+      "integrity": "sha512-nLTNwJXEPi1oMyzxRwqsLB4jCmhDrltQS/kAYhV05qbPo5NOIKpw2tb+Iok/yhd9zP9+E5Lu7sWDGD+G4fdKbQ==",
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.0.3",
+        "@lydell/node-pty-darwin-x64": "1.0.3",
+        "@lydell/node-pty-linux-x64": "1.0.3",
+        "@lydell/node-pty-win32-arm64": "1.0.3",
+        "@lydell/node-pty-win32-x64": "1.0.3"
+      }
+    },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-cpLatXzGHds9fU6KSA+5jB4CRKqqK1ITerYlbucyhfsE0uksMVpzD6Ti6jMeEq7YM0N+c61q6EURl/pIwNYSqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-IuEf8TXwo+wzoUEhqv+LtznwW94gMm4V9XVFMisFh+oRz0TNtnWHtgTCdWCVn4Dm3dpEDAjiAlTLx0ayC5uMVA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.0.3.tgz",
+      "integrity": "sha512-tfj6Zg9F5KkyCQQ2wCUXUW/1lcNgdWAVJNtt6gQH3X+fUueSrRl+R7xoWTcl5NGcfn2l7QWgUrjZcVKP3/ljTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.0.3.tgz",
+      "integrity": "sha512-5MTd7hbrvmO/de/B2MDhxjh3E109i5bSds6JtIcVR1M6+uCvWJrON5ibbvWIAqTHpFup20IyDv0cQJxVv9o9nA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.0.3.tgz",
+      "integrity": "sha512-XMANgXpBYGtKa5q+czro+TaJAyv3njbT7R81Pky+p7e4GwNdWtSUNBxtQm+O4ZLV0VJ1rNiMEHMyGOq8T9i4FA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1718,22 +1800,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "optional": true
-    },
-    "node_modules/node-pty": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.10.1.tgz",
-      "integrity": "sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2069,17 +2135,25 @@
       }
     },
     "node_modules/run-pty": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/run-pty/-/run-pty-4.0.3.tgz",
-      "integrity": "sha512-O8IWhjhChwLq7psyZZDY+Pv/CSEM7DLBXqUqEVWKMXGR18s2o2ma4IEanKWSSLBULNCpHn3n9RYvybc+7IaBig==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-pty/-/run-pty-5.0.0.tgz",
+      "integrity": "sha512-0gk83+2NmrZGGPlJ88lqt0dYHvgyau/JBdRz9OqEbNyIfmbiq9E5sGCsvHdjrLoUJVh09ZX9r5rN587ACoM3vQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "node-pty": "^0.10.1",
-        "tiny-decoders": "^7.0.1"
+        "@lydell/node-pty": "^1.0.0",
+        "tiny-decoders": "^23.0.0"
       },
       "bin": {
-        "run-pty": "run-pty.js"
+        "run-pty": "run-pty-bin.js"
       }
+    },
+    "node_modules/run-pty/node_modules/tiny-decoders": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-decoders/-/tiny-decoders-23.0.0.tgz",
+      "integrity": "sha512-gQB+za3EW9JN1ASDmrVl1a1I6Q/jzg4M75YLI9ToHCdCW4/9KvBTTNH4u3kFbg8e+/8Zn68VRF+ayuiPNqYAmg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2323,7 +2397,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/tiny-decoders/-/tiny-decoders-7.0.1.tgz",
       "integrity": "sha512-P1LaHTLASl/lCrdtwgAAVwxt4bEAPmxpf9HMQrlCkAseaT8oH8oxm8ndy4nx5rLTcL5U/Qxp1a+FDoQfS/ZgQQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2562,6 +2636,49 @@
           }
         }
       }
+    },
+    "@lydell/node-pty": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.0.3.tgz",
+      "integrity": "sha512-nLTNwJXEPi1oMyzxRwqsLB4jCmhDrltQS/kAYhV05qbPo5NOIKpw2tb+Iok/yhd9zP9+E5Lu7sWDGD+G4fdKbQ==",
+      "optional": true,
+      "requires": {
+        "@lydell/node-pty-darwin-arm64": "1.0.3",
+        "@lydell/node-pty-darwin-x64": "1.0.3",
+        "@lydell/node-pty-linux-x64": "1.0.3",
+        "@lydell/node-pty-win32-arm64": "1.0.3",
+        "@lydell/node-pty-win32-x64": "1.0.3"
+      }
+    },
+    "@lydell/node-pty-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-cpLatXzGHds9fU6KSA+5jB4CRKqqK1ITerYlbucyhfsE0uksMVpzD6Ti6jMeEq7YM0N+c61q6EURl/pIwNYSqA==",
+      "optional": true
+    },
+    "@lydell/node-pty-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-IuEf8TXwo+wzoUEhqv+LtznwW94gMm4V9XVFMisFh+oRz0TNtnWHtgTCdWCVn4Dm3dpEDAjiAlTLx0ayC5uMVA==",
+      "optional": true
+    },
+    "@lydell/node-pty-linux-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.0.3.tgz",
+      "integrity": "sha512-tfj6Zg9F5KkyCQQ2wCUXUW/1lcNgdWAVJNtt6gQH3X+fUueSrRl+R7xoWTcl5NGcfn2l7QWgUrjZcVKP3/ljTg==",
+      "optional": true
+    },
+    "@lydell/node-pty-win32-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.0.3.tgz",
+      "integrity": "sha512-5MTd7hbrvmO/de/B2MDhxjh3E109i5bSds6JtIcVR1M6+uCvWJrON5ibbvWIAqTHpFup20IyDv0cQJxVv9o9nA==",
+      "optional": true
+    },
+    "@lydell/node-pty-win32-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.0.3.tgz",
+      "integrity": "sha512-XMANgXpBYGtKa5q+czro+TaJAyv3njbT7R81Pky+p7e4GwNdWtSUNBxtQm+O4ZLV0VJ1rNiMEHMyGOq8T9i4FA==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3633,21 +3750,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "optional": true
-    },
-    "node-pty": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.10.1.tgz",
-      "integrity": "sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.14.0"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3867,13 +3969,21 @@
       }
     },
     "run-pty": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/run-pty/-/run-pty-4.0.3.tgz",
-      "integrity": "sha512-O8IWhjhChwLq7psyZZDY+Pv/CSEM7DLBXqUqEVWKMXGR18s2o2ma4IEanKWSSLBULNCpHn3n9RYvybc+7IaBig==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-pty/-/run-pty-5.0.0.tgz",
+      "integrity": "sha512-0gk83+2NmrZGGPlJ88lqt0dYHvgyau/JBdRz9OqEbNyIfmbiq9E5sGCsvHdjrLoUJVh09ZX9r5rN587ACoM3vQ==",
       "optional": true,
       "requires": {
-        "node-pty": "^0.10.1",
-        "tiny-decoders": "^7.0.1"
+        "@lydell/node-pty": "^1.0.0",
+        "tiny-decoders": "^23.0.0"
+      },
+      "dependencies": {
+        "tiny-decoders": {
+          "version": "23.0.0",
+          "resolved": "https://registry.npmjs.org/tiny-decoders/-/tiny-decoders-23.0.0.tgz",
+          "integrity": "sha512-gQB+za3EW9JN1ASDmrVl1a1I6Q/jzg4M75YLI9ToHCdCW4/9KvBTTNH4u3kFbg8e+/8Zn68VRF+ayuiPNqYAmg==",
+          "optional": true
+        }
       }
     },
     "safe-buffer": {
@@ -4046,7 +4156,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/tiny-decoders/-/tiny-decoders-7.0.1.tgz",
       "integrity": "sha512-P1LaHTLASl/lCrdtwgAAVwxt4bEAPmxpf9HMQrlCkAseaT8oH8oxm8ndy4nx5rLTcL5U/Qxp1a+FDoQfS/ZgQQ==",
-      "devOptional": true
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "sass": "1.43.3"
   },
   "optionalDependencies": {
-    "run-pty": "^4.0.3"
+    "run-pty": "^5.0.0"
   }
 }


### PR DESCRIPTION
Today, this doesn't work for me on Ubuntu 24.04.1 in WSL on Windows 11:

```console
$ npm ci --include=optional

$ npm start

[…]

sh: 1: run-pty: not found
```

We believe this explains why:

```console
$ npm remove run-pty
$ npm install run-pty@4.0.3
[…]
npm error gyp ERR! stack Error: not found: make
[…]
```

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>