### PR TITLE
Remove legacy 'deploy' npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "check-formatting": "elm-format --validate src/",
     "review": "elm-review",
     "test": "elm-test",
-    "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/",
-    "deploy": "git checkout master && git merge --no-ff -m \"Merge branch 'develop'\" develop && npm run build && git add -f js css && git commit -m \"Deploy\""
+    "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=. % sass --watch --source-map src/css/:css/"
   },
   "author": "Simon Alling",
   "devDependencies": {


### PR DESCRIPTION
I used it to deploy the legacy JavaScript version that was "officially" replaced by the Elm version in 42a9090c20b6c6b1ac7c5adbf7494e4d6ffb682d. It hasn't been used, and wouldn't work, since then.

💡 `git show --color-words=.`