### PR TITLE
Add getCurrentRound function in Game module

### DIFF
--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -2,7 +2,7 @@ module GUI.Scoreboard exposing (scoreboard)
 
 import Dict
 import GUI.Digits
-import Game exposing (ActiveGameState(..), GameState(..))
+import Game exposing (GameState)
 import Html exposing (Html, div)
 import Html.Attributes as Attr
 import Players exposing (AllPlayers, includeResultsFrom, participating)
@@ -18,16 +18,7 @@ scoreboard gameState players =
         [ Attr.id "scoreboard"
         , Attr.class "canvasHeight"
         ]
-        (case gameState of
-            Active _ (Spawning _ ( _, round )) ->
-                content players round
-
-            Active _ (Moving _ ( _, round )) ->
-                content players round
-
-            RoundOver round _ ->
-                content players round
-        )
+        (content players (Game.getCurrentRound gameState))
 
 
 content : AllPlayers -> Round -> List (Html msg)

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -7,6 +7,7 @@ module Game exposing
     , SpawnState
     , TickResult(..)
     , firstUpdateTick
+    , getCurrentRound
     , modifyMidRoundState
     , modifyRound
     , prepareLiveRound
@@ -56,6 +57,19 @@ type ActiveGameState
 type TickResult
     = RoundKeepsGoing Tick MidRoundState
     | RoundEnds Round
+
+
+getCurrentRound : GameState -> Round
+getCurrentRound gameState =
+    case gameState of
+        Active _ (Spawning _ ( _, round )) ->
+            round
+
+        Active _ (Moving _ ( _, round )) ->
+            round
+
+        RoundOver round _ ->
+            round
 
 
 modifyMidRoundState : (MidRoundState -> MidRoundState) -> GameState -> GameState


### PR DESCRIPTION
The `Scoreboard` module shouldn't need to know so much about the internals of the `GameState` type – it only needs the current round.

💡 `git show --color-words='\(content players .+|\w+|.'`