### PR TITLE
Use `requestAnimationFrame`-based main loop

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -6,18 +6,19 @@ module App exposing
 import Game exposing (GameState)
 import Menu exposing (MenuState)
 import Random
+import Types.FrameTime exposing (LeftoverFrameTime)
 
 
 type AppState
     = InMenu MenuState Random.Seed
-    | InGame GameState
+    | InGame LeftoverFrameTime GameState
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState
 modifyGameState f appState =
     case appState of
-        InGame gameState ->
-            InGame <| f gameState
+        InGame leftoverFrameTime gameState ->
+            InGame leftoverFrameTime <| f gameState
 
         _ ->
             appState

--- a/src/App.elm
+++ b/src/App.elm
@@ -6,19 +6,18 @@ module App exposing
 import Game exposing (GameState)
 import Menu exposing (MenuState)
 import Random
-import Types.FrameTime exposing (LeftoverFrameTime)
 
 
 type AppState
     = InMenu MenuState Random.Seed
-    | InGame LeftoverFrameTime GameState
+    | InGame GameState
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState
 modifyGameState f appState =
     case appState of
-        InGame leftoverFrameTime gameState ->
-            InGame leftoverFrameTime <| f gameState
+        InGame gameState ->
+            InGame <| f gameState
 
         _ ->
             appState

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -31,7 +31,7 @@ import Thickness exposing (theThickness)
 import Turning exposing (computeAngleChange, computeTurningState, turningStateFromHistory)
 import Types.Angle as Angle exposing (Angle)
 import Types.Distance as Distance exposing (Distance(..))
-import Types.FrameTime exposing (WithLeftoverFrameTime(..))
+import Types.FrameTime exposing (LeftoverFrameTime)
 import Types.Kurve as Kurve exposing (Kurve, UserInteraction(..), modifyReversedInteractions)
 import Types.Speed as Speed
 import Types.Tick as Tick exposing (Tick)
@@ -52,7 +52,7 @@ type Paused
 
 type ActiveGameState
     = Spawning SpawnState MidRoundState
-    | Moving Tick (WithLeftoverFrameTime MidRoundState)
+    | Moving Tick ( LeftoverFrameTime, MidRoundState )
 
 
 type TickResult a
@@ -66,7 +66,7 @@ getCurrentRound gameState =
         Active _ (Spawning _ ( _, round )) ->
             round
 
-        Active _ (Moving _ (WithLeftoverFrameTime _ ( _, round ))) ->
+        Active _ (Moving _ ( _, ( _, round ) )) ->
             round
 
         RoundOver round _ ->
@@ -76,8 +76,8 @@ getCurrentRound gameState =
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState
 modifyMidRoundState f gameState =
     case gameState of
-        Active p (Moving t (WithLeftoverFrameTime leftoverFrameTime midRoundState)) ->
-            Active p <| Moving t <| WithLeftoverFrameTime leftoverFrameTime <| f midRoundState
+        Active p (Moving t ( leftoverFrameTime, midRoundState )) ->
+            Active p <| Moving t <| ( leftoverFrameTime, f midRoundState )
 
         Active p (Spawning s midRoundState) ->
             Active p <| Spawning s <| f midRoundState
@@ -190,7 +190,7 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
     )
 
 
-tickResultToGameState : TickResult (WithLeftoverFrameTime MidRoundState) -> GameState
+tickResultToGameState : TickResult ( LeftoverFrameTime, MidRoundState ) -> GameState
 tickResultToGameState tickResult =
     case tickResult of
         RoundKeepsGoing tick s ->

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -52,7 +52,7 @@ type Paused
 
 type ActiveGameState
     = Spawning SpawnState MidRoundState
-    | Moving Tick LeftoverFrameTime MidRoundState
+    | Moving LeftoverFrameTime Tick MidRoundState
 
 
 type TickResult a
@@ -194,7 +194,7 @@ tickResultToGameState : TickResult ( LeftoverFrameTime, Tick, MidRoundState ) ->
 tickResultToGameState tickResult =
     case tickResult of
         RoundKeepsGoing ( leftoverFrameTime, tick, midRoundState ) ->
-            Active NotPaused (Moving tick leftoverFrameTime midRoundState)
+            Active NotPaused (Moving leftoverFrameTime tick midRoundState)
 
         RoundEnds finishedRound ->
             RoundOver finishedRound Dialog.NotOpen

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -190,11 +190,11 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
     )
 
 
-tickResultToGameState : Tick -> TickResult ( LeftoverFrameTime, MidRoundState ) -> GameState
-tickResultToGameState tick tickResult =
+tickResultToGameState : TickResult ( Tick, LeftoverFrameTime, MidRoundState ) -> GameState
+tickResultToGameState tickResult =
     case tickResult of
