### PR TITLE
Replace RenderAction with WhatToDraw even more

### DIFF
--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -1,4 +1,4 @@
-module Drawing exposing (RenderAction(..), WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeRenderAction, nothingToDraw)
+module Drawing exposing (RenderAction(..), WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeRenderActionAndWhatToDraw, nothingToDraw)
 
 import Color exposing (Color)
 import Types.Kurve exposing (Kurve)
@@ -26,20 +26,14 @@ nothingToDraw =
     LeaveAsIs
 
 
-mergeRenderAction : RenderAction -> RenderAction -> RenderAction
-mergeRenderAction actionFirst actionThen =
-    case ( actionFirst, actionThen ) of
-        ( LeaveAsIs, LeaveAsIs ) ->
-            LeaveAsIs
+mergeRenderActionAndWhatToDraw : RenderAction -> WhatToDraw -> WhatToDraw
+mergeRenderActionAndWhatToDraw actionFirst whatToDrawThen =
+    case ( actionFirst, whatToDrawThen ) of
+        ( LeaveAsIs, whatToDraw ) ->
+            whatToDraw
 
-        ( LeaveAsIs, Draw whatToDraw ) ->
-            Draw whatToDraw
-
-        ( Draw whatToDraw, LeaveAsIs ) ->
-            Draw whatToDraw
-
-        ( Draw whatFirst, Draw whatThen ) ->
-            Draw <| mergeWhatToDraw whatFirst whatThen
+        ( Draw whatFirst, whatThen ) ->
+            mergeWhatToDraw whatFirst whatThen
 
 
 mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -8,7 +8,7 @@ module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
 -}
 
 import Config exposing (Config)
-import Drawing exposing (RenderAction, draw, mergeRenderAction, nothingToDraw)
+import Drawing exposing (RenderAction, draw, mergeRenderActionAndWhatToDraw, nothingToDraw)
 import Game exposing (TickResult(..))
 import Round exposing (Round)
 import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
@@ -51,7 +51,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
 
                     newRenderAction : RenderAction
                     newRenderAction =
-                        mergeRenderAction renderActionSoFar (draw whatToDrawForThisTick)
+                        draw <| mergeRenderActionAndWhatToDraw renderActionSoFar whatToDrawForThisTick
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->


### PR DESCRIPTION
Today, `mergeRenderAction` takes two `RenderAction`s and returns a `RenderAction`, even though it's never called with `LeaveAsIs` as the second argument and therefore will never return `LeaveAsIs`. That is, we always pass information equivalent to a `WhatToDraw` as the second argument, and always receive such information back, but we hide that knowledge from the type checker. This PR changes the function to taking only one `RenderAction` (not two) and returning a `WhatToDraw`, and renames it accordingly.

In other words, this PR does for `mergeRenderAction` approximately what #271 did for `reactToTick` and #273 did for `drawSpawnsPermanently` and `drawSpawnIfAndOnlyIf`.

💡 `git show --color-words='RenderAction|action|LeaveAsIs|\( .|.'`