### PR TITLE
Refactor spawn rendering

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (RenderAction, clearEverything, draw, drawSpawnIfAndOnlyIf, drawingCmd, mergeRenderAction, nothingToDraw)
+port module Canvas exposing (RenderAction, clearEverything, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, drawingCmd, mergeRenderAction, nothingToDraw)
 
 import Color exposing (Color)
 import Config exposing (WorldConfig)
@@ -63,6 +63,16 @@ mergeWhatToDraw whatFirst whatThen =
     }
 
 
+drawSpawnsPermanently : List Kurve -> Cmd msg
+drawSpawnsPermanently kurves =
+    kurves
+        |> List.map
+            (\kurve ->
+                ( kurve.color, World.drawingPosition kurve.state.position )
+            )
+        |> bodyDrawingCmd
+
+
 drawingCmd : RenderAction -> Cmd msg
 drawingCmd renderAction =
     case renderAction of
@@ -108,25 +118,10 @@ clearEverything { width, height } =
         ]
 
 
-drawSpawnIfAndOnlyIf : Bool -> Kurve -> Cmd msg
-drawSpawnIfAndOnlyIf shouldBeVisible kurve =
-    let
-        drawingPosition : DrawingPosition
-        drawingPosition =
-            World.drawingPosition kurve.state.position
-    in
+drawSpawnIfAndOnlyIf : Bool -> Kurve -> List Kurve -> Cmd msg
+drawSpawnIfAndOnlyIf shouldBeVisible kurve alreadySpawnedKurves =
     if shouldBeVisible then
-        render <|
-            List.singleton
-                { position = drawingPosition
-                , thickness = theThickness
-                , color = Color.toCssString kurve.color
-                }
+        headDrawingCmd (kurve :: alreadySpawnedKurves)
 
     else
-        clear
-            { x = drawingPosition.leftEdge
-            , y = drawingPosition.topEdge
-            , width = theThickness
-            , height = theThickness
-            }
+        headDrawingCmd alreadySpawnedKurves

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -99,6 +99,7 @@ type LiveOrReplay
 
 type alias SpawnState =
     { kurvesLeft : List Kurve
+    , alreadySpawnedKurves : List Kurve
     , ticksLeft : Int
     }
 


### PR DESCRIPTION
Today, the flickering when Kurves are spawning is implemented by alternating between these commands:

  1. Drawing a _body_ square in the spawning Kurve's color
  2. Clearing that square

This PR replaces that with alternating between these commands:

  1. Drawing the _head_ of the spawning Kurve _and_ the already spawned ones
  2. Drawing only the heads of the already spawned ones

The change from "body" to "head" is significant: heads are drawn on the overlay canvas, which is always cleared before anything is drawn on it. Therefore, the already spawned Kurves need to be explicitly drawn in every spawn tick.

The end goal is to simplify rendering overall; I think this takes us one step closer.

## `drawSpawnsPermanently`

Today, we rely on `drawSpawnIfAndOnlyIf` being called with `True` when `ticksLeft` is even (because the final value of `ticksLeft` is `0`). Inverting that logic would make the spawn square seemingly disappear when the Kurve starts moving (but its hitbox would still be there). Here's the easiest way to demonstrate that (without the changes in this PR, of course):

```diff
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -125,7 +125,7 @@ stepSpawnState config { kurvesLeft, ticksLeft } =
                     else
                         { kurvesLeft = spawning :: waiting, ticksLeft = ticksLeft - 1 }
             in
-            ( Just newSpawnState, drawSpawnIfAndOnlyIf (isEven ticksLeft) spawning )
+            ( Just newSpawnState, drawSpawnIfAndOnlyIf (not <| isEven ticksLeft) spawning )


 update : Msg -> Model -> ( Model, Cmd Msg )
```

With the flickering heads now being drawn on the auto-cleared overlay canvas instead of the persistent main canvas, body squares must be explicitly "committed" to the main canvas when spawning is complete and the Kurves are about to start moving. `drawSpawnsPermanently` does that.

## Further simplification

With this PR, the `clear` port is only used for one thing (clearing the entire main canvas), which will let us simplify/specialize it. However, that's not done here, in order to keep diff size and complexity down, since changes concerning `Cmd`s tend to be the most tricky ones and introduce the most surprising problems.

💡 `git show --color-words='alreadySpawnedKurves |headDrawingCmd .+|\w+|.'`