### PR TITLE
Align position representation with original game

### DIFF
--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -13,7 +13,7 @@ greenZombie =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 4.5, 1.5 )
+            { position = ( 3.5, 0.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -12,7 +12,7 @@ red y_red =
         { color = Color.red
         , id = playerIds.red
         , state =
-            { position = ( 150.5, y_red )
+            { position = ( 149.5, y_red )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -25,7 +25,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100.5, 107.5 )
+            { position = ( 99.5, 106.5 )
             , direction = Angle (pi / 2 + 0.02)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -12,7 +12,7 @@ red =
         { color = Color.red
         , id = playerIds.red
         , state =
-            { position = ( 100.5, 100.5 )
+            { position = ( 99.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -25,7 +25,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 98.5, 110.5 )
+            { position = ( 97.5, 109.5 )
             , direction = Angle pi
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -12,7 +12,7 @@ red =
         { color = Color.red
         , id = playerIds.red
         , state =
-            { position = ( 60.5, 60.5 )
+            { position = ( 59.5, 59.5 )
             , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }
@@ -25,7 +25,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 30.5, 30.5 )
+            { position = ( 29.5, 29.5 )
             , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallBasic.elm
+++ b/src/TestScenarios/CrashIntoWallBasic.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 2.5, 100.5 )
+            { position = ( 1.5, 99.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60
             }

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100.5, 477.5 )
+            { position = ( 99.5, 476.5 )
             , direction = Angle 0
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100.5, 3.5 )
+            { position = ( 99.5, 2.5 )
             , direction = Angle (pi / 2 + 0.01)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 2.5, 100.5 )
+            { position = ( 1.5, 99.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 556.5, 100.5 )
+            { position = ( 555.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100.5, 2.5 )
+            { position = ( 99.5, 1.5 )
             , direction = Angle pi
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -12,7 +12,7 @@ red =
         { color = Color.red
         , id = playerIds.red
         , state =
-            { position = ( 200.5, 100.5 )
+            { position = ( 199.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -25,7 +25,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 100.5, 196.5 )
+            { position = ( 99.5, 195.5 )
             , direction = Angle (3 * pi / 4)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -12,7 +12,7 @@ red =
         { color = Color.red
         , id = playerIds.red
         , state =
-            { position = ( 30.5, 30.5 )
+            { position = ( 29.5, 29.5 )
             , direction = Angle (pi / 4)
             , holeStatus = Unholy 60000
             }
@@ -25,7 +25,7 @@ yellow =
         { color = Color.yellow
         , id = playerIds.yellow
         , state =
-            { position = ( 88.5, 88.5 )
+            { position = ( 87.5, 87.5 )
             , direction = Angle (5 * pi / 4)
             , holeStatus = Unholy 60000
             }
@@ -38,7 +38,7 @@ orange =
         { color = Color.orange
         , id = playerIds.orange
         , state =
-            { position = ( 100.5, 400.5 )
+            { position = ( 99.5, 399.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -51,7 +51,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 19.5, 98.5 )
+            { position = ( 18.5, 97.5 )
             , direction = Angle (3 * pi / 4)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -13,7 +13,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 108.5, 100.5 )
+            { position = ( 107.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -13,7 +13,7 @@ greenZombie =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 32.5, 3.5 )
+            { position = ( 31.5, 2.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }

--- a/src/World.elm
+++ b/src/World.elm
@@ -58,7 +58,7 @@ drawingPosition ( x, y ) =
 
 edgeOfSquare : Float -> Int
 edgeOfSquare xOrY =
-    round (xOrY - (theThickness / 2))
+    floor xOrY
 
 
 pixelsToOccupy : DrawingPosition -> Set Pixel

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -160,7 +160,7 @@ crashingIntoKurveTimingTests =
                     let
                         y_red : Float
                         y_red =
-                            100 + toFloat decimal / 10
+                            99 + toFloat decimal / 10
                     in
                     test
                         ("When Red's vertical position is " ++ String.fromFloat y_red)


### PR DESCRIPTION
Our understanding of the original game from #93 is that internal positions concern the _top left corner_ of the Kurve's 3 × 3 head, not its center. For example, the canonical way to represent a Kurve's head being in the very top left corner of the canvas should perhaps be thought of as (0, 0), not (1.5, 1.5). Furthermore, the floating-point components of the internal position are not rounded to the nearest integer: for example, 5.9 is rounded to 5, not 6.

This PR makes our representation match that of the original game better, which should make it easier to compare scenarios between the original game and our clone. Specifically, `edgeOfSquare` is modified to 1) not subtract 1.5 anymore, and 2) use `floor` instead of `round`.

To preserve the visual appearance and semantics of test-case scenarios, all internal positions are modified to map to the same _drawing_ positions, by subtracting 1 from each position component. It can be thought of as the two changes to `edgeOfSquare` partially canceling each other out, leaving a difference of 1 that must be compensated for. I used the same technique as in #261 to check if test-case scenarios were visually affected.

## Future improvements

Our current understanding is that the original game actually rounds _towards zero_, not down – that is, we should use `truncate` instead of `floor`. That's deliberately left out here though, because it's so incredibly counterintuitive that it deserves its own PR.

Resolves #191.

💡 `git show --color-words='round|[0-9]+|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>