### PR TITLE
Replace RenderAction with Maybe WhatToDraw

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,7 +1,7 @@
 port module Canvas exposing (clearEverything, drawingCmd)
 
 import Color exposing (Color)
-import Drawing exposing (RenderAction(..))
+import Drawing exposing (WhatToDraw)
 import Thickness exposing (theThickness)
 import Types.Kurve exposing (Kurve)
 import World exposing (DrawingPosition)
@@ -16,13 +16,13 @@ port clearMain : () -> Cmd msg
 port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
 
 
-drawingCmd : RenderAction -> Cmd msg
-drawingCmd renderAction =
-    case renderAction of
-        LeaveAsIs ->
+drawingCmd : Maybe WhatToDraw -> Cmd msg
+drawingCmd maybeWhatToDraw =
+    case maybeWhatToDraw of
+        Nothing ->
             Cmd.none
 
-        Draw whatToDraw ->
+        Just whatToDraw ->
             [ headDrawingCmd whatToDraw.headDrawing
             , bodyDrawingCmd whatToDraw.bodyDrawing
             ]

--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -1,13 +1,8 @@
-module Drawing exposing (RenderAction(..), WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeRenderActionAndWhatToDraw, nothingToDraw)
+module Drawing exposing (WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeWhatToDraw, nothingToDraw)
 
 import Color exposing (Color)
 import Types.Kurve exposing (Kurve)
 import World exposing (DrawingPosition)
-
-
-type RenderAction
-    = LeaveAsIs
-    | Draw WhatToDraw
 
 
 type alias WhatToDraw =
@@ -16,31 +11,26 @@ type alias WhatToDraw =
     }
 
 
-draw : WhatToDraw -> RenderAction
+draw : WhatToDraw -> Maybe WhatToDraw
 draw =
-    Draw
+    Just
 
 
-nothingToDraw : RenderAction
+nothingToDraw : Maybe WhatToDraw
 nothingToDraw =
-    LeaveAsIs
+    Nothing
 
 
-mergeRenderActionAndWhatToDraw : RenderAction -> WhatToDraw -> WhatToDraw
-mergeRenderActionAndWhatToDraw actionFirst whatToDrawThen =
+mergeWhatToDraw : Maybe WhatToDraw -> WhatToDraw -> WhatToDraw
+mergeWhatToDraw actionFirst whatToDrawThen =
     case ( actionFirst, whatToDrawThen ) of
-        ( LeaveAsIs, whatToDraw ) ->
+        ( Nothing, whatToDraw ) ->
             whatToDraw
 
-        ( Draw whatFirst, whatThen ) ->
-            mergeWhatToDraw whatFirst whatThen
-
-
-mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw
-mergeWhatToDraw whatFirst whatThen =
-    { headDrawing = whatThen.headDrawing
-    , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
-    }
+        ( Just whatFirst, whatThen ) ->
+            { headDrawing = whatThen.headDrawing
+            , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
+            }
 
 
 drawSpawnsPermanently : List Kurve -> WhatToDraw

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -167,11 +167,11 @@ update msg ({ config, pressedButtons } as model) =
 
         AnimationFrame liveOrReplay { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
             let
-                ( tickResult, renderAction ) =
+                ( tickResult, whatToDraw ) =
                     MainLoop.consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState
             in
             ( { model | appState = InGame (tickResultToGameState liveOrReplay tickResult) }
-            , drawingCmd renderAction
+            , drawingCmd whatToDraw
             )
 
         ButtonUsed Down button ->
@@ -306,11 +306,11 @@ update msg ({ config, pressedButtons } as model) =
 
                                 Moving leftoverTimeFromPreviousFrame lastTick midRoundState ->
                                     let
-                                        ( tickResult, renderAction ) =
+                                        ( tickResult, whatToDraw ) =
                                             MainLoop.consumeAnimationFrame config (toFloat config.replay.skipStepInMs) leftoverTimeFromPreviousFrame lastTick midRoundState
                                     in
                                     ( { model | appState = InGame (tickResultToGameState Replay tickResult) }
-                                    , drawingCmd renderAction
+                                    , drawingCmd whatToDraw
                                     )
 
                         Key "KeyR" ->

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -8,7 +8,7 @@ module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
 -}
 
 import Config exposing (Config)
-import Drawing exposing (RenderAction, draw, mergeRenderActionAndWhatToDraw, nothingToDraw)
+import Drawing exposing (WhatToDraw, mergeWhatToDraw, nothingToDraw)
 import Game exposing (TickResult(..))
 import Round exposing (Round)
 import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
@@ -22,7 +22,7 @@ consumeAnimationFrame :
     -> LeftoverFrameTime
     -> Tick
     -> Round
-    -> ( TickResult ( LeftoverFrameTime, Tick, Round ), RenderAction )
+    -> ( TickResult ( LeftoverFrameTime, Tick, Round ), Maybe WhatToDraw )
 consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState =
     let
         timeToConsume : FrameTime
@@ -37,9 +37,9 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
             LeftoverFrameTime
             -> Tick
             -> Round
-            -> RenderAction
-            -> ( TickResult ( LeftoverFrameTime, Tick, Round ), RenderAction )
-        recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar renderActionSoFar =
+            -> Maybe WhatToDraw
+            -> ( TickResult ( LeftoverFrameTime, Tick, Round ), Maybe WhatToDraw )
+        recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar whatToDrawSoFar =
             if timeLeftToConsume >= timestep then
                 let
                     incrementedTick : Tick
@@ -49,22 +49,22 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                     ( tickResult, whatToDrawForThisTick ) =
                         Game.reactToTick config incrementedTick midRoundStateSoFar
 
-                    newRenderAction : RenderAction
-                    newRenderAction =
-                        draw <| mergeRenderActionAndWhatToDraw renderActionSoFar whatToDrawForThisTick
+                    newWhatToDraw : WhatToDraw
+                    newWhatToDraw =
+                        mergeWhatToDraw whatToDrawSoFar whatToDrawForThisTick
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->
-                        recurse (timeLeftToConsume - timestep) incrementedTick newMidRoundState newRenderAction
+                        recurse (timeLeftToConsume - timestep) incrementedTick newMidRoundState (Just newWhatToDraw)
 
                     RoundEnds finishedRound ->
                         ( RoundEnds finishedRound
-                        , newRenderAction
+                        , Just newWhatToDraw
                         )
 
             else
                 ( RoundKeepsGoing ( timeLeftToConsume, lastTickReactedTo, midRoundStateSoFar )
-                , renderActionSoFar
+                , whatToDrawSoFar
                 )
     in
     recurse timeToConsume lastTick midRoundState nothingToDraw


### PR DESCRIPTION
After the recent changes in #271 and #273, I feel like the extra indirection that `RenderAction` constitutes isn't worth it anymore. This PR replaces it with the isomorphic type `Maybe WhatToDraw`.

💡 `git show --color-words='[Rr]ender|Action|draw|.'`