-        RoundKeepsGoing s ->
-            Active NotPaused (Moving tick s)
+        RoundKeepsGoing ( tick, leftoverFrameTime, midRoundState ) ->
+            Active NotPaused (Moving tick ( leftoverFrameTime, midRoundState ))
 
         RoundEnds finishedRound ->
             RoundOver finishedRound Dialog.NotOpen

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -31,7 +31,7 @@ import Thickness exposing (theThickness)
 import Turning exposing (computeAngleChange, computeTurningState, turningStateFromHistory)
 import Types.Angle as Angle exposing (Angle)
 import Types.Distance as Distance exposing (Distance(..))
-import Types.FrameTime exposing (LeftoverFrameTime, WithLeftoverFrameTime(..))
+import Types.FrameTime exposing (WithLeftoverFrameTime(..))
 import Types.Kurve as Kurve exposing (Kurve, UserInteraction(..), modifyReversedInteractions)
 import Types.Speed as Speed
 import Types.Tick as Tick exposing (Tick)
@@ -55,8 +55,8 @@ type ActiveGameState
     | Moving Tick (WithLeftoverFrameTime MidRoundState)
 
 
-type TickResult
-    = RoundKeepsGoing Tick MidRoundState
+type TickResult a
+    = RoundKeepsGoing Tick a
     | RoundEnds Round
 
 
@@ -148,7 +148,7 @@ prepareRoundFromKnownInitialState initialState =
     round
 
 
-reactToTick : Config -> Tick -> MidRoundState -> ( TickResult, Cmd msg )
+reactToTick : Config -> Tick -> MidRoundState -> ( TickResult MidRoundState, Cmd msg )
 reactToTick config tick (( _, currentRound ) as midRoundState) =
     let
         ( newKurvesGenerator, newOccupiedPixels, newColoredDrawingPositions ) =
@@ -174,7 +174,7 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
             , seed = newSeed
             }
 
-        tickResult : TickResult
+        tickResult : TickResult MidRoundState
         tickResult =
             if roundIsOver newKurves then
                 RoundEnds newCurrentRound
@@ -190,11 +190,11 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
     )
 
 
-tickResultToGameState : LeftoverFrameTime -> TickResult -> GameState
-tickResultToGameState leftoverFrameTime tickResult =
+tickResultToGameState : TickResult (WithLeftoverFrameTime MidRoundState) -> GameState
+tickResultToGameState tickResult =
     case tickResult of
         RoundKeepsGoing tick s ->
-            Active NotPaused (Moving tick (WithLeftoverFrameTime leftoverFrameTime s))
+            Active NotPaused (Moving tick s)
 
         RoundEnds finishedRound ->
             RoundOver finishedRound Dialog.NotOpen

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -190,10 +190,10 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
     )
 
 
-tickResultToGameState : TickResult ( Tick, LeftoverFrameTime, MidRoundState ) -> GameState
+tickResultToGameState : TickResult ( LeftoverFrameTime, Tick, MidRoundState ) -> GameState
 tickResultToGameState tickResult =
     case tickResult of
-        RoundKeepsGoing ( tick, leftoverFrameTime, midRoundState ) ->
+        RoundKeepsGoing ( leftoverFrameTime, tick, midRoundState ) ->
             Active NotPaused (Moving tick ( leftoverFrameTime, midRoundState ))
 
         RoundEnds finishedRound ->

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -52,7 +52,7 @@ type Paused
 
 type ActiveGameState
     = Spawning SpawnState MidRoundState
-    | Moving Tick ( LeftoverFrameTime, MidRoundState )
+    | Moving Tick LeftoverFrameTime MidRoundState
 
 
 type TickResult a
@@ -66,7 +66,7 @@ getCurrentRound gameState =
         Active _ (Spawning _ ( _, round )) ->
             round
 
-        Active _ (Moving _ ( _, ( _, round ) )) ->
+        Active _ (Moving _ _ ( _, round )) ->
             round
 
         RoundOver round _ ->
@@ -76,8 +76,8 @@ getCurrentRound gameState =
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState
 modifyMidRoundState f gameState =
     case gameState of
-        Active p (Moving t ( leftoverFrameTime, midRoundState )) ->
-            Active p <| Moving t <| ( leftoverFrameTime, f midRoundState )
+        Active p (Moving t leftoverFrameTime midRoundState) ->
+            Active p <| Moving t leftoverFrameTime <| f midRoundState
 
         Active p (Spawning s midRoundState) ->
             Active p <| Spawning s <| f midRoundState
