### PR TITLE
Build SASS in 'build' npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "elm-tooling install",
     "install-hooks": "[ -d .git/ ] && cp hooks/* .git/hooks",
     "sass-build": "sass --source-map src/css/:css/",
-    "build": "elm-watch make --optimize",
+    "build": "elm-watch make --optimize && npm run sass-build",
     "check-formatting": "elm-format --validate src/",
     "review": "elm-review",
     "test": "elm-test",


### PR DESCRIPTION
I think of the `build` script as "building for production", so it doesn't make any sense for it not to build everything.

💡 `git show --color-words=.`