### PR TITLE
Simplify `SpawnTick` case in `update`

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -109,8 +109,13 @@ update msg ({ config, pressedButtons } as model) =
                     ( model, Cmd.none )
 
         SpawnTick spawnState plannedMidRoundState ->
-            stepSpawnState config spawnState
-                |> Tuple.mapFirst (\makeActiveGameState -> { model | appState = InGame <| Active NotPaused <| makeActiveGameState plannedMidRoundState })
+            let
+                ( makeActiveGameState, cmd ) =
+                    stepSpawnState config spawnState
+            in
+            ( { model | appState = InGame <| Active NotPaused <| makeActiveGameState plannedMidRoundState }
+            , cmd
+            )
 
         GameTick { lastTick } midRoundState ->
             let


### PR DESCRIPTION
I find the code in the `SpawnTick` case quite difficult to understand every time I'm working with it. This PR replaces the use of `Tuple.mapFirst` with a `let` expression, making it slightly easier to understand. The weird `makeActiveGameState` function will be dealt with in an upcoming PR.

💡 `git show --color-words=.`