### PR TITLE
Dry-run scenario script in CI

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -28,8 +28,9 @@ jobs:
           src: ./tools
       - name: Check Python lint
         run: ruff check ./tools
-      - name: Check scenario script
-        run: |
-          sudo apt-get install --yes xdotool
-          DRY_RUN=true ./tools/scenario.py docs/original-game/ZATACKA.EXE 0x7fffd8010ff6 tools/dosbox-linux.conf
-          DRY_RUN=true ./tools/scenario.py docs/original-game/ZATACKA.EXE 0x7fffc1c65ff6 tools/dosbox-wsl.conf
+      - name: Install xdotool
+        run: sudo apt-get install --yes xdotool
+      - name: Dry-run scenario script (Linux)
+        run: DRY_RUN=true ./tools/scenario.py docs/original-game/ZATACKA.EXE 0x7fffd8010ff6 tools/dosbox-linux.conf
+      - name: Dry-run scenario script (WSL)
+        run: DRY_RUN=true ./tools/scenario.py docs/original-game/ZATACKA.EXE 0x7fffc1c65ff6 tools/dosbox-wsl.conf


### PR DESCRIPTION
In addition to minimizing the risk of accidentally breaking it, this makes it explicit how it's supposed to work, without relying on the Git history.

## Why not in Dockerfile?

The reason we only do it in CI and not in the Dockerfile (which is also built in CI) is that the Dockerfile doesn't have Python installed and therefore cannot run the scenario script.

## xdotool

Without installing xdotool in CI, `check_that_dosbox_is_not_already_open` fails like this:

    FileNotFoundError: [Errno 2] No such file or directory: 'xdotool'

## Base addresses

The base addresses (`0x7fffd8010ff6` and `0x7fffc1c65ff6`) are the ones I use on my Ubuntu laptop and in WSL on my main PC, respectively. See `git log --grep '7fffd8010ff6|7fffc1c65ff6' -E`, #93 and #180 for more information about them.

💡 `git show --ignore-space-change`