### PR TITLE
Add script for manipulating original game

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Usage: see the Git history for this script.
+
+import math
+import subprocess
+import sys
+
+process_id = sys.argv[1]
+
+RED = 0
+YELLOW = 1
+ORANGE = 2
+GREEN = 3
+PINK = 4
+BLUE = 5
+NUMBER_OF_PLAYERS = 6
+
+SIZEOF_FLOAT = 4
+
+BASE_ADDRESS = 0x7FFFD8010FF6  # Rendered as "7fffd8010ff6" in scanmem.
+
+space_for_x_coordinates = NUMBER_OF_PLAYERS * SIZEOF_FLOAT
+space_for_y_coordinates = NUMBER_OF_PLAYERS * SIZEOF_FLOAT
+
+x_coordinates_address = BASE_ADDRESS
+y_coordinates_address = BASE_ADDRESS + space_for_x_coordinates
+directions_address = BASE_ADDRESS + space_for_x_coordinates + space_for_y_coordinates
+
+
+def write_float32(address: int, value: float) -> str:
+    return f"write float32 {hex(address)} {value}"
+
+
+def set_x(player_id: int, x: float) -> str:
+    return write_float32(x_coordinates_address + player_id * SIZEOF_FLOAT, x)
+
+
+def set_y(player_id: int, y: float) -> str:
+    return write_float32(y_coordinates_address + player_id * SIZEOF_FLOAT, y)
+
+
+def set_position(player_id: int, x: float, y: float) -> str:
+    return sequence(
+        [
+            set_x(player_id, x),
+            set_y(player_id, y),
+        ],
+    )
+
+
+def set_direction_raw(player_id: int, direction: float) -> str:
+    return write_float32(directions_address + player_id * SIZEOF_FLOAT, direction)
+
+
+def set_direction_conventional(player_id: int, conventional_direction: float) -> str:
+    return set_direction_raw(player_id, conventional_direction + math.pi / 2)
+
+
+def sequence(commands: list[str]) -> str:
+    return ";".join(commands)
+
+
+def scanmem_program(scenario_commands: list[str]) -> str:
+    SETUP_COMMANDS: list[str] = [
+        "option endianness 1",
+    ]
+
+    TEARDOWN_COMMANDS: list[str] = [
+        "exit",
+    ]
+
+    return sequence(SETUP_COMMANDS + scenario_commands + TEARDOWN_COMMANDS)
+
+
+scanmem_command: str = scanmem_program(
+    [
+        set_position(RED, 200, 50),
+        set_direction_conventional(RED, 0),
+        set_position(YELLOW, 200, 100),
+        set_direction_conventional(YELLOW, 0),
+        set_position(GREEN, 200, 150),
+        set_direction_conventional(GREEN, 0),
+    ],
+)
+
+print("BEGIN scanmem program")
+print()
+print("    ", scanmem_command)
+print()
+print("END scanmem program")
+print()
+
+subprocess.run(["scanmem", process_id, "--errexit", "--command", scanmem_command])


### PR DESCRIPTION
This landmark PR adds a basic proof-of-concept script that modifies the memory of the original game to set up a custom scenario. It includes a small DSL for expressing scenarios, and the minimum scaffolding for staging a scenario in an already running `ZATACKA.EXE` inside DOSBox.

An example scenario is included which can be staged like this:

  1. Install [scanmem](https://github.com/scanmem/scanmem) version 0.17.

  2. Temporarily [disable address space layout randomization (ASLR)][aslr]:

     ```bash
     echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
     ```

     Otherwise, the game's state won't end up at a predictable location in memory.

  3. Set `memsize=1` in DOSBox's config file (`~/.dosbox/dosbox-0.74-3.conf` or similar). With the default value of 16, the game's state still won't end up at a predictable location in memory.

  4. Launch the original game as usual.

  5. Join with Red, Yellow and Green, and start the game.

  6. When the Kurves have started moving:

     ```bash
     sudo ./tools/scenario.py `pgrep dosbox`
     ```

Red, Yellow and Green should immediately teleport and start moving perfectly horizontally.

It works because the game stores the players' x coordinates, y coordinates and directions as 32-bit floats starting at `0x7FFFD8010FF6` (at least on my ThinkPad X1 Carbon). This command prints those three arrays (indexed by player ID, with Red = 0):

    sudo scanmem `pgrep dosbox` --errexit --command "option endianness 1;dump 0x7fffd8010ff6 72;exit"

Each player's direction seems to be represented in counter-clockwise radians, with 0 somewhat counterintuitively for me being down, π / 2 being right, etc. It doesn't seem to be normalized to any specific interval; I've seen it grow to above 20 and shrink to below –10.

This is a major breakthrough in our efforts to reverse-engineer the original game. Based on [the groundwork] laid by @lydell and me in #93, @Swij and I came up with this script during a trip to [Vroeger Was Alles Beter: Classics Reloaded][vwab]. Turns out that the front seats of a Tesla Model 3, the Rødby–Puttgarden ferry and a Dutch hotel room are quite decent environments for reverse engineering an old DOS game.

[aslr]: https://askubuntu.com/questions/318315/how-can-i-temporarily-disable-aslr-address-space-layout-randomization/318476#318476
[the groundwork]: https://github.com/SimonAlling/kurve/issues/93#issuecomment-3417461145
[vwab]: https://vwab.nl/