### PR TITLE
Make player IDs less hardcoded in test scenarios

### DIFF
--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -2,6 +2,7 @@ module TestScenarioHelpers exposing
     ( CumulativeInteraction
     , makeUserInteractions
     , makeZombieKurve
+    , playerIds
     , roundWith
     , tickNumber
     )
@@ -15,6 +16,24 @@ import Types.Kurve as Kurve exposing (HoleStatus(..), Kurve, UserInteraction(..)
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick as Tick exposing (Tick)
 import Types.TurningState exposing (TurningState)
+
+
+playerIds :
+    { red : PlayerId
+    , yellow : PlayerId
+    , orange : PlayerId
+    , green : PlayerId
+    , pink : PlayerId
+    , blue : PlayerId
+    }
+playerIds =
+    { red = 0
+    , yellow = 1
+    , orange = 2
+    , green = 3
+    , pink = 4
+    , blue = 5
+    }
 
 
 {-| Creates a Kurve that just moves forward.

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -1,7 +1,7 @@
 module TestScenarios.AroundTheWorld exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeUserInteractions, makeZombieKurve)
+import TestScenarioHelpers exposing (makeUserInteractions, makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
@@ -11,7 +11,7 @@ greenZombie : Kurve
 greenZombie =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 4.5, 1.5 )
             , direction = Angle 0

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CrashIntoTailEnd90Degrees exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ red : Kurve
 red =
     makeZombieKurve
         { color = Color.red
-        , id = 0
+        , id = playerIds.red
         , state =
             { position = ( 100.5, 100.5 )
             , direction = Angle 0
@@ -23,7 +23,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 98.5, 110.5 )
             , direction = Angle (pi / 2)

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CrashIntoTipOfTailEnd exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ red : Kurve
 red =
     makeZombieKurve
         { color = Color.red
-        , id = 0
+        , id = playerIds.red
         , state =
             { position = ( 60.5, 60.5 )
             , direction = Angle (-pi / 4)
@@ -23,7 +23,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 30.5, 30.5 )
             , direction = Angle (-pi / 4)

--- a/src/TestScenarios/CrashIntoWallBasic.elm
+++ b/src/TestScenarios/CrashIntoWallBasic.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CrashIntoWallBasic exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 2.5, 100 )
             , direction = Angle pi

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CrashIntoWallExactTiming exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 100, 3.5 )
             , direction = Angle 0.01

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CuttingCornersBasic exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ red : Kurve
 red =
     makeZombieKurve
         { color = Color.red
-        , id = 0
+        , id = playerIds.red
         , state =
             { position = ( 200.5, 100.5 )
             , direction = Angle 0
@@ -23,7 +23,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 100.5, 196.5 )
             , direction = Angle (pi / 4)

--- a/src/TestScenarios/CuttingCornersPerfectOverpaintingTheoretical.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpaintingTheoretical.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CuttingCornersPerfectOverpaintingTheoretical exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ red : Kurve
 red =
     makeZombieKurve
         { color = Color.red
-        , id = 0
+        , id = playerIds.red
         , state =
             { position = ( 30.5, 30.5 )
             , direction = Angle (-pi / 4)
@@ -23,7 +23,7 @@ yellow : Kurve
 yellow =
     makeZombieKurve
         { color = Color.yellow
-        , id = 1
+        , id = playerIds.yellow
         , state =
             { position = ( 60.5, 60.5 )
             , direction = Angle (-pi / 4)
@@ -36,7 +36,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 19.5, 98.5 )
             , direction = Angle (pi / 4)

--- a/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
+++ b/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
@@ -1,7 +1,7 @@
 module TestScenarios.CuttingCornersThreePixelsRealExample exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ red : Kurve
 red =
     makeZombieKurve
         { color = Color.red
-        , id = 0
+        , id = playerIds.red
         , state =
             { position = ( 299.5, 302.5 )
             , direction = Angle (-71 * (2 * pi / 360))
@@ -23,7 +23,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 319, 269 )
             , direction = Angle (-123 * (2 * pi / 360))

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -1,7 +1,7 @@
 module TestScenarios.SpeedEffectOnGame exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -10,7 +10,7 @@ green : Kurve
 green =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 108, 100 )
             , direction = Angle 0

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -1,7 +1,7 @@
 module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (CumulativeInteraction, makeUserInteractions, makeZombieKurve)
+import TestScenarioHelpers exposing (CumulativeInteraction, makeUserInteractions, makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
@@ -11,7 +11,7 @@ greenZombie : Kurve
 greenZombie =
     makeZombieKurve
         { color = Color.green
-        , id = 3
+        , id = playerIds.green
         , state =
             { position = ( 32.5, 3.5 )
             , direction = Angle 0

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -6,7 +6,7 @@ import Expect
 import String
 import Test exposing (Test, describe, test)
 import TestHelpers exposing (defaultConfigWithSpeed, expectRoundOutcome)
-import TestScenarioHelpers exposing (makeZombieKurve, roundWith, tickNumber)
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds, roundWith, tickNumber)
 import TestScenarios.AroundTheWorld
 import TestScenarios.CrashIntoTailEnd90Degrees
 import TestScenarios.CrashIntoTipOfTailEnd
@@ -190,7 +190,7 @@ crashingIntoWallTests =
                                 green =
                                     makeZombieKurve
                                         { color = Color.green
-                                        , id = 3
+                                        , id = playerIds.green
                                         , state =
                                             { position = startingPosition
                                             , direction = direction
@@ -305,7 +305,7 @@ crashingIntoKurveTimingTests =
                                 red =
                                     makeZombieKurve
                                         { color = Color.red
-                                        , id = 0
+                                        , id = playerIds.red
                                         , state =
                                             { position = ( 150, y_red )
                                             , direction = Angle 0
@@ -317,7 +317,7 @@ crashingIntoKurveTimingTests =
                                 green =
                                     makeZombieKurve
                                         { color = Color.green
-                                        , id = 3
+                                        , id = playerIds.green
                                         , state =
                                             { position = ( 100, 107.5 )
                                             , direction = Angle 0.02


### PR DESCRIPTION
In the original game, the players have unambiguous IDs (or indices):

  0. 🟥 Red
  1. 🟨 Yellow
  2. 🟧 Orange
  3. 🟩 Green
  4. 🟪 Pink
  5. 🟦 Blue

Player IDs play no part in any test case today (but that might change). Nevertheless, by convention, our test scenarios stick to the ID–color correspondence above, but that's entirely implicit. This PR makes it more explicit by giving color names to the IDs, thereby making it much easier to follow the convention and to tell whether it's being followed.

💡 `git show --color-words=.`