### PR TITLE
Replace RenderAction with WhatToDraw where possible

### DIFF
--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -49,23 +49,22 @@ mergeWhatToDraw whatFirst whatThen =
     }
 
 
-drawSpawnsPermanently : List Kurve -> RenderAction
+drawSpawnsPermanently : List Kurve -> WhatToDraw
 drawSpawnsPermanently kurves =
-    Draw
-        { headDrawing = []
-        , bodyDrawing =
-            kurves
-                |> List.map
-                    (\kurve ->
-                        ( kurve.color, World.drawingPosition kurve.state.position )
-                    )
-        }
+    { headDrawing = []
+    , bodyDrawing =
+        kurves
+            |> List.map
+                (\kurve ->
+                    ( kurve.color, World.drawingPosition kurve.state.position )
+                )
+    }
 
 
-drawSpawnIfAndOnlyIf : Bool -> Kurve -> List Kurve -> RenderAction
+drawSpawnIfAndOnlyIf : Bool -> Kurve -> List Kurve -> WhatToDraw
 drawSpawnIfAndOnlyIf shouldBeVisible kurve alreadySpawnedKurves =
     if shouldBeVisible then
-        Draw { headDrawing = kurve :: alreadySpawnedKurves, bodyDrawing = [] }
+        { headDrawing = kurve :: alreadySpawnedKurves, bodyDrawing = [] }
 
     else
-        Draw { headDrawing = alreadySpawnedKurves, bodyDrawing = [] }
+        { headDrawing = alreadySpawnedKurves, bodyDrawing = [] }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,7 +6,7 @@ import Browser.Events
 import Canvas exposing (clearEverything, drawingCmd)
 import Config exposing (Config)
 import Dialog
-import Drawing exposing (RenderAction, drawSpawnIfAndOnlyIf, drawSpawnsPermanently)
+import Drawing exposing (WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently)
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
@@ -110,7 +110,7 @@ type Msg
     | FocusLost
 
 
-stepSpawnState : Config -> SpawnState -> ( Maybe SpawnState, RenderAction )
+stepSpawnState : Config -> SpawnState -> ( Maybe SpawnState, WhatToDraw )
 stepSpawnState config { kurvesLeft, alreadySpawnedKurves, ticksLeft } =
     case kurvesLeft of
         [] ->
@@ -149,7 +149,7 @@ update msg ({ config, pressedButtons } as model) =
 
         SpawnTick liveOrReplay spawnState plannedMidRoundState ->
             let
-                ( maybeSpawnState, renderAction ) =
+                ( maybeSpawnState, whatToDraw ) =
                     stepSpawnState config spawnState
 
                 activeGameState : ActiveGameState
@@ -162,7 +162,7 @@ update msg ({ config, pressedButtons } as model) =
                             Moving MainLoop.noLeftoverFrameTime Tick.genesis plannedMidRoundState
             in
             ( { model | appState = InGame <| Active liveOrReplay NotPaused activeGameState }
-            , drawingCmd renderAction
+            , drawingCmd <| draw whatToDraw
             )
 
         AnimationFrame liveOrReplay { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->


### PR DESCRIPTION
Since #270, `drawSpawnsPermanently` and `drawSpawnIfAndOnlyIf` return a `RenderAction`, even though they can never return `LeaveAsIs`. That is, they always just return information equivalent to a `WhatToDraw`, but we hide that knowledge from the type checker. This PR changes them to returning a `WhatToDraw`.

In other words, this PR does for `drawSpawnsPermanently` and `drawSpawnIfAndOnlyIf` what #271 did for `reactToTick`.

💡 `git show --color-words='\w+|.'`