### PR TITLE
Fix incorrect Kurve order in test case

### DIFF
--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -47,7 +47,7 @@ green =
 
 spawnedKurves : List Kurve
 spawnedKurves =
-    [ red, green, yellow ]
+    [ red, yellow, green ]
 
 
 expectedOutcome : RoundOutcome


### PR DESCRIPTION
The order in the original game is unambiguous:

  0. 🟥 Red
  1. 🟨 Yellow
  2. 🟧 Orange
  3. 🟩 Green
  4. 🟪 Pink
  5. 🟦 Blue

Since the players are updated in that order in the original game, their order in the test-case scenario may actually be significant.