### PR TITLE
Move test-scenario outcomes to scenario modules

### DIFF
--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -1,5 +1,7 @@
 module TestScenarioHelpers exposing
     ( CumulativeInteraction
+    , RoundEndingInterpretation
+    , RoundOutcome
     , makeUserInteractions
     , makeZombieKurve
     , playerIds
@@ -16,6 +18,7 @@ import Types.Kurve as Kurve exposing (HoleStatus(..), Kurve, UserInteraction(..)
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick as Tick exposing (Tick)
 import Types.TurningState exposing (TurningState)
+import World exposing (DrawingPosition)
 
 
 playerIds :
@@ -101,3 +104,28 @@ tickNumber n =
 
         Just tick ->
             tick
+
+
+{-| A description of when and how a round should end.
+-}
+type alias RoundOutcome =
+    { tickThatShouldEndIt : Tick
+    , howItShouldEnd : RoundEndingInterpretation
+    }
+
+
+type alias RoundEndingInterpretation =
+    { aliveAtTheEnd : List AliveKurve
+    , deadAtTheEnd : List DeadKurve
+    }
+
+
+type alias AliveKurve =
+    { id : PlayerId
+    }
+
+
+type alias DeadKurve =
+    { id : PlayerId
+    , theDrawingPositionItNeverMadeItTo : DrawingPosition
+    }

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -1,7 +1,7 @@
-module TestScenarios.AroundTheWorld exposing (spawnedKurves)
+module TestScenarios.AroundTheWorld exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeUserInteractions, makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeUserInteractions, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
@@ -39,3 +39,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 2011
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 0, topEdge = -1 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoKurveTiming exposing (spawnedKurves)
+module TestScenarios.CrashIntoKurveTiming exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -35,3 +35,17 @@ green =
 spawnedKurves : Float -> List Kurve
 spawnedKurves y_red =
     [ red y_red, green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 226
+    , howItShouldEnd =
+        { aliveAtTheEnd = [ { id = playerIds.red } ]
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 324, topEdge = 101 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoTailEnd90Degrees exposing (spawnedKurves)
+module TestScenarios.CrashIntoTailEnd90Degrees exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -35,3 +35,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ red, green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 8
+    , howItShouldEnd =
+        { aliveAtTheEnd = [ { id = playerIds.red } ]
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 97, topEdge = 101 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoTipOfTailEnd exposing (spawnedKurves)
+module TestScenarios.CrashIntoTipOfTailEnd exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -35,3 +35,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ red, green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 39
+    , howItShouldEnd =
+        { aliveAtTheEnd = [ { id = playerIds.red } ]
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoWallBasic.elm
+++ b/src/TestScenarios/CrashIntoWallBasic.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoWallBasic exposing (spawnedKurves)
+module TestScenarios.CrashIntoWallBasic exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -22,3 +22,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 2
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = -1, topEdge = 99 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoWallBottom exposing (spawnedKurves)
+module TestScenarios.CrashIntoWallBottom exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -22,3 +22,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 2
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 99, topEdge = 478 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoWallExactTiming exposing (spawnedKurves)
+module TestScenarios.CrashIntoWallExactTiming exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -22,3 +22,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 251
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 349, topEdge = -1 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoWallLeft exposing (spawnedKurves)
+module TestScenarios.CrashIntoWallLeft exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -22,3 +22,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 2
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = -1, topEdge = 99 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoWallRight exposing (spawnedKurves)
+module TestScenarios.CrashIntoWallRight exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -22,3 +22,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 2
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CrashIntoWallTop exposing (spawnedKurves)
+module TestScenarios.CrashIntoWallTop exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -22,3 +22,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 2
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 99, topEdge = -1 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CuttingCornersBasic exposing (spawnedKurves)
+module TestScenarios.CuttingCornersBasic exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -35,3 +35,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ red, green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 277
+    , howItShouldEnd =
+        { aliveAtTheEnd = [ { id = playerIds.red } ]
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 295, topEdge = -1 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CuttingCornersPerfectOverpainting exposing (spawnedKurves)
+module TestScenarios.CuttingCornersPerfectOverpainting exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -48,3 +48,20 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ red, green, yellow ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 138
+    , howItShouldEnd =
+        { aliveAtTheEnd = [ { id = playerIds.yellow } ]
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 116, topEdge = -1 }
+              }
+            , { id = playerIds.red
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
+++ b/src/TestScenarios/CuttingCornersThreePixelsRealExample.elm
@@ -1,7 +1,7 @@
-module TestScenarios.CuttingCornersThreePixelsRealExample exposing (spawnedKurves)
+module TestScenarios.CuttingCornersThreePixelsRealExample exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 
@@ -35,3 +35,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ red, green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 40
+    , howItShouldEnd =
+        { aliveAtTheEnd = [ { id = playerIds.red } ]
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 296, topEdge = 301 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -1,9 +1,10 @@
-module TestScenarios.SpeedEffectOnGame exposing (spawnedKurves)
+module TestScenarios.SpeedEffectOnGame exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (RoundOutcome, makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+import Types.Tick exposing (Tick)
 
 
 green : Kurve
@@ -22,3 +23,17 @@ green =
 spawnedKurves : List Kurve
 spawnedKurves =
     [ green ]
+
+
+expectedOutcome : Tick -> RoundOutcome
+expectedOutcome expectedEndTick =
+    { tickThatShouldEndIt = expectedEndTick
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
+              }
+            ]
+        }
+    }

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -1,7 +1,7 @@
-module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (spawnedKurves)
+module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (CumulativeInteraction, makeUserInteractions, makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (CumulativeInteraction, RoundOutcome, makeUserInteractions, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
@@ -46,3 +46,17 @@ makeLap i =
     , ( 414 - 20 * i, TurningRight )
     , ( 45, NotTurning )
     ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 23875
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 372, topEdge = 217 }
+              }
+            ]
+        }
+    }

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -4,7 +4,7 @@ import Config
 import String
 import Test exposing (Test, describe, test)
 import TestHelpers exposing (defaultConfigWithSpeed, expectRoundOutcome)
-import TestScenarioHelpers exposing (playerIds, roundWith, tickNumber)
+import TestScenarioHelpers exposing (roundWith, tickNumber)
 import TestScenarios.AroundTheWorld
 import TestScenarios.CrashIntoKurveTiming
 import TestScenarios.CrashIntoTailEnd90Degrees
@@ -44,31 +44,13 @@ basicTests =
                 roundWith TestScenarios.CrashIntoWallBasic.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 2
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = -1, topEdge = 99 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoWallBasic.expectedOutcome
         , test "Around the world, touching each wall" <|
             \_ ->
                 roundWith TestScenarios.AroundTheWorld.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 2011
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 0, topEdge = -1 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.AroundTheWorld.expectedOutcome
         ]
 
 
@@ -80,31 +62,13 @@ crashingIntoKurveTests =
                 roundWith TestScenarios.CrashIntoTailEnd90Degrees.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 8
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = [ { id = playerIds.red } ]
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 97, topEdge = 101 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoTailEnd90Degrees.expectedOutcome
         , test "Hitting a Kurve's tail end at a 45-degree angle is a crash" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoTipOfTailEnd.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 39
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = [ { id = playerIds.red } ]
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoTipOfTailEnd.expectedOutcome
         ]
 
 
@@ -116,61 +80,25 @@ crashingIntoWallTests =
                 roundWith TestScenarios.CrashIntoWallTop.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 2
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 99, topEdge = -1 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoWallTop.expectedOutcome
         , test "Right wall" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoWallRight.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 2
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoWallRight.expectedOutcome
         , test "Bottom wall" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoWallBottom.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 2
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 99, topEdge = 478 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoWallBottom.expectedOutcome
         , test "Left wall" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoWallLeft.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 2
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = -1, topEdge = 99 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CrashIntoWallLeft.expectedOutcome
         ]
 
 
