### PR TITLE
Don't store tick in TickResult

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -55,7 +55,7 @@ type ActiveGameState
 
 
 type TickResult
-    = RoundKeepsGoing Tick MidRoundState
+    = RoundKeepsGoing MidRoundState
     | RoundEnds Round
 
 
@@ -179,7 +179,7 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
                 RoundEnds newCurrentRound
 
             else
-                RoundKeepsGoing tick <| modifyRound (always newCurrentRound) midRoundState
+                RoundKeepsGoing <| modifyRound (always newCurrentRound) midRoundState
     in
     ( tickResult
     , [ headDrawingCmd newKurves.alive
@@ -189,10 +189,10 @@ reactToTick config tick (( _, currentRound ) as midRoundState) =
     )
 
 
-tickResultToGameState : TickResult -> GameState
-tickResultToGameState tickResult =
+tickResultToGameState : Tick -> TickResult -> GameState
+tickResultToGameState tick tickResult =
     case tickResult of
-        RoundKeepsGoing tick s ->
+        RoundKeepsGoing s ->
             Active NotPaused (Moving tick s)
 
         RoundEnds finishedRound ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -128,10 +128,14 @@ update msg ({ config, pressedButtons } as model) =
 
         GameTick { lastTick } midRoundState ->
             let
+                tick : Tick
+                tick =
+                    Tick.succ lastTick
+
                 ( tickResult, cmd ) =
-                    Game.reactToTick config (Tick.succ lastTick) midRoundState
+                    Game.reactToTick config tick midRoundState
             in
-            ( { model | appState = InGame (tickResultToGameState tickResult) }
+            ( { model | appState = InGame (tickResultToGameState tick tickResult) }
             , cmd
             )
 

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -43,12 +43,16 @@ playOutRound config initialState =
         recurse : Tick -> MidRoundState -> ( Tick, Round )
         recurse tick midRoundState =
             let
+                nextTick : Tick
+                nextTick =
+                    Tick.succ tick
+
                 tickResult : TickResult
                 tickResult =
-                    reactToTick config (Tick.succ tick) midRoundState |> Tuple.first
+                    reactToTick config nextTick midRoundState |> Tuple.first
             in
             case tickResult of
-                RoundKeepsGoing nextTick nextMidRoundState ->
+                RoundKeepsGoing nextMidRoundState ->
                     recurse nextTick nextMidRoundState
 
                 RoundEnds actualRoundResult ->


### PR DESCRIPTION
It's a bit confusing that `reactToTick` takes a `Tick` and returns a `TickResult` containing _the same_ `Tick`. This PR should make it more obvious that `reactToTick` doesn't compute the next tick.

💡 `git show --color-words='\w+|.'`