### PR TITLE
Remove unused parameter in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -140,7 +140,7 @@ def check_address_space_layout_randomization() -> None:
         )
 
 
-def find_and_focus_dosbox(timeout: float = 15.0) -> str | None:
+def find_and_focus_dosbox() -> str | None:
     res = subprocess.run(
         [
             "xdotool",


### PR DESCRIPTION
Apparently Ruff didn't report that it became unused in #204. -.-

💡 `git show --color-words=.`