### PR TITLE
DRY up scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -185,7 +185,6 @@ def prepare_and_get_process_id(process_id_or_path_to_original_game: str) -> str:
         time.sleep(2)
         press_key("space")
         time.sleep(0.5)
-        # Players need to join here in order to be able to participate in the staged scenario.
         for player_id in SCENARIO.keys():
             JOIN_PLAYER[player_id]()
         time.sleep(0.5)


### PR DESCRIPTION
Staging a scenario in the scenario script today is quite tedious and error-prone. In addition to describing the scenario using `set_player_state` calls, one must

  * ensure that each participating player has a corresponding `KEY_*_LEFT` constant;
  * make sure that all participating players actually press their Left key to join the game; and
  * adjust the `time.sleep` command that waits while the Kurves are spawning to match the number of participating players (traditionally 𝑛 + 0.1 for 𝑛 players).

As suggested by @lydell, this PR DRYes all of that up so that the script takes care of the dirty work.

Note that there's currently no way to make a player participate in the game but not in the scenario, but that can easily be changed should the need arise.

## `KP_Divide`

In the original game, Pink's Left key is `/` on the numpad. To figure out how to express it in a way xdotool would understand, I did `man xdotool` and found this:

> Generally, any valid X Keysym string will work.

So I googled `x keysym` and the top result was [X11.keysyms] from Cambridge University, which contained this line:

    #define XK_KP_Divide                     0xffaf

[X11.keysyms]: https://www.cl.cam.ac.uk/~mgk25/ucs/keysymdef.h