### PR TITLE
Improve perfect-overpainting test-case scenario

### DIFF
--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -67,10 +67,13 @@ expectedOutcome : RoundOutcome
 expectedOutcome =
     { tickThatShouldEndIt = tickNumber 138
     , howItShouldEnd =
-        { aliveAtTheEnd = [ { id = playerIds.yellow } ]
+        { aliveAtTheEnd = [ { id = playerIds.orange } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
               , theDrawingPositionItNeverMadeItTo = { leftEdge = 116, topEdge = -1 }
+              }
+            , { id = playerIds.yellow
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 58, topEdge = 58 }
               }
             , { id = playerIds.red
               , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }


### PR DESCRIPTION
## Problem

The scenario in question is problematic due to a subtle difference between test-case scenarios and scenarios staged in the original game.

Take for example a test-case scenario with a Kurve with `position = ( 1.5, 1.5 )` and `direction = Angle (pi / 2)`. One would expect it to start at the very top of the playing field, leaving no empty space between itself and the left wall. Ad-hoc visualization via the hack in #144 confirms that:

    🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛⬛
    🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛⬛
    🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛

(One square = one pixel.)

One would expect that an equivalent scenario in the original game could be staged like this in `tools/scenario.py`:

```python
set_player_state(RED, x=0, y=0, direction=math.pi / 2),
```

(The reason it's `x=0, y=0` and not `x=1.5, y=1.5` is that the original game expresses Kurve positions as "where the top left corner of the head is", while we express them as "where the _center_ of the head is"; see #191.)

Surprisingly, when that scenario is staged, it does leave a thin empty space between the Kurve and the left wall:

    ⬛🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛⬛
    ⬛🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛⬛
    ⬛🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛

The reason why that happens is simply that the Kurve has never _really_ been at (0, 0). It was at some random location and had drawn its head there; then it was violently teleported to (0, 0), but nothing was drawn there; then the game, thinking the Kurve _had_ been at (0, 0), moved it to something like (1, 0) and drew its "next head" there.

**In general, when staging a scenario in the original game, one must think of the specified positions as where the Kurves should _come from_, not where they should _spawn_.**

## Solution

This PR modifies the test-case scenario in question so that Red and Yellow collide head-on instead of Red crashing into Yellow's tail, making it easy to accurately stage the scenario in the original game:

```python
set_player_state(RED, x=29, y=29, direction=pi / 4),
set_player_state(YELLOW, x=87, y=87, direction=5 * pi / 4),
set_player_state(ORANGE, x=99, y=399, direction=pi / 2),
set_player_state(GREEN, x=18, y=98, direction=3 * pi / 4),
```

(One might wonder why its `x=18, y=98` and not `x=18, y=97`, as one would expect the original-game counterpart to `position = ( 19.5, 98.5 )` to be. The reason is probably that we use `round` in `edgeOfSquare`, where `truncate` would better match the original game's implementation. Future improvement planned.)

Orange is added because otherwise there's only one player (Green) alive after Red and Yellow have crashed, ending the round immediately.

### Why not modify the scenario script?

We considered modifying the scenario script so that it would negate the teleportation off-by-one error by computing where the Kurve would need to be for _the game_ to move it to the specified position (and therefore draw a head there). In essence, we would compute, based on the specified position and angle, where the Kurve would have been one tick before it got to that position.

However, we decided against that because the game would not necessarily always move the Kurve to exactly the specified position due to floating-point rounding errors. For example (in Node):

    > 123.456 - Math.cos(263) + Math.cos(263)
    123.45599999999999

💡 `git show --color-words='yellow|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>