### PR TITLE
Limit DOSBox memory size in scenario script

### DIFF
--- a/tools/dosbox.conf
+++ b/tools/dosbox.conf
@@ -1,0 +1,2 @@
+[dosbox]
+memsize=1 # Necessary for game state to end up at a consistent, predictable memory address.

--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -2,9 +2,12 @@
 # Usage: see the Git history for this script.
 
 import math
+import os
 import subprocess
 import sys
 import time
+
+parent_dir_of_script = os.path.dirname(os.path.abspath(__file__))
 
 process_id_or_path_to_original_game = sys.argv[1]
 
@@ -111,8 +114,15 @@ def prepare_and_get_process_id(process_id_or_path_to_original_game: str) -> str:
         path_to_original_game = process_id_or_path_to_original_game
         print(f"🚀 Launching original game at {path_to_original_game} …")
 
+        additional_config_file = os.path.join(parent_dir_of_script, "dosbox.conf")
         proc = subprocess.Popen(
-            ["dosbox", path_to_original_game],
+            [
+                "dosbox",
+                "-userconf",
+                "-conf",
+                additional_config_file,
+                path_to_original_game,
+            ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )


### PR DESCRIPTION
As mentioned in #164, #165 and #170, the scenario script relies on `memsize=1` being set in the user's DOSBox config file (`~/.dosbox/dosbox-0.74-3.conf` or similar). This PR removes that assumption, instead forcing `memsize=1` automatically.

## About the diff

`-userconf` is important because without it, the user's config file is completely ignored. We probably don't want it to be ignored, because the user may have useful settings there, such as window resolution, scaler settings, etc. In any case, ignoring it isn't in scope for this PR.

💡 `git show --color-words=.`