@@ -221,16 +149,7 @@ crashingIntoWallTimingTest =
             roundWith TestScenarios.CrashIntoWallExactTiming.spawnedKurves
                 |> expectRoundOutcome
                     Config.default
-                    { tickThatShouldEndIt = tickNumber 251
-                    , howItShouldEnd =
-                        { aliveAtTheEnd = []
-                        , deadAtTheEnd =
-                            [ { id = playerIds.green
-                              , theDrawingPositionItNeverMadeItTo = { leftEdge = 349, topEdge = -1 }
-                              }
-                            ]
-                        }
-                    }
+                    TestScenarios.CrashIntoWallExactTiming.expectedOutcome
 
 
 crashingIntoKurveTimingTests : Test
@@ -250,16 +169,7 @@ crashingIntoKurveTimingTests =
                             roundWith (TestScenarios.CrashIntoKurveTiming.spawnedKurves y_red)
                                 |> expectRoundOutcome
                                     Config.default
-                                    { tickThatShouldEndIt = tickNumber 226
-                                    , howItShouldEnd =
-                                        { aliveAtTheEnd = [ { id = playerIds.red } ]
-                                        , deadAtTheEnd =
-                                            [ { id = playerIds.green
-                                              , theDrawingPositionItNeverMadeItTo = { leftEdge = 324, topEdge = 101 }
-                                              }
-                                            ]
-                                        }
-                                    }
+                                    TestScenarios.CrashIntoKurveTiming.expectedOutcome
                         )
                 )
         )
