### PR TITLE
Represent process ID as int in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -195,7 +195,7 @@ def press_key(key: str) -> None:
 
 def launch_original_game(
     path_to_original_game: str, participating_players: list[PlayerId]
-) -> str:
+) -> int:
     print(f"🚀 Launching original game at {path_to_original_game} …")
 
     proc = subprocess.Popen(
@@ -223,7 +223,7 @@ def launch_original_game(
     press_key("space")
     time.sleep(len(participating_players) + 0.1)
 
-    return str(proc.pid)
+    return proc.pid
 
 
 def main() -> None:
@@ -266,10 +266,10 @@ def main() -> None:
         )
         return
 
-    process_id: str = launch_original_game(path_to_original_game, participating_players)
+    process_id: int = launch_original_game(path_to_original_game, participating_players)
 
     subprocess.run(
-        ["sudo", "scanmem", process_id, "--errexit", "--command", scanmem_program],
+        ["sudo", "scanmem", str(process_id), "--errexit", "--command", scanmem_program],
     )
 
 


### PR DESCRIPTION
Its being represented as a string is a remnant from when it could come not only from `subprocess.Popen`, but also from a command-line argument. That ceased being the case in #211.

💡 `git show --color-words='str|.'`