### PR TITLE
Don't audit npm dependencies in CI

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         working-directory: elm-version/
         run: |
-          npm ci --omit optional
+          npm ci --omit optional --no-audit
           npm run build
 
       - name: Checkout legacy JavaScript version


### PR DESCRIPTION
As [suggested] by @lydell:

> I usually skip auditing in CI […], since nobody looks at that in CI (it just wastes a tiny bit of time in CI).

[suggested]: https://github.com/SimonAlling/kurve/pull/223#discussion_r2529970552

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>