### PR TITLE
Make test cases more similar to each other

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -49,9 +49,14 @@ basicTests =
                         , howItShouldEnd =
                             \round ->
                                 case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [], kurve :: [] ) ->
-                                        Expect.equal kurve.state.position
-                                            ( 0.5, 100 )
+                                    ( [], [ deadKurve ] ) ->
+                                        let
+                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
+                                            theDrawingPositionItNeverMadeItTo =
+                                                World.drawingPosition deadKurve.state.position
+                                        in
+                                        theDrawingPositionItNeverMadeItTo
+                                            |> Expect.equal { leftEdge = -1, topEdge = 99 }
 
                                     _ ->
                                         Expect.fail "Expected exactly one dead Kurve and no alive ones"
@@ -65,7 +70,7 @@ basicTests =
                         , howItShouldEnd =
                             \round ->
                                 case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [], deadKurve :: [] ) ->
+                                    ( [], [ deadKurve ] ) ->
                                         let
                                             theDrawingPositionItNeverMadeItTo : World.DrawingPosition
                                             theDrawingPositionItNeverMadeItTo =
@@ -272,11 +277,11 @@ crashingIntoWallTimingTest =
                     , howItShouldEnd =
                         \round ->
                             case ( round.kurves.alive, round.kurves.dead ) of
-                                ( [], [ kurve ] ) ->
+                                ( [], [ deadKurve ] ) ->
                                     let
                                         theDrawingPositionItNeverMadeItTo : World.DrawingPosition
                                         theDrawingPositionItNeverMadeItTo =
-                                            World.drawingPosition kurve.state.position
+                                            World.drawingPosition deadKurve.state.position
                                     in
                                     theDrawingPositionItNeverMadeItTo
                                         |> Expect.equal { leftEdge = 349, topEdge = -1 }


### PR DESCRIPTION
I'm planning to modify `expectRoundOutcome` so that `howItShouldEnd` isn't a function arbitrarily expecting individual things about the finished round, but instead a more comprehensive and standardized description of how the round should end.

In preparation for that, this PR modifies a few test cases that diverge somewhat from the current pattern:

  * The very first test case is modified to expect a (denied) _drawing_ position instead of an "internal" position.
  * Three test cases (including the previously mentioned one) are modified to pattern match using `( [], [ deadKurve ] )`, instead of slightly different variations thereof.