### PR TITLE
Enable skipping ahead in a replay

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -45,6 +45,9 @@ default =
     , game =
         { isGameOver = defaultGameOverCondition
         }
+    , replay =
+        { skipStepInMs = 5000
+        }
     }
 
 
@@ -73,6 +76,7 @@ type alias Config =
     , spawn : SpawnConfig
     , world : WorldConfig
     , game : GameConfig
+    , replay : ReplayConfig
     }
 
 
@@ -102,6 +106,11 @@ type alias WorldConfig =
 
 type alias GameConfig =
     { isGameOver : ParticipatingPlayers -> Bool
+    }
+
+
+type alias ReplayConfig =
+    { skipStepInMs : Int
     }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -297,7 +297,7 @@ update msg ({ config, pressedButtons } as model) =
                                 Moving leftoverTimeFromPreviousFrame lastTick midRoundState ->
                                     let
                                         ( tickResult, cmd ) =
-                                            MainLoop.consumeAnimationFrame config replaySkipStepInMs leftoverTimeFromPreviousFrame lastTick midRoundState
+                                            MainLoop.consumeAnimationFrame config (toFloat config.replay.skipStepInMs) leftoverTimeFromPreviousFrame lastTick midRoundState
                                     in
                                     ( { model | appState = InGame (tickResultToGameState Replay tickResult) }
                                     , cmd
@@ -336,11 +336,6 @@ update msg ({ config, pressedButtons } as model) =
                 _ ->
                     -- Not expected to ever happen.
                     ( model, Cmd.none )
-
-
-replaySkipStepInMs : FrameTime
-replaySkipStepInMs =
-    5000
 
 
 gameOver : Random.Seed -> Model -> ( Model, Cmd msg )


### PR DESCRIPTION
It can be extremely boring to sit around waiting for a replay to play out in real time. This PR makes it possible to fast-forward 5 seconds at a time using the right arrow key, similarly to how media players typically work.

The implementation is literally just the `AnimationFrame` branch with `delta` replaced by 5000 milliseconds.

## Limitations

  * Going _back_ is much harder to implement, so that's not included here.
  * Skipping during spawning isn't enabled here, but hopefully soon will be.