### PR TITLE
Remove extra space below BGI 8 × 8 letters

### DIFF
--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -13,6 +13,10 @@ html, body {
     height: 100%;
 }
 
+p {
+    line-height: 0; // Prevents extra "padding" below the actual letters (which are effectively 8 × 8 bitmap images).
+}
+
 body {
     background-color: black;
     overflow: hidden;


### PR DESCRIPTION
The "Press Space to continue" text (shown when the game is paused due to loss of focus) isn't perfectly centered vertically: the distance from the top of the canvas to the top of the "P" is 230 pixels, but the distance from the bottom of the canvas to the bottom of the "p" is 234 pixels. This PR fixes that, and hopefully makes our "text" (which really consists of 8 × 8 bitmap images) more predictable in general.