### PR TITLE
Use Node 24 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.0-alpine3.16
+FROM node:24.10.0-alpine3.22
 
 WORKDIR /app
 


### PR DESCRIPTION
For the record, the Dockerfile is implicitly used in CI; see `.github/workflows/validation.yaml`.