### PR TITLE
Run `sudo` early in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -8,6 +8,8 @@ import time
 
 process_id_or_path_to_original_game = sys.argv[1]
 
+subprocess.run(["sudo", "true"])  # Fail early if password hasn't been entered recently.
+
 RED = 0
 YELLOW = 1
 ORANGE = 2


### PR DESCRIPTION
I constantly make the mistake of running the scenario script without having done `sudo true` or similar first. What happens then is that the scenario isn't staged at all, and when I go back to the terminal, it's stuck on `[sudo] password for alling:`.

This PR improves the situation by running `sudo` early, so that the password prompt appears before DOSBox is launched in front of the terminal.