### PR TITLE
Add support for Blue in scenario script

### DIFF
--- a/tools/scenario.py
+++ b/tools/scenario.py
@@ -246,6 +246,11 @@ def main() -> None:
         )
         return
 
+    if PlayerId.BLUE in participating_players:
+        print(
+            "💡 Blue is participating; make sure to keep the cursor within the DOSBox window."
+        )
+
     GDB_PROGRAM_FILE = ".compiled-scenario.gdb"
     with open(GDB_PROGRAM_FILE, "+w") as f:
         print(f"📝 Writing {GDB_PROGRAM_FILE} …")


### PR DESCRIPTION
Up until now, we haven't been able to automate a scenario including Blue, because we haven't known how to click in the DOSBox window to make Blue join the game. That limitation became explicit in #203 and was acknowledged again in #223.

## Limitations

  * The mouse cursor must be inside the DOSBox window; otherwise DOSBox seems to crash when Blue tries to join (in WSL and Ubuntu alike).
  * It doesn't seem to be completely stable in WSL; Blue sometimes fails to join.

## Implementation details

### Why `lambda: click_mouse_button()`?

One might think that `click_mouse_button` would be equivalent, but Ruff reports this error:

    F821 Undefined name `click_mouse_button`

And the scenario script indeed fails like this at run time:

    NameError: name 'click_mouse_button' is not defined

Moving `click_mouse_button` to before `JOIN_PLAYER` would make it work, but I think `click_mouse_button` belongs next to `press_key`.

### Why not `xdotool click`?

`man xdotool` describes the `click` command like this:

> Send a click, that is, a mousedown followed by mouseup for the given button with a short delay between the two (currently 12ms).

But to my surprise, `click` doesn't work, while `mousedown` followed by `mouseup` does.

💡 `git show --color-words='\w+|.'`