### PR TITLE
Un-hardcode base address in tools

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -10,6 +10,7 @@ import time
 parent_dir_of_script = os.path.dirname(os.path.abspath(__file__))
 
 process_id_or_path_to_original_game = sys.argv[1]
+raw_base_address = sys.argv[2] # e.g. 7fffd8010ff6
 
 subprocess.run(["sudo", "true"])  # Fail early if password hasn't been entered recently.
 
@@ -23,14 +24,13 @@ NUMBER_OF_PLAYERS = 6
 
 SIZEOF_FLOAT = 4
 
-BASE_ADDRESS = 0x7FFFD8010FF6  # Rendered as "7fffd8010ff6" in scanmem.
-
 space_for_x_coordinates = NUMBER_OF_PLAYERS * SIZEOF_FLOAT
 space_for_y_coordinates = NUMBER_OF_PLAYERS * SIZEOF_FLOAT
 
-x_coordinates_address = BASE_ADDRESS
-y_coordinates_address = BASE_ADDRESS + space_for_x_coordinates
-directions_address = BASE_ADDRESS + space_for_x_coordinates + space_for_y_coordinates
+base_address = int(raw_base_address, 16)
+x_coordinates_address = base_address
+y_coordinates_address = base_address + space_for_x_coordinates
+directions_address = base_address + space_for_x_coordinates + space_for_y_coordinates
 
 
 def write_float32(address: int, value: float) -> str:

--- a/tools/show-game-state.sh
+++ b/tools/show-game-state.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-sudo scanmem `pgrep dosbox` --errexit --command "option dump_with_ascii 0;dump 0x7fffd8010ff6 72;exit" 2>/dev/null | $(dirname $0)/interpret-scanmem-output.py
+USAGE="For example: $0 7fffd8010ff6"
+
+base_address="${1:?Please specify base address. $USAGE}"
+
+sudo scanmem `pgrep dosbox` --errexit --command "option dump_with_ascii 0;dump ${base_address} 72;exit" 2>/dev/null | $(dirname $0)/interpret-scanmem-output.py


### PR DESCRIPTION
As first documented in #180, the so-called base address (the address in memory where the parts of the game state currently known to us starts) isn't consistent between computers:

  * On my Ubuntu laptop, it's `0x7fffd8010ff6`.
  * In WSL on my Windows PC, it seems to be `0x7fffc1c65ff6`, _but_ [I have to change `memsize=1` to `memsize=2` in `tools/dosbox.conf` for scanmem to work at all][comment]. I haven't figured out any way to stage a scenario or show the game state with `memsize=1` in WSL.

This PR parameterizes the base address in the tools that use it, so that it must be provided as a command-line argument. For example:

  * `./tools/scenario.py docs/original-game/ZATACKA.EXE 7fffd8010ff6`
  * `watch -n 0.1 ./tools/show-game-state.sh 7fffd8010ff6`

[comment]: https://github.com/SimonAlling/kurve/issues/180#issuecomment-3499364500

💡 `git show --color-words='7fffd8010ff6|.'`