### PR TITLE
Replace RenderAction with WhatToDraw in reactToTick

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (RenderAction, clearEverything, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, drawingCmd, mergeRenderAction, nothingToDraw)
+port module Canvas exposing (RenderAction, WhatToDraw, clearEverything, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, drawingCmd, mergeRenderAction, nothingToDraw)
 
 import Color exposing (Color)
 import Thickness exposing (theThickness)
@@ -26,12 +26,9 @@ type alias WhatToDraw =
     }
 
 
-draw : List Kurve -> List ( Color, DrawingPosition ) -> RenderAction
-draw aliveKurves newColoredDrawingPositions =
+draw : WhatToDraw -> RenderAction
+draw =
     Draw
-        { headDrawing = aliveKurves
-        , bodyDrawing = newColoredDrawingPositions
-        }
 
 
 nothingToDraw : RenderAction

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -17,7 +17,7 @@ module Game exposing
     , tickResultToGameState
     )
 
-import Canvas exposing (RenderAction, draw)
+import Canvas exposing (WhatToDraw)
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
 import Dialog
@@ -146,7 +146,7 @@ prepareRoundFromKnownInitialState initialState =
     round
 
 
-reactToTick : Config -> Tick -> Round -> ( TickResult Round, RenderAction )
+reactToTick : Config -> Tick -> Round -> ( TickResult Round, WhatToDraw )
 reactToTick config tick currentRound =
     let
         ( newKurvesGenerator, newOccupiedPixels, newColoredDrawingPositions ) =
@@ -181,7 +181,9 @@ reactToTick config tick currentRound =
                 RoundKeepsGoing newCurrentRound
     in
     ( tickResult
-    , draw newKurves.alive newColoredDrawingPositions
+    , { headDrawing = newKurves.alive
+      , bodyDrawing = newColoredDrawingPositions
+      }
     )
 
 

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -7,7 +7,7 @@ module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
 
 -}
 
-import Canvas exposing (RenderAction, mergeRenderAction, nothingToDraw)
+import Canvas exposing (RenderAction, draw, mergeRenderAction, nothingToDraw)
 import Config exposing (Config)
 import Game exposing (TickResult(..))
 import Round exposing (Round)
@@ -46,12 +46,12 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                     incrementedTick =
                         Tick.succ lastTickReactedTo
 
-                    ( tickResult, renderActionForThisTick ) =
+                    ( tickResult, whatToDrawForThisTick ) =
                         Game.reactToTick config incrementedTick midRoundStateSoFar
 
                     newRenderAction : RenderAction
                     newRenderAction =
-                        mergeRenderAction renderActionSoFar renderActionForThisTick
+                        mergeRenderAction renderActionSoFar (draw whatToDrawForThisTick)
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->


### PR DESCRIPTION
In #257, `reactToTick` was changed to return a `RenderAction`, even though it could never return `LeaveAsIs`. That is, it would always just return information equivalent to a `WhatToDraw`, but we hid that knowledge from the type checker. This PR changes it back to returning a `WhatToDraw`.

💡 `git show --color-words='\w+|.'`