### PR TITLE
Update outdated 'Play' section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ To launch it, install [DOSBox](https://www.dosbox.com) and then run `dosbox docs
 
 ## Play
 
-The Elm remake is not yet released, but you can play the legacy JavaScript version.
-
-* **Online:**  Go to [kurve.se](http://kurve.se).
-* **Locally:** [Download the game](/SimonAlling/kurve/archive/master.zip) and open `ZATACKA.html` in your browser.
+* **Online:** Go to [kurve.se](http://kurve.se) (legacy JavaScript version) or [kurve.se/elm](http://kurve.se/elm) (Elm version).
+* **Locally:** [Download the game](/SimonAlling/kurve/archive/master.zip) (legacy JavaScript version) and open `ZATACKA.html` in your browser.
 
 Fullscreen is recommended for the best experience.


### PR DESCRIPTION
It has been outdated since we deployed the Elm version in #162.

💡 `git show --color-words='The Elm remake.+|.'`