### PR TITLE
Refactor `compileCore` using `List.foldr`

### DIFF
--- a/tools/ScenarioInOriginalGame/Scanmem.elm
+++ b/tools/ScenarioInOriginalGame/Scanmem.elm
@@ -24,15 +24,16 @@ compile baseAddress core =
 
 compileCore : AbsoluteAddress -> List ModMemCmd -> List ScanmemCommand
 compileCore baseAddress =
-    List.map
-        (\(ModifyMemory relativeAddress newValue) ->
+    List.foldr
+        (\(ModifyMemory relativeAddress newValue) compiledContinuation ->
             let
                 serializedAddress : String
                 serializedAddress =
                     resolveAddress baseAddress relativeAddress |> serializeAddress
             in
-            "write float32 " ++ serializedAddress ++ " " ++ String.fromFloat newValue
+            ("write float32 " ++ serializedAddress ++ " " ++ String.fromFloat newValue) :: compiledContinuation
         )
+        []
 
 
 setupCommands : List ScanmemCommand


### PR DESCRIPTION
As mentioned in #223, the plan is to replace scanmem with gdb (#231). The gdb programs we'll need to produce will have a nested structure, so it won't be possible – or at least not easy – to implement `compileCore` using `List.map`. This PR therefore replaces `map` with `foldr` as a preparation step for #231.