### PR TITLE
Enable dry-running scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -225,7 +225,7 @@ def prepare_and_get_process_id(path_to_original_game: str) -> str:
 
 
 def main() -> None:
-    is_dry_run = os.environ.get(ENV_VAR_DRY_RUN) == "true"
+    is_dry_run = bool(os.environ.get(ENV_VAR_DRY_RUN))
 
     subprocess.run(
         ["sudo", "true"]


### PR DESCRIPTION
When modifying the scenario script, I often run it to see what it _would_ do (e.g. what scanmem program it would run), but I don't want it to actually do it. This PR simplifies that.

## How to _dry-run_ the scenario script as of this PR

    DRY_RUN=true ./tools/scenario.py docs/original-game/ZATACKA.EXE 7fffd8010ff6 tools/dosbox-linux.conf