### PR TITLE
Treat WhatToDraw as an opaque type

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (WhatToDraw, clearEverything, drawSpawnIfAndOnlyIf, drawingCmd, mergeWhatToDraw, nothingToDraw)
+port module Canvas exposing (WhatToDraw, clearEverything, draw, drawSpawnIfAndOnlyIf, drawingCmd, mergeWhatToDraw, nothingToDraw)
 
 import Color exposing (Color)
 import Config exposing (WorldConfig)
@@ -19,6 +19,13 @@ port renderOverlay : List { position : DrawingPosition, thickness : Int, color :
 type alias WhatToDraw =
     { headDrawing : List Kurve
     , bodyDrawing : List ( Color, DrawingPosition )
+    }
+
+
+draw : List Kurve -> List ( Color, DrawingPosition ) -> WhatToDraw
+draw aliveKurves newColoredDrawingPositions =
+    { headDrawing = aliveKurves
+    , bodyDrawing = newColoredDrawingPositions
     }
 
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -17,7 +17,7 @@ module Game exposing
     , tickResultToGameState
     )
 
-import Canvas exposing (WhatToDraw)
+import Canvas exposing (WhatToDraw, draw)
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
 import Dialog
@@ -180,9 +180,7 @@ reactToTick config tick currentRound =
                 RoundKeepsGoing newCurrentRound
     in
     ( tickResult
-    , { headDrawing = newKurves.alive
-      , bodyDrawing = newColoredDrawingPositions
-      }
+    , draw newKurves.alive newColoredDrawingPositions
     )
 
 


### PR DESCRIPTION
"Why not make it truly opaque?"

Well, maybe we will, but not right now.

💡 `git show --color-words='\w+|.'`