### PR TITLE
Use .5 coordinates consistently in test cases

### DIFF
--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -12,7 +12,7 @@ red y_red =
         { color = Color.red
         , id = playerIds.red
         , state =
-            { position = ( 150, y_red )
+            { position = ( 150.5, y_red )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -25,7 +25,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100, 107.5 )
+            { position = ( 100.5, 107.5 )
             , direction = Angle (pi / 2 + 0.02)
             , holeStatus = Unholy 60000
             }
@@ -44,7 +44,7 @@ expectedOutcome =
         { aliveAtTheEnd = [ { id = playerIds.red } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 324, topEdge = 101 }
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 325, topEdge = 101 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallBasic.elm
+++ b/src/TestScenarios/CrashIntoWallBasic.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 2.5, 100 )
+            { position = ( 2.5, 100.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60
             }

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100, 477.5 )
+            { position = ( 100.5, 477.5 )
             , direction = Angle 0
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100, 3.5 )
+            { position = ( 100.5, 3.5 )
             , direction = Angle (pi / 2 + 0.01)
             , holeStatus = Unholy 60000
             }
@@ -31,7 +31,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 349, topEdge = -1 }
+              , theDrawingPositionItNeverMadeItTo = { leftEdge = 350, topEdge = -1 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 2.5, 100 )
+            { position = ( 2.5, 100.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 556.5, 100 )
+            { position = ( 556.5, 100.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100, 2.5 )
+            { position = ( 100.5, 2.5 )
             , direction = Angle pi
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -38,7 +38,7 @@ orange =
         { color = Color.orange
         , id = playerIds.orange
         , state =
-            { position = ( 100, 400 )
+            { position = ( 100.5, 400.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -13,7 +13,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 108, 100 )
+            { position = ( 108.5, 100.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }


### PR DESCRIPTION
We've usually found test-case scenarios with positions like (100.5, 60.5) instead of (100, 60) easier to reason about, because (100.5, 60.5) is the exact center of the pixelated square representing that position on the canvas. This PR makes all test-case scenarios use such coordinates.

The only test-case scenarios visually and/or semantically affected by this PR are these:

  * `CrashIntoKurveTiming`
  * `CrashIntoWallExactTiming`

Green's "upward snapping" is delayed by one tick, causing Green to die one tick later.

## Checking if test cases are visually affected

I wrote this script:

```bash
#!/bin/bash

set -euo pipefail

visualizeTestScenario() {
  scenarioName="$1"
  git restore src/Main.elm
  git apply <<EOF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -47,2 +47,3 @@ import Round exposing (Round, initialStateForReplaying, modifyAlive, modifyKurve
 import Set exposing (Set)
+import TestScenarios.${scenarioName}
 import Time
@@ -66,4 +67,12 @@ init : () -> ( Model, Cmd Msg )
 init _ =
+    let
+        ( gameState, cmd ) =
+            { seedAfterSpawn = Random.initialSeed 0
+            , spawnedKurves = TestScenarios.${scenarioName}.spawnedKurves
+            }
+                |> prepareReplayRound
+                |> newRoundGameStateAndCmd Config.default Replay
+    in
     ( { pressedButtons = Set.empty
-      , appState = InMenu SplashScreen (Random.initialSeed 1337)
+      , appState = InGame gameState
       , config = Config.default
@@ -71,3 +80,3 @@ init _ =
       }
-    , Cmd.none
+    , cmd
     )
EOF
}

for f in src/TestScenarios/*.elm; do
  scenarioName=$(basename --suffix=".elm" $f)
  visualizeTestScenario "$scenarioName"
  { while ! npm run build; do sleep 2; done }
  echo -n "💡 CURRENT: ${scenarioName} "
  read -p "(Enter to continue)"
done
```

Then I ran `npm start` in two [worktrees]: without and with the changes in this PR, respectively. In each worktree, I used the script above to go through the scenarios one by one. In the meantime, I had http://localhost:8000 (without this PR) and http://localhost:8001 (with this PR) open in adjacent browser tabs, which I switched between to check for visual changes.

I ran into these problems:

  * I had to delete `npm run install-hooks && ` in the alternative worktree for `npm start` to work:

    ```diff
    --- a/package.json
    +++ b/package.json
    @@ -12,3 +12,3 @@
        "test": "elm-test",
    -    "start": "npm run install-hooks && run-pty % elm-watch hot % esbuild --serve --servedir=./_site/ % sass --watch --source-map src/css/:_site/css/"
    +    "start": "run-pty % elm-watch hot % esbuild --serve --servedir=./_site/ % sass --watch --source-map src/css/:_site/css/"
      },
    ```

  * The `CrashIntoKurveTiming` scenario required manual modifications in `Main.elm`, because unlike the others, its `spawnedKurves` takes an argument. The effect of this PR on the visualization was the same for all these arguments:

      * `100 + toFloat 0 / 10`
      * `100 + toFloat 5 / 10`
      * `100 + toFloat 9 / 10`

I don't know if `100` should be changed to `100.5` in the definition of `y_red`, but I think it makes sense to keep it, so that we create test cases for 100.0, 100.1, …, 100.9.

[worktrees]: https://git-scm.com/docs/git-worktree

💡 `git show --color-words='[0-9.]+|.'`