### PR TITLE
Pin OS and action versions in CI

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   validation:
     name: PR Validation Build
-    runs-on: ubuntu-24.04.3
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1.2.0
       - name: Build Docker image


### PR DESCRIPTION
I'm absolutely not a fan of non-deterministic CI setups that suddenly start failing or misbehaving without any in-repo changes.

💡 `git show --color-words=.`