### PR TITLE
Align direction representation with original game

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -27,6 +27,7 @@ import NoUnused.Variables
 import Review.Rule exposing (Rule)
 import Simplify
 
+
 config : List Rule
 config =
     [ NoConfusingPrefixOperator.rule

--- a/src/Config.elm
+++ b/src/Config.elm
@@ -36,7 +36,7 @@ default =
         , protectionAudacity = 0.25 -- Closer to 1 ⇔ less risk of spawn kills but higher risk of no solution
         , flickerTicksPerSecond = 20 -- At each tick, the spawning Kurve is toggled between visible and invisible.
         , numberOfFlickerTicks = 5
-        , angleInterval = ( -pi / 2, pi / 2 )
+        , angleInterval = ( 0, pi )
         }
     , world =
         { width = 559

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -345,10 +345,13 @@ updateKurve config turningState occupiedPixels kurve =
 
         newPosition : Position
         newPosition =
-            ( x + distanceTraveledSinceLastTick * Angle.cos newDirection
-            , -- The coordinate system is traditionally "flipped" (wrt standard math) such that the Y axis points downwards.
-              -- Therefore, we have to use minus instead of plus for the Y-axis calculation.
-              y - distanceTraveledSinceLastTick * Angle.sin newDirection
+            -- This is based on how the original MS-DOS game works:
+            --
+            --   * The coordinate system is "flipped" (wrt standard math) such that the Y axis points downwards.
+            --   * Directions are zeroed around down, not right as in standard math.
+            --
+            ( x + distanceTraveledSinceLastTick * Angle.sin newDirection
+            , y + distanceTraveledSinceLastTick * Angle.cos newDirection
             )
 
         ( confirmedDrawingPositions, fate ) =

--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -46,7 +46,7 @@ makeZombieKurve { color, id, state } =
     , state = state
     , stateAtSpawn =
         { position = ( 0, 0 )
-        , direction = Angle 0
+        , direction = Angle (pi / 2)
         , holeStatus = Unholy 0
         }
     , reversedInteractions = []

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -14,7 +14,7 @@ greenZombie =
         , id = playerIds.green
         , state =
             { position = ( 4.5, 1.5 )
-            , direction = Angle 0
+            , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -13,7 +13,7 @@ red =
         , id = playerIds.red
         , state =
             { position = ( 100.5, 100.5 )
-            , direction = Angle 0
+            , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
         }
@@ -26,7 +26,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 98.5, 110.5 )
-            , direction = Angle (pi / 2)
+            , direction = Angle pi
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -13,7 +13,7 @@ red =
         , id = playerIds.red
         , state =
             { position = ( 60.5, 60.5 )
-            , direction = Angle (-pi / 4)
+            , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }
         }
@@ -26,7 +26,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 30.5, 30.5 )
-            , direction = Angle (-pi / 4)
+            , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoWallBasic.elm
+++ b/src/TestScenarios/CrashIntoWallBasic.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 2.5, 100 )
-            , direction = Angle pi
+            , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60
             }
         }

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 100, 477.5 )
-            , direction = Angle (-pi / 2)
+            , direction = Angle 0
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 100, 3.5 )
-            , direction = Angle 0.01
+            , direction = Angle (pi / 2 + 0.01)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 2.5, 100 )
-            , direction = Angle pi
+            , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 556.5, 100 )
-            , direction = Angle 0
+            , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 100, 2.5 )
-            , direction = Angle (pi / 2)
+            , direction = Angle pi
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -13,7 +13,7 @@ red =
         , id = playerIds.red
         , state =
             { position = ( 200.5, 100.5 )
-            , direction = Angle 0
+            , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
         }
@@ -26,7 +26,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 100.5, 196.5 )
-            , direction = Angle (pi / 4)
+            , direction = Angle (3 * pi / 4)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -13,7 +13,7 @@ red =
         , id = playerIds.red
         , state =
             { position = ( 30.5, 30.5 )
-            , direction = Angle (-pi / 4)
+            , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }
         }
@@ -26,7 +26,7 @@ yellow =
         , id = playerIds.yellow
         , state =
             { position = ( 60.5, 60.5 )
-            , direction = Angle (-pi / 4)
+            , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }
         }
