### PR TITLE
Deploy Elm version (alongside legacy JavaScript)

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
+        with:
+          path: elm-version/
 
       - name: Setup Node
         uses: actions/setup-node@v5.0.0
@@ -31,6 +33,45 @@ jobs:
           package-manager-cache: false # I don't know if this is needed, but: https://github.com/actions/setup-node/blob/13427813f706a0f6c9b74603b31103c40ab1c35a/README.md?plain=1#L18
 
       - name: Build
+        working-directory: elm-version/
         run: |
           npm ci --omit optional
           npm run build
+
+      - name: Checkout legacy JavaScript version
+        uses: actions/checkout@v5.0.0
+        with:
+          path: legacy-javascript-version/
+          ref: master
+          sparse-checkout: |
+            /index.html
+            /ZATACKA.html
+            /favicon.ico
+            /manifest.json
+            /js/
+            /css/
+            /resources/
+          sparse-checkout-cone-mode: false
+
+      - name: Copy legacy JavaScript version
+        run: |
+          cp --recursive legacy-javascript-version/ website-root # Assumption: target directory doesn't already exist; created here.
+
+      - name: Copy Elm version
+        run: |
+          cp --recursive elm-version/_site/ website-root/elm
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4.0.0
+        with:
+          name: github-pages
+          path: website-root/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5
+        with:
+          artifact_name: github-pages


### PR DESCRIPTION
Four years after the Elm foundations were laid down in 8abdf548c3c54af98c5c5f0c4a1e9d380bce19e2, and three years after we declared this "officially an Elm project" in 42a9090c20b6c6b1ac7c5adbf7494e4d6ffb682d, the time has finally come to actually deploy the Elm version.

Today, the legacy JavaScript version (most likely built from 28a4e5142ebe7c0329669166252ef9605242bad8) is deployed as a GitHub Pages site at https://kurve.se, by virtue of existing as a built web app on the `master` branch (currently 139a33e6f97e6208903e0ef73c3a513383d748fb).

This PR defines a GitHub Actions workflow that will hopefully deploy the Elm version alongside the legacy JavaScript version every time the `main` branch is updated. The intention is that https://kurve.se will continue to serve the legacy JavaScript version for the time being, while the Elm version will be available at https://kurve.se/elm.