### PR TITLE
Rename MidRoundStateVariant to LiveOrReplay

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,8 +1,8 @@
 module Game exposing
     ( ActiveGameState(..)
     , GameState(..)
+    , LiveOrReplay(..)
     , MidRoundState
-    , MidRoundStateVariant(..)
     , Paused(..)
     , SpawnState
     , TickResult(..)
@@ -87,10 +87,10 @@ modifyMidRoundState f gameState =
 
 
 type alias MidRoundState =
-    ( MidRoundStateVariant, Round )
+    ( LiveOrReplay, Round )
 
 
-type MidRoundStateVariant
+type LiveOrReplay
     = Live
     | Replay
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -16,8 +16,8 @@ import Game
     exposing
         ( ActiveGameState(..)
         , GameState(..)
+        , LiveOrReplay(..)
         , MidRoundState
-        , MidRoundStateVariant(..)
         , Paused(..)
         , SpawnState
         , firstUpdateTick

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -7,8 +7,8 @@ import Config exposing (Config, KurveConfig)
 import Expect
 import Game
     exposing
-        ( MidRoundState
-        , MidRoundStateVariant(..)
+        ( LiveOrReplay(..)
+        , MidRoundState
         , TickResult(..)
         , prepareRoundFromKnownInitialState
         , reactToTick


### PR DESCRIPTION
`MidRoundStateVariant` says almost nothing about what it really means. `LiveOrReplay` is much more self-explanatory.

💡 `git show --color-words='\w+|.'`