### PR TITLE
Rename `wid` variable in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -154,10 +154,10 @@ def find_and_focus_dosbox() -> str:
         text=True,
     )
     if res.returncode == 0 and res.stdout.strip():
-        wid: str = res.stdout.strip().splitlines()[-1]  # (most recent window ID)
-        subprocess.run(["xdotool", "windowactivate", "--sync", wid])
-        subprocess.run(["xdotool", "windowfocus", wid])
-        return wid
+        window_id: str = res.stdout.strip().splitlines()[-1]  # (most recent window ID)
+        subprocess.run(["xdotool", "windowactivate", "--sync", window_id])
+        subprocess.run(["xdotool", "windowfocus", window_id])
+        return window_id
     print("❌ Couldn't find the DOSBox window.")
     exit(1)
 


### PR DESCRIPTION
I think `window_id` is clearer, and we used it elsewhere until #206.

💡 `git show --color-words='wid|.'`