### PR TITLE
Remove 'Theoretical' in name of confirmed scenario

### DIFF
--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -1,4 +1,4 @@
-module TestScenarios.CuttingCornersPerfectOverpaintingTheoretical exposing (spawnedKurves)
+module TestScenarios.CuttingCornersPerfectOverpainting exposing (spawnedKurves)
 
 import Color
 import TestScenarioHelpers exposing (makeZombieKurve, playerIds)

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -12,7 +12,7 @@ import TestScenarios.CrashIntoTipOfTailEnd
 import TestScenarios.CrashIntoWallBasic
 import TestScenarios.CrashIntoWallExactTiming
 import TestScenarios.CuttingCornersBasic
-import TestScenarios.CuttingCornersPerfectOverpaintingTheoretical
+import TestScenarios.CuttingCornersPerfectOverpainting
 import TestScenarios.CuttingCornersThreePixelsRealExample
 import TestScenarios.SpeedEffectOnGame
 import TestScenarios.StressTestRealisticTurtleSurvivalRound
@@ -332,7 +332,7 @@ cuttingCornersTests =
                         }
         , test "The perfect overpainting (squeezing through a non-existent gap)" <|
             \_ ->
-                roundWith TestScenarios.CuttingCornersPerfectOverpaintingTheoretical.spawnedKurves
+                roundWith TestScenarios.CuttingCornersPerfectOverpainting.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
                         { tickThatShouldEndIt = tickNumber 138


### PR DESCRIPTION
The test case in question was completely theoretical when it was added #126 – it was something I assumed was possible in the original game, but had never seen happen. I deliberately still added it as a regression test for our collision handling.

In #93, we finally proved that it _is_ possible, and it therefore isn't theoretical anymore. Here's how to reproduce it in the original game:

  1. Replace the `set_player_state` calls in `tools/scenario.py` with these lines:

     ```python
     set_player_state(RED, x=29, y=29, conventional_direction=-math.pi / 4),
     set_player_state(YELLOW, x=58.5, y=58.5, conventional_direction=-math.pi / 4),
     set_player_state(GREEN, x=17.5, y=98.5, conventional_direction=math.pi / 4),
     ```

  2. Ensure the prerequisites in #164 and #165 are met.

  3. Run `./tools/scenario.py docs/original-game/ZATACKA.EXE`.

The staged scenario is identical to the test case renamed by this PR, with respect to where the Kurves spawn and how Green squeezes through the non-existent gap between Red and Yellow. (It's not exactly identical with respect to how the round ends, probably due to other, unrelated inaccuracies in our clone.)