### PR TITLE
Simplify and standardize test cases

### DIFF
--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -2,7 +2,6 @@ module AchtungTest exposing (tests)
 
 import Color
 import Config
-import Expect
 import String
 import Test exposing (Test, describe, test)
 import TestHelpers exposing (defaultConfigWithSpeed, expectRoundOutcome)
@@ -47,19 +46,13 @@ basicTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 2
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [], [ deadKurve ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        theDrawingPositionItNeverMadeItTo
-                                            |> Expect.equal { leftEdge = -1, topEdge = 99 }
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve and no alive ones"
+                            { aliveAtTheEnd = []
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = -1, topEdge = 99 }
+                                  }
+                                ]
+                            }
                         }
         , test "Around the world, touching each wall" <|
             \_ ->
@@ -68,19 +61,13 @@ basicTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 2011
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [], [ deadKurve ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        theDrawingPositionItNeverMadeItTo
-                                            |> Expect.equal { leftEdge = 0, topEdge = -1 }
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve and no alive ones"
+                            { aliveAtTheEnd = []
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 0, topEdge = -1 }
+                                  }
+                                ]
+                            }
                         }
         ]
 
@@ -95,26 +82,13 @@ crashingIntoKurveTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 8
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [ _ ], [ deadKurve ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        Expect.all
-                                            [ \() ->
-                                                theDrawingPositionItNeverMadeItTo
-                                                    |> Expect.equal { leftEdge = 97, topEdge = 101 }
-                                            , \() ->
-                                                deadKurve.color
-                                                    |> Expect.equal Color.green
-                                            ]
-                                            ()
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve and one alive one"
+                            { aliveAtTheEnd = [ { id = playerIds.red } ]
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 97, topEdge = 101 }
+                                  }
+                                ]
+                            }
                         }
         , test "Hitting a Kurve's tail end at a 45-degree angle is a crash" <|
             \_ ->
@@ -123,26 +97,13 @@ crashingIntoKurveTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 39
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [ _ ], [ deadKurve ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        Expect.all
-                                            [ \() ->
-                                                theDrawingPositionItNeverMadeItTo
-                                                    |> Expect.equal { leftEdge = 57, topEdge = 57 }
-                                            , \() ->
-                                                deadKurve.color
-                                                    |> Expect.equal Color.green
-                                            ]
-                                            ()
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve and one alive one"
+                            { aliveAtTheEnd = [ { id = playerIds.red } ]
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
+                                  }
+                                ]
+                            }
                         }
         ]
 
@@ -208,19 +169,13 @@ crashingIntoWallTests =
                                     Config.default
                                     { tickThatShouldEndIt = tickThatShouldEndIt
                                     , howItShouldEnd =
-                                        \round ->
-                                            case ( round.kurves.alive, round.kurves.dead ) of
-                                                ( [], [ deadKurve ] ) ->
-                                                    let
-                                                        theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                                        theDrawingPositionItNeverMadeItTo =
-                                                            World.drawingPosition deadKurve.state.position
-                                                    in
-                                                    theDrawingPositionItNeverMadeItTo
-                                                        |> Expect.equal drawingPositionItShouldNeverMakeItTo
-
-                                                _ ->
-                                                    Expect.fail "Expected exactly one dead Kurve and no alive ones"
+                                        { aliveAtTheEnd = []
+                                        , deadAtTheEnd =
+                                            [ { id = playerIds.green
+                                              , theDrawingPositionItNeverMadeItTo = drawingPositionItShouldNeverMakeItTo
+                                              }
+                                            ]
+                                        }
                                     }
                 )
         )
@@ -275,19 +230,13 @@ crashingIntoWallTimingTest =
                     Config.default
                     { tickThatShouldEndIt = tickNumber 251
                     , howItShouldEnd =
-                        \round ->
-                            case ( round.kurves.alive, round.kurves.dead ) of
-                                ( [], [ deadKurve ] ) ->
-                                    let
-                                        theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                        theDrawingPositionItNeverMadeItTo =
-                                            World.drawingPosition deadKurve.state.position
-                                    in
-                                    theDrawingPositionItNeverMadeItTo
-                                        |> Expect.equal { leftEdge = 349, topEdge = -1 }
-
-                                _ ->
-                                    Expect.fail "Expected exactly one dead Kurve and no alive ones"
+                        { aliveAtTheEnd = []
+                        , deadAtTheEnd =
+                            [ { id = playerIds.green
+                              , theDrawingPositionItNeverMadeItTo = { leftEdge = 349, topEdge = -1 }
+                              }
+                            ]
+                        }
                     }
 
 