@@ -273,49 +183,19 @@ cuttingCornersTests =
                 roundWith TestScenarios.CuttingCornersBasic.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 277
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = [ { id = playerIds.red } ]
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 295, topEdge = -1 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CuttingCornersBasic.expectedOutcome
         , test "It is possible to paint over three pixels when cutting a corner (real example from original game)" <|
             \_ ->
                 roundWith TestScenarios.CuttingCornersThreePixelsRealExample.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 40
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = [ { id = playerIds.red } ]
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 296, topEdge = 301 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CuttingCornersThreePixelsRealExample.expectedOutcome
         , test "The perfect overpainting (squeezing through a non-existent gap)" <|
             \_ ->
                 roundWith TestScenarios.CuttingCornersPerfectOverpainting.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 138
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = [ { id = playerIds.yellow } ]
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 116, topEdge = -1 }
-                                  }
-                                , { id = playerIds.red
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.CuttingCornersPerfectOverpainting.expectedOutcome
         ]
 
 
@@ -333,16 +213,7 @@ speedTests =
                             roundWith TestScenarios.SpeedEffectOnGame.spawnedKurves
                                 |> expectRoundOutcome
                                     (defaultConfigWithSpeed speed)
-                                    { tickThatShouldEndIt = expectedEndTick
-                                    , howItShouldEnd =
-                                        { aliveAtTheEnd = []
-                                        , deadAtTheEnd =
-                                            [ { id = playerIds.green
-                                              , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
-                                              }
-                                            ]
-                                        }
-                                    }
+                                    (TestScenarios.SpeedEffectOnGame.expectedOutcome expectedEndTick)
                 )
         )
 
@@ -355,14 +226,5 @@ stressTests =
                 roundWith TestScenarios.StressTestRealisticTurtleSurvivalRound.spawnedKurves
                     |> expectRoundOutcome
                         Config.default
-                        { tickThatShouldEndIt = tickNumber 23875
-                        , howItShouldEnd =
-                            { aliveAtTheEnd = []
-                            , deadAtTheEnd =
-                                [ { id = playerIds.green
-                                  , theDrawingPositionItNeverMadeItTo = { leftEdge = 372, topEdge = 217 }
-                                  }
-                                ]
-                            }
-                        }
+                        TestScenarios.StressTestRealisticTurtleSurvivalRound.expectedOutcome
         ]

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -7,35 +7,10 @@ import Config exposing (Config, KurveConfig)
 import Expect
 import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundFromKnownInitialState, reactToTick)
 import Round exposing (Round, RoundInitialState)
-import Types.PlayerId exposing (PlayerId)
+import TestScenarioHelpers exposing (RoundEndingInterpretation, RoundOutcome)
 import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
-import World exposing (DrawingPosition)
-
-
-{-| A description of when and how a round should end.
--}
-type alias RoundOutcome =
-    { tickThatShouldEndIt : Tick
-    , howItShouldEnd : RoundEndingInterpretation
-    }
-
-
-type alias RoundEndingInterpretation =
-    { aliveAtTheEnd : List AliveKurve
-    , deadAtTheEnd : List DeadKurve
-    }
-
-
-type alias AliveKurve =
-    { id : PlayerId
-    }
-
-
-type alias DeadKurve =
-    { id : PlayerId
-    , theDrawingPositionItNeverMadeItTo : DrawingPosition
-    }
+import World
 
 
 expectRoundOutcome : Config -> RoundOutcome -> RoundInitialState -> Expect.Expectation


### PR DESCRIPTION
Now that all test scenarios have been moved to `TestScenarios` modules (see #181 and #194), it's time to move the expected outcomes as well, so that each scenario and its expected outcome can more easily be viewed together.

The changes follow the same pattern throughout the test suite, save for these exceptions:

  * `RoundOutcome` is moved to the `TestScenarioHelpers` so that it can be used in `TestScenarios` modules.
  * Unlike all other existing test scenarios, the expected outcome of the `SpeedEffectOnGame` scenario depends on the configured speed, so its `expectedOutcome` has type `Tick -> RoundOutcome` instead of `RoundOutcome`.

💡 `git show --color-moved --color-moved-ws=allow-indentation-change`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>