### PR TITLE
Remove draw and nothingToDraw

### DIFF
--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -1,4 +1,4 @@
-module Drawing exposing (WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeWhatToDraw, nothingToDraw)
+module Drawing exposing (WhatToDraw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeWhatToDraw)
 
 import Color exposing (Color)
 import Types.Kurve exposing (Kurve)
@@ -9,16 +9,6 @@ type alias WhatToDraw =
     { headDrawing : List Kurve
     , bodyDrawing : List ( Color, DrawingPosition )
     }
-
-
-draw : WhatToDraw -> Maybe WhatToDraw
-draw =
-    Just
-
-
-nothingToDraw : Maybe WhatToDraw
-nothingToDraw =
-    Nothing
 
 
 mergeWhatToDraw : Maybe WhatToDraw -> WhatToDraw -> WhatToDraw

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,7 +6,7 @@ import Browser.Events
 import Canvas exposing (clearEverything, drawingCmd)
 import Config exposing (Config)
 import Dialog
-import Drawing exposing (WhatToDraw, draw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently)
+import Drawing exposing (WhatToDraw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently)
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
@@ -162,7 +162,7 @@ update msg ({ config, pressedButtons } as model) =
                             Moving MainLoop.noLeftoverFrameTime Tick.genesis plannedMidRoundState
             in
             ( { model | appState = InGame <| Active liveOrReplay NotPaused activeGameState }
-            , drawingCmd <| draw whatToDraw
+            , drawingCmd <| Just whatToDraw
             )
 
         AnimationFrame liveOrReplay { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -8,7 +8,7 @@ module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
 -}
 
 import Config exposing (Config)
-import Drawing exposing (WhatToDraw, mergeWhatToDraw, nothingToDraw)
+import Drawing exposing (WhatToDraw, mergeWhatToDraw)
 import Game exposing (TickResult(..))
 import Round exposing (Round)
 import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
@@ -67,7 +67,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                 , whatToDrawSoFar
                 )
     in
-    recurse timeToConsume lastTick midRoundState nothingToDraw
+    recurse timeToConsume lastTick midRoundState Nothing
 
 
 noLeftoverFrameTime : LeftoverFrameTime


### PR DESCRIPTION
I don't think they provide enough value to justify the indirection.

💡 `git show --color-words='\w+|.'`