### PR TITLE
Rename Paused type to PausedOrNot

### DIFF
--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -2,7 +2,7 @@ module GUI.TextOverlay exposing (textOverlay)
 
 import Color
 import GUI.Text
-import Game exposing (GameState(..), Paused(..))
+import Game exposing (GameState(..), PausedOrNot(..))
 import Html exposing (Html, div, p)
 import Html.Attributes as Attr
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -3,7 +3,7 @@ module Game exposing
     , GameState(..)
     , LiveOrReplay(..)
     , MidRoundState
-    , Paused(..)
+    , PausedOrNot(..)
     , SpawnState
     , TickResult(..)
     , firstUpdateTick
@@ -41,11 +41,11 @@ import World exposing (DrawingPosition, Pixel, Position, distanceToTicks)
 
 
 type GameState
-    = Active Paused ActiveGameState
+    = Active PausedOrNot ActiveGameState
     | RoundOver Round Dialog.State
 
 
-type Paused
+type PausedOrNot
     = Paused
     | NotPaused
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -18,7 +18,7 @@ import Game
         , GameState(..)
         , LiveOrReplay(..)
         , MidRoundState
-        , Paused(..)
+        , PausedOrNot(..)
         , SpawnState
         , firstUpdateTick
         , modifyMidRoundState


### PR DESCRIPTION
I find it a bit confusing that `Paused` is both a type and a data constructor for that type, and I find it weird that `NotPaused` is a `Paused`. The type–value ambiguity also affects searchability negatively; see `git grep '\bPaused\b'`.

💡 `git show --color-words=.`