### PR TITLE
Split long import lines

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -12,13 +12,37 @@ import GUI.Lobby exposing (lobby)
 import GUI.Scoreboard exposing (scoreboard)
 import GUI.SplashScreen exposing (splashScreen)
 import GUI.TextOverlay exposing (textOverlay)
-import Game exposing (ActiveGameState(..), GameState(..), MidRoundState, MidRoundStateVariant(..), Paused(..), SpawnState, firstUpdateTick, modifyMidRoundState, modifyRound, prepareLiveRound, prepareReplayRound, recordUserInteraction, tickResultToGameState)
+import Game
+    exposing
+        ( ActiveGameState(..)
+        , GameState(..)
+        , MidRoundState
+        , MidRoundStateVariant(..)
+        , Paused(..)
+        , SpawnState
+        , firstUpdateTick
+        , modifyMidRoundState
+        , modifyRound
+        , prepareLiveRound
+        , prepareReplayRound
+        , recordUserInteraction
+        , tickResultToGameState
+        )
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
 import Input exposing (Button(..), ButtonDirection(..), inputSubscriptions, updatePressedButtons)
 import MainLoop
 import Menu exposing (MenuState(..))
-import Players exposing (AllPlayers, atLeastOneIsParticipating, everyoneLeaves, handlePlayerJoiningOrLeaving, includeResultsFrom, initialPlayers, participating)
+import Players
+    exposing
+        ( AllPlayers
+        , atLeastOneIsParticipating
+        , everyoneLeaves
+        , handlePlayerJoiningOrLeaving
+        , includeResultsFrom
+        , initialPlayers
+        , participating
+        )
 import Random
 import Round exposing (Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -5,7 +5,14 @@ module TestHelpers exposing
 
 import Config exposing (Config, KurveConfig)
 import Expect
-import Game exposing (MidRoundState, MidRoundStateVariant(..), TickResult(..), prepareRoundFromKnownInitialState, reactToTick)
+import Game
+    exposing
+        ( MidRoundState
+        , MidRoundStateVariant(..)
+        , TickResult(..)
+        , prepareRoundFromKnownInitialState
+        , reactToTick
+        )
 import Round exposing (Round, RoundInitialState)
 import TestScenarioHelpers exposing (RoundEndingInterpretation, RoundOutcome)
 import Types.Speed exposing (Speed)


### PR DESCRIPTION
Very long import lines make code and diffs harder to read. I used the following command to find import lines longer than 100 characters, courtesy of ChatGPT:

```bash
for f in $(git ls-files ':*.elm'); do
  awk '/^import/ && length($0) > 100 { print FILENAME ": " $0 }' $f
done
```

Then I let `elm-format` split those that weren't in `TestScenarios` modules, because I didn't want to jump into the rabbit hole of considering whether all `TestScenarios` modules should be modified then.

We should arguably enforce this with some automated rule or something, but I think this is an improvement regardless.

💡 `git show --word-diff-regex=.`