@@ -194,7 +194,7 @@ tickResultToGameState : TickResult ( LeftoverFrameTime, Tick, MidRoundState ) ->
 tickResultToGameState tickResult =
     case tickResult of
         RoundKeepsGoing ( leftoverFrameTime, tick, midRoundState ) ->
-            Active NotPaused (Moving tick ( leftoverFrameTime, midRoundState ))
+            Active NotPaused (Moving tick leftoverFrameTime midRoundState)
 
         RoundEnds finishedRound ->
             RoundOver finishedRound Dialog.NotOpen

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -127,7 +127,7 @@ update msg ({ config, pressedButtons } as model) =
                             Spawning newSpawnState plannedMidRoundState
 
                         Nothing ->
-                            Moving Tick.genesis ( MainLoop.noLeftoverFrameTime, plannedMidRoundState )
+                            Moving Tick.genesis MainLoop.noLeftoverFrameTime plannedMidRoundState
             in
             ( { model | appState = InGame <| Active NotPaused activeGameState }
             , cmd
@@ -306,7 +306,7 @@ handleUserInteraction direction button model =
                 InGame (Active _ (Spawning _ ( Live, _ ))) ->
                     recordInteractionBefore firstUpdateTick
 
-                InGame (Active _ (Moving lastTick ( _, ( Live, _ ) ))) ->
+                InGame (Active _ (Moving lastTick _ ( Live, _ ))) ->
                     recordInteractionBefore (Tick.succ lastTick)
 
                 _ ->
@@ -335,7 +335,7 @@ subscriptions model =
             InGame (Active NotPaused (Spawning spawnState plannedMidRoundState)) ->
                 Time.every (1000 / model.config.spawn.flickerTicksPerSecond) (always <| SpawnTick spawnState plannedMidRoundState)
 
-            InGame (Active NotPaused (Moving lastTick ( leftoverTimeFromPreviousFrame, midRoundState ))) ->
+            InGame (Active NotPaused (Moving lastTick leftoverTimeFromPreviousFrame midRoundState)) ->
                 Browser.Events.onAnimationFrameDelta
                     (\delta ->
                         AnimationFrame

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -136,7 +136,7 @@ update msg ({ config, pressedButtons } as model) =
         AnimationFrame { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
                 ( tickResult, cmd ) =
-                    MainLoop.consumeFrameTime config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState )
+                    MainLoop.consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState )
             in
             ( { model | appState = InGame (tickResultToGameState tickResult) }
             , cmd

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -127,7 +127,7 @@ update msg ({ config, pressedButtons } as model) =
                             Spawning newSpawnState plannedMidRoundState
 
                         Nothing ->
-                            Moving Tick.genesis MainLoop.noLeftoverFrameTime plannedMidRoundState
+                            Moving MainLoop.noLeftoverFrameTime Tick.genesis plannedMidRoundState
             in
             ( { model | appState = InGame <| Active NotPaused activeGameState }
             , cmd
@@ -306,7 +306,7 @@ handleUserInteraction direction button model =
                 InGame (Active _ (Spawning _ ( Live, _ ))) ->
                     recordInteractionBefore firstUpdateTick
 
-                InGame (Active _ (Moving lastTick _ ( Live, _ ))) ->
+                InGame (Active _ (Moving _ lastTick ( Live, _ ))) ->
                     recordInteractionBefore (Tick.succ lastTick)
 
                 _ ->
@@ -335,7 +335,7 @@ subscriptions model =
             InGame (Active NotPaused (Spawning spawnState plannedMidRoundState)) ->
                 Time.every (1000 / model.config.spawn.flickerTicksPerSecond) (always <| SpawnTick spawnState plannedMidRoundState)
 
-            InGame (Active NotPaused (Moving lastTick leftoverTimeFromPreviousFrame midRoundState)) ->
+            InGame (Active NotPaused (Moving leftoverTimeFromPreviousFrame lastTick midRoundState)) ->
                 Browser.Events.onAnimationFrameDelta
                     (\delta ->
                         AnimationFrame

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -135,10 +135,10 @@ update msg ({ config, pressedButtons } as model) =
 
         AnimationFrame { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
-                ( WithLeftoverFrameTime newLeftoverFrameTime tickResult, cmd ) =
+                ( tickResult, cmd ) =
                     MainLoop.consumeFrameTime config delta lastTick (WithLeftoverFrameTime leftoverTimeFromPreviousFrame midRoundState)
             in
-            ( { model | appState = InGame (tickResultToGameState newLeftoverFrameTime tickResult) }
+            ( { model | appState = InGame (tickResultToGameState tickResult) }
             , cmd
             )
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -55,8 +55,13 @@ startRound model midRoundState =
     let
         ( gameState, cmd ) =
             newRoundGameStateAndCmd model.config midRoundState
+
+        leftoverFrameTime : LeftoverFrameTime
+        leftoverFrameTime =
+            -- The leftover time here shouldn't matter, because it should be set to 0 when the Kurves start moving anyway.
+            MainLoop.noLeftoverTime
     in
-    ( { model | appState = InGame MainLoop.noLeftoverTime gameState }, cmd )
+    ( { model | appState = InGame leftoverFrameTime gameState }, cmd )
 
 
 newRoundGameStateAndCmd : Config -> MidRoundState -> ( GameState, Cmd msg )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -127,7 +127,7 @@ update msg ({ config, pressedButtons } as model) =
                             Spawning newSpawnState plannedMidRoundState
 
                         Nothing ->
-                            Moving Tick.genesis ( MainLoop.noLeftoverTime, plannedMidRoundState )
+                            Moving Tick.genesis ( MainLoop.noLeftoverFrameTime, plannedMidRoundState )
             in
             ( { model | appState = InGame <| Active NotPaused activeGameState }
             , cmd

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -136,7 +136,7 @@ update msg ({ config, pressedButtons } as model) =
         AnimationFrame { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
                 ( tickResult, cmd ) =
-                    MainLoop.consumeAnimationFrame config delta lastTick leftoverTimeFromPreviousFrame midRoundState
+                    MainLoop.consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState
             in
             ( { model | appState = InGame (tickResultToGameState tickResult) }
             , cmd

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -136,7 +136,7 @@ update msg ({ config, pressedButtons } as model) =
         AnimationFrame { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
                 ( tickResult, cmd ) =
-                    MainLoop.consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState )
+                    MainLoop.consumeAnimationFrame config delta lastTick leftoverTimeFromPreviousFrame midRoundState
             in
             ( { model | appState = InGame (tickResultToGameState tickResult) }
             , cmd

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -135,14 +135,10 @@ update msg ({ config, pressedButtons } as model) =
 
         AnimationFrame { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
-                tick : Tick
-                tick =
-                    Tick.succ lastTick
-
                 ( tickResult, cmd ) =
                     MainLoop.consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState )
             in
-            ( { model | appState = InGame (tickResultToGameState tick tickResult) }
+            ( { model | appState = InGame (tickResultToGameState tickResult) }
             , cmd
             )
 

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -33,10 +33,11 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
 
         recurse :
             Tick
-            -> ( LeftoverFrameTime, MidRoundState )
+            -> LeftoverFrameTime
+            -> MidRoundState
             -> Cmd msg
             -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
-        recurse lastTickReactedTo ( timeLeftToConsume, midRoundStateSoFar ) cmdSoFar =
+        recurse lastTickReactedTo timeLeftToConsume midRoundStateSoFar cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
                     incrementedTick : Tick
@@ -52,7 +53,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->
-                        recurse incrementedTick ( timeLeftToConsume - timestep, newMidRoundState ) newCmd
+                        recurse incrementedTick (timeLeftToConsume - timestep) newMidRoundState newCmd
 
                     RoundEnds finishedRound ->
                         ( RoundEnds finishedRound
@@ -64,7 +65,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                 , cmdSoFar
                 )
     in
-    recurse lastTick ( timeToConsume, midRoundState ) Cmd.none
+    recurse lastTick timeToConsume midRoundState Cmd.none
 
 
 noLeftoverFrameTime : LeftoverFrameTime

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -32,12 +32,12 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
             1000 / Tickrate.toFloat config.kurves.tickrate
 
         recurse :
-            Tick
-            -> LeftoverFrameTime
+            LeftoverFrameTime
+            -> Tick
             -> MidRoundState
             -> Cmd msg
             -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
-        recurse lastTickReactedTo timeLeftToConsume midRoundStateSoFar cmdSoFar =
+        recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
                     incrementedTick : Tick
@@ -53,7 +53,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->
-                        recurse incrementedTick (timeLeftToConsume - timestep) newMidRoundState newCmd
+                        recurse (timeLeftToConsume - timestep) incrementedTick newMidRoundState newCmd
 
                     RoundEnds finishedRound ->
                         ( RoundEnds finishedRound
@@ -65,7 +65,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                 , cmdSoFar
                 )
     in
-    recurse lastTick timeToConsume midRoundState Cmd.none
+    recurse timeToConsume lastTick midRoundState Cmd.none
 
 
 noLeftoverFrameTime : LeftoverFrameTime

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -22,8 +22,12 @@ consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundSta
         recurse timeLeftToConsume someTick midRoundStateSoFar cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
+                    nextTick : Tick
+                    nextTick =
+                        Tick.succ someTick
+
                     ( tickResult, cmdForThisTick ) =
-                        Game.reactToTick config someTick midRoundStateSoFar
+                        Game.reactToTick config nextTick midRoundStateSoFar
 
                     newCmd : Cmd msg
                     newCmd =
@@ -31,7 +35,7 @@ consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundSta
                 in
                 case tickResult of
                     RoundKeepsGoing _ newMidRoundState ->
-                        recurse (timeLeftToConsume - timestep) (Tick.succ someTick) newMidRoundState newCmd
+                        recurse (timeLeftToConsume - timestep) nextTick newMidRoundState newCmd
 
                     RoundEnds finishedRound ->
                         ( 0, RoundEnds finishedRound, newCmd )

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -19,15 +19,15 @@ consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundSta
             1000 / Tickrate.toFloat config.kurves.tickrate
 
         recurse : FrameTime -> Tick -> MidRoundState -> Cmd msg -> ( LeftoverFrameTime, TickResult, Cmd msg )
-        recurse timeLeftToConsume someTick midRoundStateSoFar cmdSoFar =
+        recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
-                    nextTick : Tick
-                    nextTick =
-                        Tick.succ someTick
+                    incrementedTick : Tick
+                    incrementedTick =
+                        Tick.succ lastTickReactedTo
 
                     ( tickResult, cmdForThisTick ) =
-                        Game.reactToTick config nextTick midRoundStateSoFar
+                        Game.reactToTick config incrementedTick midRoundStateSoFar
 
                     newCmd : Cmd msg
                     newCmd =
@@ -35,14 +35,14 @@ consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundSta
                 in
                 case tickResult of
                     RoundKeepsGoing _ newMidRoundState ->
-                        recurse (timeLeftToConsume - timestep) nextTick newMidRoundState newCmd
+                        recurse (timeLeftToConsume - timestep) incrementedTick newMidRoundState newCmd
 
                     RoundEnds finishedRound ->
                         ( 0, RoundEnds finishedRound, newCmd )
 
             else
                 ( timeLeftToConsume
-                , RoundKeepsGoing someTick midRoundStateSoFar
+                , RoundKeepsGoing lastTickReactedTo midRoundStateSoFar
                 , cmdSoFar
                 )
     in

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -14,7 +14,7 @@ import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 
 
-consumeAnimationFrame : Config -> FrameTime -> Tick -> ( LeftoverFrameTime, MidRoundState ) -> ( TickResult ( LeftoverFrameTime, MidRoundState ), Cmd msg )
+consumeAnimationFrame : Config -> FrameTime -> Tick -> ( LeftoverFrameTime, MidRoundState ) -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
 consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState ) =
     let
         timeToConsume : FrameTime
@@ -25,7 +25,7 @@ consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, mid
         timestep =
             1000 / Tickrate.toFloat config.kurves.tickrate
 
-        recurse : Tick -> ( LeftoverFrameTime, MidRoundState ) -> Cmd msg -> ( TickResult ( LeftoverFrameTime, MidRoundState ), Cmd msg )
+        recurse : Tick -> ( LeftoverFrameTime, MidRoundState ) -> Cmd msg -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
         recurse lastTickReactedTo ( timeLeftToConsume, midRoundStateSoFar ) cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
@@ -50,7 +50,7 @@ consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, mid
                         )
 
             else
-                ( RoundKeepsGoing ( timeLeftToConsume, midRoundStateSoFar )
+                ( RoundKeepsGoing ( lastTickReactedTo, timeLeftToConsume, midRoundStateSoFar )
                 , cmdSoFar
                 )
     in

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -7,7 +7,7 @@ import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 
 
-consumeFrameTime : Config -> FrameTime -> Tick -> WithLeftoverFrameTime MidRoundState -> ( WithLeftoverFrameTime TickResult, Cmd msg )
+consumeFrameTime : Config -> FrameTime -> Tick -> WithLeftoverFrameTime MidRoundState -> ( TickResult (WithLeftoverFrameTime MidRoundState), Cmd msg )
 consumeFrameTime config delta lastTick (WithLeftoverFrameTime leftoverTimeFromPreviousFrame midRoundState) =
     let
         timeToConsume : FrameTime
@@ -18,7 +18,7 @@ consumeFrameTime config delta lastTick (WithLeftoverFrameTime leftoverTimeFromPr
         timestep =
             1000 / Tickrate.toFloat config.kurves.tickrate
 
-        recurse : Tick -> WithLeftoverFrameTime MidRoundState -> Cmd msg -> ( WithLeftoverFrameTime TickResult, Cmd msg )
+        recurse : Tick -> WithLeftoverFrameTime MidRoundState -> Cmd msg -> ( TickResult (WithLeftoverFrameTime MidRoundState), Cmd msg )
         recurse lastTickReactedTo (WithLeftoverFrameTime timeLeftToConsume midRoundStateSoFar) cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
@@ -38,13 +38,12 @@ consumeFrameTime config delta lastTick (WithLeftoverFrameTime leftoverTimeFromPr
                         recurse incrementedTick (WithLeftoverFrameTime (timeLeftToConsume - timestep) newMidRoundState) newCmd
 
                     RoundEnds finishedRound ->
-                        ( -- The leftover time here shouldn't matter, because it should be set to 0 at the start of every round anyway.
-                          WithLeftoverFrameTime noLeftoverTime <| RoundEnds finishedRound
+                        ( RoundEnds finishedRound
                         , newCmd
                         )
 
             else
-                ( WithLeftoverFrameTime timeLeftToConsume <| RoundKeepsGoing lastTickReactedTo midRoundStateSoFar
+                ( RoundKeepsGoing lastTickReactedTo (WithLeftoverFrameTime timeLeftToConsume midRoundStateSoFar)
                 , cmdSoFar
                 )
     in

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -1,5 +1,12 @@
 module MainLoop exposing (consumeAnimationFrame, noLeftoverTime)
 
+{-| Based on Isaac Sukin's `MainLoop.js`.
+
+  - <https://github.com/IceCreamYou/MainLoop.js/tree/247e7c41fe4bfa7e15ff4cc524d56056feffd306>
+  - <http://www.isaacsukin.com/news/2015/01/detailed-explanation-javascript-game-loops-and-timing>
+
+-}
+
 import Config exposing (Config)
 import Game exposing (MidRoundState, TickResult(..))
 import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -1,0 +1,50 @@
+module MainLoop exposing (consumeFrameTime, noLeftoverTime)
+
+import Config exposing (Config)
+import Game exposing (MidRoundState, TickResult(..))
+import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
+import Types.Tick as Tick exposing (Tick)
+import Types.Tickrate as Tickrate
+
+
+consumeFrameTime : Config -> FrameTime -> LeftoverFrameTime -> Tick -> MidRoundState -> ( LeftoverFrameTime, TickResult, Cmd msg )
+consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundState =
+    let
+        timeToConsume : FrameTime
+        timeToConsume =
+            delta + leftoverTimeFromPreviousFrame
+
+        timestep : FrameTime
+        timestep =
+            1000 / Tickrate.toFloat config.kurves.tickrate
+
+        recurse : FrameTime -> Tick -> MidRoundState -> Cmd msg -> ( LeftoverFrameTime, TickResult, Cmd msg )
+        recurse timeLeftToConsume someTick midRoundStateSoFar cmdSoFar =
+            if timeLeftToConsume >= timestep then
+                let
+                    ( tickResult, cmdForThisTick ) =
+                        Game.reactToTick config someTick midRoundStateSoFar
+
+                    newCmd : Cmd msg
+                    newCmd =
+                        Cmd.batch [ cmdSoFar, cmdForThisTick ]
+                in
+                case tickResult of
+                    RoundKeepsGoing _ newMidRoundState ->
+                        recurse (timeLeftToConsume - timestep) (Tick.succ someTick) newMidRoundState newCmd
+
+                    RoundEnds finishedRound ->
+                        ( 0, RoundEnds finishedRound, newCmd )
+
+            else
+                ( timeLeftToConsume
+                , RoundKeepsGoing someTick midRoundStateSoFar
+                , cmdSoFar
+                )
+    in
+    recurse timeToConsume lastTick midRoundState Cmd.none
+
+
+noLeftoverTime : LeftoverFrameTime
+noLeftoverTime =
+    0

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -38,7 +38,11 @@ consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundSta
                         recurse (timeLeftToConsume - timestep) incrementedTick newMidRoundState newCmd
 
                     RoundEnds finishedRound ->
-                        ( noLeftoverTime, RoundEnds finishedRound, newCmd )
+                        ( -- The leftover time here shouldn't matter, because it should be set to 0 at the start of every round anyway.
+                          noLeftoverTime
+                        , RoundEnds finishedRound
+                        , newCmd
+                        )
 
             else
                 ( timeLeftToConsume

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -1,4 +1,4 @@
-module MainLoop exposing (consumeAnimationFrame, noLeftoverTime)
+module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
 
 {-| Based on Isaac Sukin's `MainLoop.js`.
 
@@ -57,6 +57,6 @@ consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, mid
     recurse lastTick ( timeToConsume, midRoundState ) Cmd.none
 
 
-noLeftoverTime : LeftoverFrameTime
-noLeftoverTime =
+noLeftoverFrameTime : LeftoverFrameTime
+noLeftoverFrameTime =
     0

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -38,7 +38,7 @@ consumeFrameTime config delta leftoverTimeFromPreviousFrame lastTick midRoundSta
                         recurse (timeLeftToConsume - timestep) incrementedTick newMidRoundState newCmd
 
                     RoundEnds finishedRound ->
-                        ( 0, RoundEnds finishedRound, newCmd )
+                        ( noLeftoverTime, RoundEnds finishedRound, newCmd )
 
             else
                 ( timeLeftToConsume

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -31,7 +31,11 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
         timestep =
             1000 / Tickrate.toFloat config.kurves.tickrate
 
-        recurse : Tick -> ( LeftoverFrameTime, MidRoundState ) -> Cmd msg -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
+        recurse :
+            Tick
+            -> ( LeftoverFrameTime, MidRoundState )
+            -> Cmd msg
+            -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
         recurse lastTickReactedTo ( timeLeftToConsume, midRoundStateSoFar ) cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -17,11 +17,11 @@ import Types.Tickrate as Tickrate
 consumeAnimationFrame :
     Config
     -> FrameTime
-    -> Tick
     -> LeftoverFrameTime
+    -> Tick
     -> MidRoundState
     -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
-consumeAnimationFrame config delta lastTick leftoverTimeFromPreviousFrame midRoundState =
+consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState =
     let
         timeToConsume : FrameTime
         timeToConsume =

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -14,7 +14,12 @@ import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 
 
-consumeAnimationFrame : Config -> FrameTime -> Tick -> ( LeftoverFrameTime, MidRoundState ) -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
+consumeAnimationFrame :
+    Config
+    -> FrameTime
+    -> Tick
+    -> ( LeftoverFrameTime, MidRoundState )
+    -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
 consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState ) =
     let
         timeToConsume : FrameTime

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -20,7 +20,7 @@ consumeAnimationFrame :
     -> LeftoverFrameTime
     -> Tick
     -> MidRoundState
-    -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
+    -> ( TickResult ( LeftoverFrameTime, Tick, MidRoundState ), Cmd msg )
 consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState =
     let
         timeToConsume : FrameTime
@@ -36,7 +36,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
             -> Tick
             -> MidRoundState
             -> Cmd msg
-            -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
+            -> ( TickResult ( LeftoverFrameTime, Tick, MidRoundState ), Cmd msg )
         recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar cmdSoFar =
             if timeLeftToConsume >= timestep then
                 let
@@ -61,7 +61,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                         )
 
             else
-                ( RoundKeepsGoing ( lastTickReactedTo, timeLeftToConsume, midRoundStateSoFar )
+                ( RoundKeepsGoing ( timeLeftToConsume, lastTickReactedTo, midRoundStateSoFar )
                 , cmdSoFar
                 )
     in

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -18,9 +18,10 @@ consumeAnimationFrame :
     Config
     -> FrameTime
     -> Tick
-    -> ( LeftoverFrameTime, MidRoundState )
+    -> LeftoverFrameTime
+    -> MidRoundState
     -> ( TickResult ( Tick, LeftoverFrameTime, MidRoundState ), Cmd msg )
-consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState ) =
+consumeAnimationFrame config delta lastTick leftoverTimeFromPreviousFrame midRoundState =
     let
         timeToConsume : FrameTime
         timeToConsume =

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -1,4 +1,4 @@
-module MainLoop exposing (consumeFrameTime, noLeftoverTime)
+module MainLoop exposing (consumeAnimationFrame, noLeftoverTime)
 
 import Config exposing (Config)
 import Game exposing (MidRoundState, TickResult(..))
@@ -7,8 +7,8 @@ import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 
 
-consumeFrameTime : Config -> FrameTime -> Tick -> ( LeftoverFrameTime, MidRoundState ) -> ( TickResult ( LeftoverFrameTime, MidRoundState ), Cmd msg )
-consumeFrameTime config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState ) =
+consumeAnimationFrame : Config -> FrameTime -> Tick -> ( LeftoverFrameTime, MidRoundState ) -> ( TickResult ( LeftoverFrameTime, MidRoundState ), Cmd msg )
+consumeAnimationFrame config delta lastTick ( leftoverTimeFromPreviousFrame, midRoundState ) =
     let
         timeToConsume : FrameTime
         timeToConsume =

--- a/src/Types/FrameTime.elm
+++ b/src/Types/FrameTime.elm
@@ -1,0 +1,9 @@
+module Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
+
+
+type alias FrameTime =
+    Float
+
+
+type alias LeftoverFrameTime =
+    FrameTime

--- a/src/Types/FrameTime.elm
+++ b/src/Types/FrameTime.elm
@@ -1,4 +1,4 @@
-module Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
+module Types.FrameTime exposing (FrameTime, LeftoverFrameTime, WithLeftoverFrameTime(..))
 
 
 type alias FrameTime =
@@ -7,3 +7,7 @@ type alias FrameTime =
 
 type alias LeftoverFrameTime =
     FrameTime
+
+
+type WithLeftoverFrameTime a
+    = WithLeftoverFrameTime LeftoverFrameTime a

--- a/src/Types/FrameTime.elm
+++ b/src/Types/FrameTime.elm
@@ -1,4 +1,4 @@
-module Types.FrameTime exposing (FrameTime, LeftoverFrameTime, WithLeftoverFrameTime(..))
+module Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
 
 
 type alias FrameTime =
@@ -7,7 +7,3 @@ type alias FrameTime =
 
 type alias LeftoverFrameTime =
     FrameTime
-
-
-type WithLeftoverFrameTime a
-    = WithLeftoverFrameTime LeftoverFrameTime a

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -43,7 +43,7 @@ playOutRound config initialState =
         recurse : Tick -> MidRoundState -> ( Tick, Round )
         recurse tick midRoundState =
             let
-                tickResult : TickResult
+                tickResult : TickResult MidRoundState
                 tickResult =
                     reactToTick config (Tick.succ tick) midRoundState |> Tuple.first
             in


### PR DESCRIPTION
Today, we simulate real time with `Time.every` (so presumably `setInterval` under the hood). Its [docs] are crystal clear though:

> **This function is not for animation.** Use the [`onAnimationFrame`][af] function for that sort of thing! It syncs up with repaints and will end up being much smoother for any moving visuals.
>
> [af]: https://package.elm-lang.org/packages/elm/browser/latest/Browser-Events#onAnimationFrame

So using `onAnimationFrame` (based on `requestAnimationFrame`) is exactly what we do in this PR, except we use `onAnimationFrameDelta` for convenience. The implementation is based on @IceCreamYou's [`MainLoop.js`][MainLoop], which was used in the legacy JavaScript version of this game, and whose inner workings are described in detail in [this excellent blog post].

And yes: the game does indeed run much more smoothly, at least on a 60 Hz monitor. However, the smoothness seems _worse_ at 120 Hz, at least when not running the browser in fullscreen. This seems to be the case in both Chrome and Firefox on my main PC with Windows, but it's very inconsistent and hard to reproduce reliably. I have also observed severe stuttering on my laptop with a 60 Hz screen and Ubuntu 20.04. I really don't know …

For reference: the `AroundTheWorld` test case is great for testing animation smoothness.

## About the diff

The "starting point" of the changeset is that the `Time.every` subscription is replaced by a `Browser.Events.onAnimationFrameDelta` one. The corresponding message variant is renamed from `GameTick` to `AnimationFrame` and augmented to hold the frame delta of the current frame and any leftover time from the previous frame.

The next step is that the application of `Game.reactToTick` is moved from `update` into the new `MainLoop.consumeAnimationFrame` function.

All other changes are made in response to the changes above. In particular:

  * `ActiveGameState` is modified so that the `Moving` variant can hold any leftover frame time that needs to be accounted for in the next animation frame.
  * `TickResult` is modified so that the `RoundKeepsGoing` variant can hold any type of information, because then the `RoundKeepsGoing`/`RoundEnds` structure can be used both when we have a `LeftoverFrameTime` and a `Tick`, and when we don't.
  * `tickResultToGameState` is modified not to take a `Tick` anymore, instead taking a `TickResult ( LeftoverFrameTime, Tick, MidRoundState )`, because such a value is readily available at the call site.

[docs]: https://github.com/elm/time/blob/dc3b75b7366e59b99962706f7bf064d3634a4bba/src/Time.elm#L414C1-L416C44
[MainLoop]: https://github.com/IceCreamYou/MainLoop.js/tree/247e7c41fe4bfa7e15ff4cc524d56056feffd306
[this excellent blog post]: http://www.isaacsukin.com/news/2015/01/detailed-explanation-javascript-game-loops-and-timing

💡 `git show --color-words=' -> |Game\.reactToTick|Time\.every .+always <|\w+|.`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>