### PR TITLE
Make reactToTick Cmd-free

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (bodyDrawingCmd, clearEverything, drawSpawnIfAndOnlyIf, headDrawingCmd)
+port module Canvas exposing (WhatToDraw, clearEverything, drawSpawnIfAndOnlyIf, drawingCmd)
 
 import Color exposing (Color)
 import Config exposing (WorldConfig)
@@ -14,6 +14,20 @@ port clear : { x : Int, y : Int, width : Int, height : Int } -> Cmd msg
 
 
 port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
+
+
+type alias WhatToDraw =
+    { headDrawing : List Kurve
+    , bodyDrawing : List ( Color, DrawingPosition )
+    }
+
+
+drawingCmd : WhatToDraw -> Cmd msg
+drawingCmd whatToDraw =
+    [ headDrawingCmd whatToDraw.headDrawing
+    , bodyDrawingCmd whatToDraw.bodyDrawing
+    ]
+        |> Cmd.batch
 
 
 bodyDrawingCmd : List ( Color, DrawingPosition ) -> Cmd msg

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -17,7 +17,7 @@ module Game exposing
     , tickResultToGameState
     )
 
-import Canvas exposing (bodyDrawingCmd, headDrawingCmd)
+import Canvas exposing (WhatToDraw)
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
 import Dialog
@@ -145,7 +145,7 @@ prepareRoundFromKnownInitialState initialState =
     round
 
 
-reactToTick : Config -> Tick -> Round -> ( TickResult Round, Cmd msg )
+reactToTick : Config -> Tick -> Round -> ( TickResult Round, WhatToDraw )
 reactToTick config tick currentRound =
     let
         ( newKurvesGenerator, newOccupiedPixels, newColoredDrawingPositions ) =
@@ -180,10 +180,9 @@ reactToTick config tick currentRound =
                 RoundKeepsGoing newCurrentRound
     in
     ( tickResult
-    , [ headDrawingCmd newKurves.alive
-      , bodyDrawingCmd newColoredDrawingPositions
-      ]
-        |> Cmd.batch
+    , { headDrawing = newKurves.alive
+      , bodyDrawing = newColoredDrawingPositions
+      }
     )
 
 

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -7,6 +7,7 @@ module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
 
 -}
 
+import Canvas exposing (drawingCmd)
 import Config exposing (Config)
 import Game exposing (TickResult(..))
 import Round exposing (Round)
@@ -45,12 +46,12 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                     incrementedTick =
                         Tick.succ lastTickReactedTo
 
-                    ( tickResult, cmdForThisTick ) =
+                    ( tickResult, whatToDrawForThisTick ) =
                         Game.reactToTick config incrementedTick midRoundStateSoFar
 
                     newCmd : Cmd msg
                     newCmd =
-                        Cmd.batch [ cmdSoFar, cmdForThisTick ]
+                        Cmd.batch [ cmdSoFar, whatToDrawForThisTick |> drawingCmd ]
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->


### PR DESCRIPTION
I don't like that we have so much `Cmd` sprinkled across the code base. `Cmd`-returning functions are harder to test, the order of batched commands is not specified, etc. This PR makes `reactToTick` return a description of what do draw, which we can then derive a `Cmd` from. That is, `reactToTick` doesn't use `headDrawingCmd` or `bodyDrawingCmd` anymore, and they are therefore unexposed in the `Canvas` module.

💡 `git show --color-words='drawingCmd|[A-Z]?[a-z]+|.'`