### PR TITLE
Specialize `clear` port

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -64,9 +64,9 @@
             }
         });
 
-        app.ports.clear.subscribe(rectangle => {
+        app.ports.clear.subscribe(() => {
             const canvas_main = document.getElementById("canvas_main");
-            clearRectangleIfCanvasExists(canvas_main, rectangle);
+            clearRectangleIfCanvasExists(canvas_main, { x: 0, y: 0, width: canvas_main?.width, height: canvas_main?.height });
         });
 
         app.ports.renderOverlay.subscribe(squares => {

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,7 +1,6 @@
 port module Canvas exposing (RenderAction, clearEverything, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, drawingCmd, mergeRenderAction, nothingToDraw)
 
 import Color exposing (Color)
-import Config exposing (WorldConfig)
 import Thickness exposing (theThickness)
 import Types.Kurve exposing (Kurve)
 import World exposing (DrawingPosition)
@@ -10,7 +9,7 @@ import World exposing (DrawingPosition)
 port render : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
 
 
-port clear : { x : Int, y : Int, width : Int, height : Int } -> Cmd msg
+port clear : () -> Cmd msg
 
 
 port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
@@ -110,11 +109,11 @@ headDrawingCmd =
             )
 
 
-clearEverything : WorldConfig -> Cmd msg
-clearEverything { width, height } =
+clearEverything : Cmd msg
+clearEverything =
     Cmd.batch
         [ renderOverlay []
-        , clear { x = 0, y = 0, width = width, height = height }
+        , clear ()
         ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -91,7 +91,7 @@ newRoundGameStateAndCmd config liveOrReplay plannedMidRoundState =
             , ticksLeft = config.spawn.numberOfFlickerTicks
             }
             plannedMidRoundState
-    , clearEverything config.world
+    , clearEverything
     )
 
 


### PR DESCRIPTION
Since #258, the `clear` port is only used for one thing: clearing the entire main canvas. it therefore doesn't need to take the region to be cleared as an argument anymore.

💡 `git show --color-words='rectangle|.'`