### PR TITLE
Don't use default case in TextOverlay.content

### DIFF
--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -22,7 +22,10 @@ content gameState =
         Active _ Paused _ ->
             [ pressSpaceToContinue ]
 
-        _ ->
+        Active _ NotPaused _ ->
+            []
+
+        RoundOver _ _ ->
             []
 
 


### PR DESCRIPTION
Default cases (`_ -> …`) are landmines, as they prevent the compiler from pointing out locations where a decision might be required after adding a data constructor. They also tend to make the intention less explicit in general. There are definitely contexts where a default case makes a lot of sense, but I don't think this is one of them.