### PR TITLE
Fix out-of-sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,6 @@
     "": {
       "name": "zatacka",
       "hasInstallScript": true,
-      "dependencies": {
-        "run-pty": "5"
-      },
       "devDependencies": {
         "elm-review": "2.12.0",
         "elm-test": "0.19.1-revision12",


### PR DESCRIPTION
Apparently, #147 made `npm install` want to modify `package-lock.json`. This PR contains that modification.