### PR TITLE
Refactor replay-control input handling

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -284,21 +284,19 @@ update msg ({ config, pressedButtons } as model) =
                         _ ->
                             ( handleUserInteraction Down button model, Cmd.none )
 
-                InGame (Active liveOrReplay NotPaused s) ->
-                    case liveOrReplay of
-                        Live ->
+                InGame (Active Live NotPaused _) ->
+                    ( handleUserInteraction Down button model, Cmd.none )
+
+                InGame (Active Replay NotPaused s) ->
+                    case button of
+                        Key "KeyR" ->
+                            startRound Replay model <| prepareReplayRound (initialStateForReplaying (getActiveRound s))
+
+                        Key "Space" ->
+                            ( { model | appState = InGame (Active Replay Paused s) }, Cmd.none )
+
+                        _ ->
                             ( handleUserInteraction Down button model, Cmd.none )
-
-                        Replay ->
-                            case button of
-                                Key "KeyR" ->
-                                    startRound Replay model <| prepareReplayRound (initialStateForReplaying (getActiveRound s))
-
-                                Key "Space" ->
-                                    ( { model | appState = InGame (Active liveOrReplay Paused s) }, Cmd.none )
-
-                                _ ->
-                                    ( handleUserInteraction Down button model, Cmd.none )
 
                 InMenu GameOver seed ->
                     case button of


### PR DESCRIPTION
While working on #252, I realized that the structure of the `InGame (Active liveOrReplay NotPaused s)` branch felt backwards. It defines, for each button, what that button does in a live round and what it does when replaying. I think it's much more natural to define, for each mode (live/replay), which buttons do something in that mode.

As the diff shows, the `Live` branches really only contain no-op code, so the `InGame (Active Live NotPaused _)` branch that effectively replaces them just contains our default key handling. That has the following minor consequences:

  * It becomes technically possible to use Space and/or R to control a player. However, I don't think anyone will ever want to do that anyway, given that Space and R still have their special meanings when replaying and when a round is over.

  * We lose the comment explaining why pausing a live round is not allowed, but I think that's more of a business-logic matter anyway. That is, it's not something that will ever be added to the `InGame (Active Live NotPaused _)` branch _by accident_.

💡 `git show --color-words='InGame .+Live.+|\w+|.'`