@@ -335,26 +284,13 @@ crashingIntoKurveTimingTests =
                                     Config.default
                                     { tickThatShouldEndIt = tickNumber 226
                                     , howItShouldEnd =
-                                        \round ->
-                                            case ( round.kurves.alive, round.kurves.dead ) of
-                                                ( [ _ ], [ deadKurve ] ) ->
-                                                    let
-                                                        theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                                        theDrawingPositionItNeverMadeItTo =
-                                                            World.drawingPosition deadKurve.state.position
-                                                    in
-                                                    Expect.all
-                                                        [ \() ->
-                                                            theDrawingPositionItNeverMadeItTo
-                                                                |> Expect.equal { leftEdge = 324, topEdge = 101 }
-                                                        , \() ->
-                                                            deadKurve.color
-                                                                |> Expect.equal Color.green
-                                                        ]
-                                                        ()
-
-                                                _ ->
-                                                    Expect.fail "Expected exactly one dead Kurve and one alive one"
+                                        { aliveAtTheEnd = [ { id = playerIds.red } ]
+                                        , deadAtTheEnd =
+                                            [ { id = playerIds.green
+                                              , theDrawingPositionItNeverMadeItTo = { leftEdge = 324, topEdge = 101 }
+                                              }
+                                            ]
+                                        }
                                     }
                         )
                 )
@@ -371,26 +307,13 @@ cuttingCornersTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 277
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [ _ ], [ deadKurve ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        Expect.all
-                                            [ \() ->
-                                                theDrawingPositionItNeverMadeItTo
-                                                    |> Expect.equal { leftEdge = 295, topEdge = -1 }
-                                            , \() ->
-                                                deadKurve.color
-                                                    |> Expect.equal Color.green
-                                            ]
-                                            ()
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve and one alive one"
+                            { aliveAtTheEnd = [ { id = playerIds.red } ]
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 295, topEdge = -1 }
+                                  }
+                                ]
+                            }
                         }
         , test "It is possible to paint over three pixels when cutting a corner (real example from original game)" <|
             \_ ->
@@ -399,26 +322,13 @@ cuttingCornersTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 40
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [ _ ], [ deadKurve ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        Expect.all
-                                            [ \() ->
-                                                theDrawingPositionItNeverMadeItTo
-                                                    |> Expect.equal { leftEdge = 296, topEdge = 301 }
-                                            , \() ->
-                                                deadKurve.color
-                                                    |> Expect.equal Color.green
-                                            ]
-                                            ()
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve and one alive one"
+                            { aliveAtTheEnd = [ { id = playerIds.red } ]
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 296, topEdge = 301 }
+                                  }
+                                ]
+                            }
                         }
         , test "The perfect overpainting (squeezing through a non-existent gap)" <|
             \_ ->
@@ -427,26 +337,16 @@ cuttingCornersTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 138
                         , howItShouldEnd =
-                            \round ->
-                                case ( round.kurves.alive, round.kurves.dead ) of
-                                    ( [ _ ], [ secondDeadKurve, _ ] ) ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition secondDeadKurve.state.position
-                                        in
-                                        Expect.all
-                                            [ \() ->
-                                                theDrawingPositionItNeverMadeItTo
-                                                    |> Expect.equal { leftEdge = 116, topEdge = -1 }
-                                            , \() ->
-                                                secondDeadKurve.color
-                                                    |> Expect.equal Color.green
-                                            ]
-                                            ()
-
-                                    _ ->
-                                        Expect.fail "Expected exactly two dead Kurves and one alive one"
+                            { aliveAtTheEnd = [ { id = playerIds.yellow } ]
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 116, topEdge = -1 }
+                                  }
+                                , { id = playerIds.red
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
+                                  }
+                                ]
+                            }
                         }
         ]
 
@@ -467,19 +367,13 @@ speedTests =
                                     (defaultConfigWithSpeed speed)
                                     { tickThatShouldEndIt = expectedEndTick
                                     , howItShouldEnd =
-                                        \round ->
-                                            case round.kurves.dead of
-                                                [ deadKurve ] ->
-                                                    let
-                                                        theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                                        theDrawingPositionItNeverMadeItTo =
-                                                            World.drawingPosition deadKurve.state.position
-                                                    in
-                                                    theDrawingPositionItNeverMadeItTo
-                                                        |> Expect.equal { leftEdge = 557, topEdge = 99 }
-
-                                                _ ->
-                                                    Expect.fail "Expected exactly one dead Kurve"
+                                        { aliveAtTheEnd = []
+                                        , deadAtTheEnd =
+                                            [ { id = playerIds.green
+                                              , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
+                                              }
+                                            ]
+                                        }
                                     }
                 )
         )
