### PR TITLE
Make stepSpawnState Cmd-free

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -62,14 +62,17 @@ mergeWhatToDraw whatFirst whatThen =
     }
 
 
-drawSpawnsPermanently : List Kurve -> Cmd msg
+drawSpawnsPermanently : List Kurve -> RenderAction
 drawSpawnsPermanently kurves =
-    kurves
-        |> List.map
-            (\kurve ->
-                ( kurve.color, World.drawingPosition kurve.state.position )
-            )
-        |> bodyDrawingCmd
+    Draw
+        { headDrawing = []
+        , bodyDrawing =
+            kurves
+                |> List.map
+                    (\kurve ->
+                        ( kurve.color, World.drawingPosition kurve.state.position )
+                    )
+        }
 
 
 drawingCmd : RenderAction -> Cmd msg
@@ -117,10 +120,10 @@ clearEverything =
         ]
 
 
-drawSpawnIfAndOnlyIf : Bool -> Kurve -> List Kurve -> Cmd msg
+drawSpawnIfAndOnlyIf : Bool -> Kurve -> List Kurve -> RenderAction
 drawSpawnIfAndOnlyIf shouldBeVisible kurve alreadySpawnedKurves =
     if shouldBeVisible then
-        headDrawingCmd (kurve :: alreadySpawnedKurves)
+        Draw { headDrawing = kurve :: alreadySpawnedKurves, bodyDrawing = [] }
 
     else
-        headDrawingCmd alreadySpawnedKurves
+        Draw { headDrawing = alreadySpawnedKurves, bodyDrawing = [] }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ port module Main exposing (Model, Msg(..), main)
 import App exposing (AppState(..), modifyGameState)
 import Browser
 import Browser.Events
-import Canvas exposing (clearEverything, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, drawingCmd)
+import Canvas exposing (RenderAction, clearEverything, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, drawingCmd)
 import Config exposing (Config)
 import Dialog
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
@@ -109,7 +109,7 @@ type Msg
     | FocusLost
 
 
-stepSpawnState : Config -> SpawnState -> ( Maybe SpawnState, Cmd msg )
+stepSpawnState : Config -> SpawnState -> ( Maybe SpawnState, RenderAction )
 stepSpawnState config { kurvesLeft, alreadySpawnedKurves, ticksLeft } =
     case kurvesLeft of
         [] ->
@@ -148,7 +148,7 @@ update msg ({ config, pressedButtons } as model) =
 
         SpawnTick liveOrReplay spawnState plannedMidRoundState ->
             let
-                ( maybeSpawnState, cmd ) =
+                ( maybeSpawnState, renderAction ) =
                     stepSpawnState config spawnState
 
                 activeGameState : ActiveGameState
@@ -161,7 +161,7 @@ update msg ({ config, pressedButtons } as model) =
                             Moving MainLoop.noLeftoverFrameTime Tick.genesis plannedMidRoundState
             in
             ( { model | appState = InGame <| Active liveOrReplay NotPaused activeGameState }
-            , cmd
+            , drawingCmd renderAction
             )
 
         AnimationFrame liveOrReplay { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->


### PR DESCRIPTION
This PR builds further upon #254 and #255 by making `stepSpawnState` not return a `Cmd` anymore.

💡 `git show --ignore-space-change --color-words='\w+|.'`