@@ -39,7 +39,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 19.5, 98.5 )
-            , direction = Angle (pi / 4)
+            , direction = Angle (3 * pi / 4)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
+++ b/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
@@ -13,7 +13,7 @@ red =
         , id = playerIds.red
         , state =
             { position = ( 299.5, 302.5 )
-            , direction = Angle (-71 * (2 * pi / 360))
+            , direction = Angle (-71 * (2 * pi / 360) + (pi / 2))
             , holeStatus = Unholy 60000
             }
         }
@@ -26,7 +26,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 319, 269 )
-            , direction = Angle (-123 * (2 * pi / 360))
+            , direction = Angle (-123 * (2 * pi / 360) + (pi / 2))
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -13,7 +13,7 @@ green =
         , id = playerIds.green
         , state =
             { position = ( 108, 100 )
-            , direction = Angle 0
+            , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -14,7 +14,7 @@ greenZombie =
         , id = playerIds.green
         , state =
             { position = ( 32.5, 3.5 )
-            , direction = Angle 0
+            , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
         }

--- a/src/Types/Angle.elm
+++ b/src/Types/Angle.elm
@@ -6,7 +6,7 @@ module Types.Angle exposing
     , sin
     )
 
-{-| Angles are measured in radians.
+{-| Angles are measured in radians. Somewhat unconventionally, 0 is down (not right), to match the original game's internal representation.
 -}
 
 

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -257,7 +257,7 @@ crashingIntoKurveTimingTests =
                                         , id = playerIds.red
                                         , state =
                                             { position = ( 150, y_red )
-                                            , direction = Angle 0
+                                            , direction = Angle (pi / 2)
                                             , holeStatus = Unholy 60000
                                             }
                                         }
@@ -269,7 +269,7 @@ crashingIntoKurveTimingTests =
                                         , id = playerIds.green
                                         , state =
                                             { position = ( 100, 107.5 )
-                                            , direction = Angle 0.02
+                                            , direction = Angle (pi / 2 + 0.02)
                                             , holeStatus = Unholy 60000
                                             }
                                         }

--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -53,21 +53,15 @@ def set_position(player_id: int, x: float, y: float) -> str:
     )
 
 
-def set_direction_raw(player_id: int, direction: float) -> str:
+def set_direction(player_id: int, direction: float) -> str:
     return write_float32(directions_address + player_id * SIZEOF_FLOAT, direction)
 
 
-def set_direction_conventional(player_id: int, conventional_direction: float) -> str:
-    return set_direction_raw(player_id, conventional_direction + math.pi / 2)
-
-
-def set_player_state(
-    player_id: int, x: float, y: float, conventional_direction: float
-) -> str:
+def set_player_state(player_id: int, x: float, y: float, direction: float) -> str:
     return sequence(
         [
             set_position(player_id, x, y),
-            set_direction_conventional(player_id, conventional_direction),
+            set_direction(player_id, direction),
         ],
     )
 
@@ -175,9 +169,9 @@ def prepare_and_get_process_id(process_id_or_path_to_original_game: str) -> str:
 
 scanmem_command: str = scanmem_program(
     [
-        set_player_state(RED, x=200, y=50, conventional_direction=0),
-        set_player_state(YELLOW, x=200, y=100, conventional_direction=0),
-        set_player_state(GREEN, x=200, y=150, conventional_direction=0),
+        set_player_state(RED, x=200, y=50, direction=math.pi / 2),
+        set_player_state(YELLOW, x=200, y=100, direction=math.pi / 2),
+        set_player_state(GREEN, x=200, y=150, direction=math.pi / 2),
     ],
 )
 


### PR DESCRIPTION
As documented in #191, we've recently learned that our internal representation of a Kurve's direction is different from that in the original game. We have directions zeroed around rightwards/east, but the original game has them zeroed around downwards/south.

In order to make it easier to align the observable mechanics of our clone with those of the original game (for example by staging scenarios using `tools/scenario.py` and then creating test cases based on their respective outcomes), I think we should try to align our internal representation with the original game as much as possible.

💡 `git show --color-words='-- .+|cos|sin|def set_direction|conventional|.'`