### PR TITLE
Only print compiled scenario when dry-running

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -226,18 +226,17 @@ def main() -> None:
 
     scanmem_program: str = compiled_scenario["scanmemProgram"]
 
-    print("BEGIN scanmem program")
-    print()
-    print(scanmem_program)
-    print()
-    print("END scanmem program")
-    print()
-
     participating_players = [
         PlayerId(i) for i in compiled_scenario["participatingPlayersById"]
     ]
 
     if is_dry_run:
+        print("BEGIN scanmem program")
+        print()
+        print(scanmem_program)
+        print()
+        print("END scanmem program")
+        print()
         print(
             f"💡 Environment variable {ENV_VAR_DRY_RUN} specified. Not launching original game."
         )


### PR DESCRIPTION
The compiled scenario makes important warnings (e.g. the ASLR one) less visible, and is almost never interesting when not dry-running. Whenever there is reason to inspect a staged scenario, the script can simply be run again with `DRY_RUN=true`.

💡 `git show --color-moved --color-moved-ws=allow-indentation-change`