### PR TITLE
Scenariofy "Crashing into a wall" test cases

### DIFF
--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -1,0 +1,24 @@
+module TestScenarios.CrashIntoWallBottom exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = playerIds.green
+        , state =
+            { position = ( 100, 477.5 )
+            , direction = Angle (-pi / 2)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -1,0 +1,24 @@
+module TestScenarios.CrashIntoWallLeft exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = playerIds.green
+        , state =
+            { position = ( 2.5, 100 )
+            , direction = Angle pi
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -1,0 +1,24 @@
+module TestScenarios.CrashIntoWallRight exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = playerIds.green
+        , state =
+            { position = ( 556.5, 100 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -1,0 +1,24 @@
+module TestScenarios.CrashIntoWallTop exposing (spawnedKurves)
+
+import Color
+import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Color.green
+        , id = playerIds.green
+        , state =
+            { position = ( 100, 2.5 )
+            , direction = Angle (pi / 2)
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -10,7 +10,11 @@ import TestScenarios.AroundTheWorld
 import TestScenarios.CrashIntoTailEnd90Degrees
 import TestScenarios.CrashIntoTipOfTailEnd
 import TestScenarios.CrashIntoWallBasic
+import TestScenarios.CrashIntoWallBottom
 import TestScenarios.CrashIntoWallExactTiming
+import TestScenarios.CrashIntoWallLeft
+import TestScenarios.CrashIntoWallRight
+import TestScenarios.CrashIntoWallTop
 import TestScenarios.CuttingCornersBasic
 import TestScenarios.CuttingCornersPerfectOverpainting
 import TestScenarios.CuttingCornersThreePixelsRealExample
@@ -119,52 +123,34 @@ crashingIntoWallTests =
             testCases :
                 List
                     { wallDescription : String
-                    , startingPosition : World.Position
-                    , direction : Angle
+                    , spawnedKurves : List Kurve
                     , drawingPositionItShouldNeverMakeItTo : World.DrawingPosition
                     }
             testCases =
                 [ { wallDescription = "Top wall"
-                  , startingPosition = ( 100, 2.5 )
-                  , direction = Angle (pi / 2)
+                  , spawnedKurves = TestScenarios.CrashIntoWallTop.spawnedKurves
                   , drawingPositionItShouldNeverMakeItTo = { leftEdge = 99, topEdge = -1 }
                   }
                 , { wallDescription = "Right wall"
-                  , startingPosition = ( 556.5, 100 )
-                  , direction = Angle 0
+                  , spawnedKurves = TestScenarios.CrashIntoWallRight.spawnedKurves
                   , drawingPositionItShouldNeverMakeItTo = { leftEdge = 557, topEdge = 99 }
                   }
                 , { wallDescription = "Bottom wall"
-                  , startingPosition = ( 100, 477.5 )
-                  , direction = Angle (-pi / 2)
+                  , spawnedKurves = TestScenarios.CrashIntoWallBottom.spawnedKurves
                   , drawingPositionItShouldNeverMakeItTo = { leftEdge = 99, topEdge = 478 }
                   }
                 , { wallDescription = "Left wall"
-                  , startingPosition = ( 2.5, 100 )
-                  , direction = Angle pi
+                  , spawnedKurves = TestScenarios.CrashIntoWallLeft.spawnedKurves
                   , drawingPositionItShouldNeverMakeItTo = { leftEdge = -1, topEdge = 99 }
                   }
                 ]
          in
          testCases
             |> List.map
-                (\{ wallDescription, startingPosition, direction, drawingPositionItShouldNeverMakeItTo } ->
+                (\{ wallDescription, spawnedKurves, drawingPositionItShouldNeverMakeItTo } ->
                     test wallDescription <|
                         \_ ->
-                            let
-                                green : Kurve
-                                green =
-                                    makeZombieKurve
-                                        { color = Color.green
-                                        , id = playerIds.green
-                                        , state =
-                                            { position = startingPosition
-                                            , direction = direction
-                                            , holeStatus = Unholy 60000
-                                            }
-                                        }
-                            in
-                            roundWith [ green ]
+                            roundWith spawnedKurves
                                 |> expectRoundOutcome
                                     Config.default
                                     { tickThatShouldEndIt = tickThatShouldEndIt


### PR DESCRIPTION
Continuing where #174 left off, this PR aligns the test cases in `crashingIntoWallTests` with the pattern of describing the scenario in a `TestScenarios` module. One concrete benefit of that is that it becomes easier to visualize the scenario, as described in #144.

💡 `git show --color-moved --color-moved-ws=allow-indentation-change`