### PR TITLE
Make consumeAnimationFrame Cmd-free (fixes drawing bug)

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (WhatToDraw, clearEverything, drawSpawnIfAndOnlyIf, drawingCmd)
+port module Canvas exposing (WhatToDraw, clearEverything, drawSpawnIfAndOnlyIf, drawingCmd, mergeWhatToDraw, nothingToDraw)
 
 import Color exposing (Color)
 import Config exposing (WorldConfig)
@@ -19,6 +19,20 @@ port renderOverlay : List { position : DrawingPosition, thickness : Int, color :
 type alias WhatToDraw =
     { headDrawing : List Kurve
     , bodyDrawing : List ( Color, DrawingPosition )
+    }
+
+
+nothingToDraw : WhatToDraw
+nothingToDraw =
+    { headDrawing = []
+    , bodyDrawing = []
+    }
+
+
+mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw
+mergeWhatToDraw whatFirst whatThen =
+    { headDrawing = whatThen.headDrawing
+    , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
     }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ port module Main exposing (Model, Msg(..), main)
 import App exposing (AppState(..), modifyGameState)
 import Browser
 import Browser.Events
-import Canvas exposing (clearEverything, drawSpawnIfAndOnlyIf)
+import Canvas exposing (clearEverything, drawSpawnIfAndOnlyIf, drawingCmd)
 import Config exposing (Config)
 import Dialog
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
@@ -165,11 +165,11 @@ update msg ({ config, pressedButtons } as model) =
 
         AnimationFrame liveOrReplay { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
-                ( tickResult, cmd ) =
+                ( tickResult, whatToDraw ) =
                     MainLoop.consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState
             in
             ( { model | appState = InGame (tickResultToGameState liveOrReplay tickResult) }
-            , cmd
+            , drawingCmd whatToDraw
             )
 
         ButtonUsed Down button ->
@@ -296,11 +296,11 @@ update msg ({ config, pressedButtons } as model) =
 
                                 Moving leftoverTimeFromPreviousFrame lastTick midRoundState ->
                                     let
-                                        ( tickResult, cmd ) =
+                                        ( tickResult, whatToDraw ) =
                                             MainLoop.consumeAnimationFrame config (toFloat config.replay.skipStepInMs) leftoverTimeFromPreviousFrame lastTick midRoundState
                                     in
                                     ( { model | appState = InGame (tickResultToGameState Replay tickResult) }
-                                    , cmd
+                                    , drawingCmd whatToDraw
                                     )
 
                         Key "KeyR" ->


### PR DESCRIPTION
This PR builds further upon #254 by making `consumeAnimationFrame` not return a `Cmd` anymore. `Cmd` is thereby only used in the `Main` and `Canvas` modules.

## About `mergeWhatToDraw`

There are two things probably worth mentioning about it.

### Unnecessary?

It may seem like `mergeWhatToDraw` never builds anything that's not equal to its second argument. Try for example this:

```diff
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -32,4 +32,8 @@ nothingToDraw =
 mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw
 mergeWhatToDraw whatFirst whatThen =
+    let
+        _ =
+            Debug.log "whatFirst" whatFirst
+    in
     { headDrawing = whatThen.headDrawing
     , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
```

It may appear like `whatFirst` always just contains empty lists. But that's because `recurse` is only called once per `consumeAnimationFrame` call, unless the tickrate is close to or above the refresh rate. And in the first `recurse` call (the non-recursive one), the first argument to `mergeWhatToDraw` is hardcoded to `nothingToDraw`.

### What about `whatFirst.headDrawing`?

One might find it surprising that `whatFirst.headDrawing` is discarded altogether. The reason is that otherwise we would draw more than one head per Kurve when the tickrate is above the refresh rate.

**As it turns out, this actually fixes a rendering bug.** We currently never draw more than one head, but we may draw the _wrong_ head if the tickrate is close to or above the refresh rate.

#### Without this PR

Here's how to confirm that we only draw one head:

  1. Replace the definition of `bodyDrawingCmd` with `always Cmd.none`.
  2. In Firefox's `about:config`, set `layout.frame_rate` to 10.
  3. Start a round with one Kurve.

Without the changes in this PR, that results, just as one would expect, in very choppy graphics and the body of the Kurve being invisible.

Note in particular that only a single head is visible at any given moment. The easiest way to confirm that is to replay a round and pause it. There will be a single 3 × 3 square representing the head of the Kurve.

**That head, however, doesn't represent where the Kurve actually is** (or, at the very least, it's not guaranteed to). It represents where the Kurve was at the _first_ tick handled in the current animation frame, not the _last_ tick.

#### With this PR

Now do the same thing _with_ the changes in this PR, plus this change:

```diff
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -32,5 +32,5 @@ nothingToDraw =
 mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw
 mergeWhatToDraw whatFirst whatThen =
-    { headDrawing = whatThen.headDrawing
+    { headDrawing = whatFirst.headDrawing ++ whatThen.headDrawing
     , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
     }
```

Now the head isn't drawn as a single square anymore, but instead as a _sequence_ of squares. Pausing a replay makes that glaringly obvious; it may look something like this:

    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛🟥🟥🟥⬛⬛
    ⬛⬛⬛⬛🟥🟥🟥🟥🟥🟥⬛⬛
    ⬛⬛🟥🟥🟥🟥🟥🟥🟥🟥⬛⬛
    ⬛⬛🟥🟥🟥🟥🟥🟥🟥⬛⬛⬛
    ⬛⬛🟥🟥🟥🟥⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛

#### Detailed explanation

Today (before this PR), for every animation frame, we create a batched command. If it contains more than one head-drawing command (which it does if and only if multiple ticks are handled in a single frame), then the `renderOverlay` port is called multiple times for that animation frame. To see that, make these changes:

```diff
--- a/_site/index.html
+++ b/_site/index.html
@@ -72,2 +72,3 @@
         app.ports.renderOverlay.subscribe(squares => {
+            console.warn(squares.map(s => `(${s.position.leftEdge}, ${s.position.topEdge})`).join(" and "))
             const canvas_overlay = document.getElementById("canvas_overlay");
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -169,2 +169,5 @@ update msg ({ config, pressedButtons } as model) =
                     MainLoop.consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState
+
+                _ =
+                    Debug.log "New frame" ""
             in
```

With the refresh rate still limited to 10 Hz, the console output may look something like this in a single-player round:

    New frame: ""
    (214, 190)
    (213, 190)
    (212, 190)
    (211, 191)
    New frame: ""
    (220, 189)
    (219, 189)
    (218, 189)
    (217, 189)
    (216, 189)
    (215, 190)
    New frame: ""
    (226, 187)
    (225, 187)
    (224, 188)
    (223, 188)
    (222, 188)
    (221, 188)

Note that the heads are drawn in _reverse_ chronological order within each frame. The `renderOverlay` port always clears the entire overlay canvas before it draws anything, so drawing the heads in _reverse_ order with multiple `renderOverlay` port calls is functionally equivalent to only drawing the _first_ head.

Now do the same thing with the changes in this PR, plus the modification to `mergeWhatToDraw` shown above. The console output may look something like this:

    New frame: ""
    (211, 191) and (212, 190) and (213, 190) and (214, 190) and (215, 190)
    New frame: ""
    (216, 189) and (217, 189) and (218, 189) and (219, 189) and (220, 189) and (221, 188)
    New frame: ""
    (222, 188) and (223, 188) and (224, 188) and (225, 187) and (226, 187) and (227, 187)

Now, the `renderOverlay` port is only called once per frame, but with multiple heads. So the overlay canvas is cleared _once_ per frame and then all the heads are drawn in one go, leaving all of them visible.

So why don't we mimic the current, buggy behavior, and then fix that bug in a separate PR? Well, my understanding is that **it's not defined what the current behavior is**. As mentioned in [the documentation for `Cmd.batch`][batch]:

> Each is handed to the runtime at the same time, and since each can perform arbitrary operations in the world, there are no ordering guarantees about the results.

[batch]: https://package.elm-lang.org/packages/elm/core/1.0.5/Platform-Cmd#batch

💡 `git show --color-words='\[ cmd|[A-Z]?[a-z]+|.'`