### PR TITLE
Make focusing DOSBox more robust in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -108,7 +108,7 @@ def find_and_focus_dosbox(timeout: float = 15.0) -> str | None:
     deadline = time.time() + timeout
     while time.time() < deadline:
         res = subprocess.run(
-            ["xdotool", "search", "--onlyvisible", "--name", "DOSBox"],
+            ["xdotool", "search", "--onlyvisible", "--name", "DOSBox.+ZATACKA"],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
The current implementation mistakes VS Code for DOSBox if the currently active file in VS Code has `dosbox` (case-insensitive) in its name. So if e.g. `tools/dosbox.conf` or `~/.dosbox/dosbox-0.74-3.conf` is currently being edited, then VS Code is focused and receives the key presses intended for DOSBox, which is extremely confusing and disorienting.

This PR should remove most such false positives by making xdotool search for a window whose name also has `ZATACKA` (case-insensitive) in it.