@@ -495,18 +389,12 @@ stressTests =
                         Config.default
                         { tickThatShouldEndIt = tickNumber 23875
                         , howItShouldEnd =
-                            \round ->
-                                case round.kurves.dead of
-                                    [ deadKurve ] ->
-                                        let
-                                            theDrawingPositionItNeverMadeItTo : World.DrawingPosition
-                                            theDrawingPositionItNeverMadeItTo =
-                                                World.drawingPosition deadKurve.state.position
-                                        in
-                                        theDrawingPositionItNeverMadeItTo
-                                            |> Expect.equal { leftEdge = 372, topEdge = 217 }
-
-                                    _ ->
-                                        Expect.fail "Expected exactly one dead Kurve"
+                            { aliveAtTheEnd = []
+                            , deadAtTheEnd =
+                                [ { id = playerIds.green
+                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 372, topEdge = 217 }
+                                  }
+                                ]
+                            }
                         }
         ]

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -7,15 +7,34 @@ import Config exposing (Config, KurveConfig)
 import Expect
 import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundFromKnownInitialState, reactToTick)
 import Round exposing (Round, RoundInitialState)
+import Types.PlayerId exposing (PlayerId)
 import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
+import World exposing (DrawingPosition)
 
 
 {-| A description of when and how a round should end.
 -}
 type alias RoundOutcome =
     { tickThatShouldEndIt : Tick
-    , howItShouldEnd : Round -> Expect.Expectation
+    , howItShouldEnd : RoundEndingInterpretation
+    }
+
+
+type alias RoundEndingInterpretation =
+    { aliveAtTheEnd : List AliveKurve
+    , deadAtTheEnd : List DeadKurve
+    }
+
+
+type alias AliveKurve =
+    { id : PlayerId
+    }
+
+
+type alias DeadKurve =
+    { id : PlayerId
+    , theDrawingPositionItNeverMadeItTo : DrawingPosition
     }
 
 
@@ -32,9 +51,31 @@ expectRoundOutcome config { tickThatShouldEndIt, howItShouldEnd } initialState =
 
             else
                 Expect.fail <| "Expected round to end on tick " ++ showTick tickThatShouldEndIt ++ " but it ended on tick " ++ showTick actualEndTick ++ "."
-        , \_ -> howItShouldEnd actualRoundResult
+        , \_ ->
+            interpretRoundEnding actualRoundResult
+                |> Expect.equal howItShouldEnd
         ]
         ()
+
+
+interpretRoundEnding : Round -> RoundEndingInterpretation
+interpretRoundEnding { kurves } =
+    { aliveAtTheEnd =
+        kurves.alive
+            |> List.map
+                (\kurve ->
+                    { id = kurve.id
+                    }
+                )
+    , deadAtTheEnd =
+        kurves.dead
+            |> List.map
+                (\kurve ->
+                    { id = kurve.id
+                    , theDrawingPositionItNeverMadeItTo = World.drawingPosition kurve.state.position
+                    }
+                )
+    }
 
 
 playOutRound : Config -> RoundInitialState -> ( Tick, Round )


### PR DESCRIPTION
Today, all our test cases follow the same structure: initialize a round using `roundWith`, pass the resulting `RoundInitialState` to `expectRoundOutcome`, and tell it what expectations to place on the round when it is over. It's quite verbose, repetitive and fragile.

This PR standardizes the test cases, removes boilerplate and simplifies them: instead of placing arbitrary expectations on various aspects of the finished round (which tend to always be very similar anyway), we describe the expected ending in a standardized, unambiguous way where it's not possible to forget anything.

One concrete benefit of the new way is that a `RoundOutcome` doesn't contain any `Expectation` anymore, which makes it possible to move the expected outcomes into the corresponding `TestScenarios` modules, should we want to. They can also be serialized, should the need arise.

This improvement was triggered by the recent breakthroughs in #93. I think they will allow us, with some degree of automation, to define test cases based on the actual behavior of the original game. Then I think it will be extra important for test cases to be expressed as simply as possible.

## About `AliveKurve`

One might wonder why `AliveKurve` doesn't have a `theDrawingPositionItNeverMadeItTo` field like `DeadKurve`. Well, we don't have any test case that checks where the winner was when the round ended, so it's completely unnecessary. Admittedly, we don't have any test case that checks who won either, so the `id` field is also unnecessary by the same logic. But I think it makes test cases more readable if it's explicitly stated who should win.

## About `aliveAtTheEnd`

One might wonder why the `aliveAtTheEnd` field has type `List AliveKurve` and not something like `Maybe AliveKurve`. The latter would perhaps result in nicer-looking test cases, but it doesn't match our model: the type checker doesn't know that there cannot be more than one Kurve alive at the end of a round. (Note that there are _zero_ Kurves alive at the end of a single-player round.)