### PR TITLE
Launch original game and stage scenario together

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -199,9 +199,11 @@ def press_key(key: str) -> None:
     subprocess.run(["xdotool", "key", key])
 
 
-def launch_original_game(
-    path_to_original_game: str, participating_players: list[PlayerId]
-) -> int:
+def launch_original_game_and_stage_scenario(
+    path_to_original_game: str,
+    participating_players: list[PlayerId],
+    scanmem_program: str,
+) -> None:
     print(f"🚀 Launching original game at {path_to_original_game} …")
 
     proc = subprocess.Popen(
@@ -229,7 +231,7 @@ def launch_original_game(
     press_key("space")
     time.sleep(len(participating_players) + 0.1)
 
-    return proc.pid
+    stage_scenario(proc.pid, scanmem_program)
 
 
 def main() -> None:
@@ -272,9 +274,11 @@ def main() -> None:
         )
         return
 
-    process_id: int = launch_original_game(path_to_original_game, participating_players)
-
-    stage_scenario(process_id, scanmem_program)
+    launch_original_game_and_stage_scenario(
+        path_to_original_game,
+        participating_players,
+        scanmem_program,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I think this makes the overall flow slightly more readable. For example, it becomes more obvious that `time.sleep(len(participating_players) + 0.1)` is the last thing that happens before the scenario is staged.