### PR TITLE
Enable automation in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -121,7 +121,7 @@ def prepare_and_get_process_id(process_id_or_path_to_original_game: str) -> str:
         press_key(KEY_GREEN_LEFT)
         time.sleep(0.5)
         press_key("space")
-        time.sleep(4)
+        time.sleep(3.1)
 
         return str(proc.pid)
 


### PR DESCRIPTION
This PR builds further upon #164 by making the scenario script capable of automatically launching the original game in DOSBox, enrolling players and starting the match before staging a scenario.

The existing usage described in #164 is unchanged, except the script doesn't need to be run with `sudo` anymore.

To use the new automation capability:

  1. Perform steps 1–3 in #164.
  2. Install [xdotool] version 3.20160805.1.
  3. Run `sudo true` so the scenario script doesn't get stuck when it runs `sudo`.
  4. `./tools/scenario.py docs/original-game/ZATACKA.EXE`

The implementation was written by ChatGPT, and then I adapted and cleaned it up somewhat.

## `sudo` in the script

Note that `scenario.py` runs scanmem with `sudo` now, and that `scenario.py` itself should _not_ be run with `sudo`. If `scenario.py` is run with `sudo` (and `docs/original-game/ZATACKA.EXE` as argument), then DOSBox doesn't use `~/.dosbox/dosbox-0.74-3.conf` (because it runs as root), so `memsize=1` isn't in effect, resulting in non-predictable memory addresses.

Also, as kindly pointed out by @Swij, it does make sense in general to only use root privileges for the parts that actually need it.

[xdotool]: https://github.com/jordansissel/xdotool

💡 `git show --color-words='"sudo|.'`