### PR TITLE
Split drawingCmd into two slightly different functions

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -1,4 +1,4 @@
-port module Canvas exposing (clearEverything, drawingCmd)
+port module Canvas exposing (clearEverything, drawingCmd, maybeDrawingCmd)
 
 import Color exposing (Color)
 import Drawing exposing (WhatToDraw)
@@ -16,17 +16,22 @@ port clearMain : () -> Cmd msg
 port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
 
 
-drawingCmd : Maybe WhatToDraw -> Cmd msg
-drawingCmd maybeWhatToDraw =
+maybeDrawingCmd : Maybe WhatToDraw -> Cmd msg
+maybeDrawingCmd maybeWhatToDraw =
     case maybeWhatToDraw of
         Nothing ->
             Cmd.none
 
         Just whatToDraw ->
-            [ headDrawingCmd whatToDraw.headDrawing
-            , bodyDrawingCmd whatToDraw.bodyDrawing
-            ]
-                |> Cmd.batch
+            drawingCmd whatToDraw
+
+
+drawingCmd : WhatToDraw -> Cmd msg
+drawingCmd whatToDraw =
+    [ headDrawingCmd whatToDraw.headDrawing
+    , bodyDrawingCmd whatToDraw.bodyDrawing
+    ]
+        |> Cmd.batch
 
 
 bodyDrawingCmd : List ( Color, DrawingPosition ) -> Cmd msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ port module Main exposing (Model, Msg(..), main)
 import App exposing (AppState(..), modifyGameState)
 import Browser
 import Browser.Events
-import Canvas exposing (clearEverything, drawingCmd)
+import Canvas exposing (clearEverything, drawingCmd, maybeDrawingCmd)
 import Config exposing (Config)
 import Dialog
 import Drawing exposing (WhatToDraw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently)
@@ -156,7 +156,7 @@ update msg ({ config, pressedButtons } as model) =
                             Moving MainLoop.noLeftoverFrameTime Tick.genesis plannedMidRoundState
             in
             ( { model | appState = InGame <| Active liveOrReplay NotPaused activeGameState }
-            , drawingCmd <| Just whatToDraw
+            , drawingCmd whatToDraw
             )
 
         AnimationFrame liveOrReplay { delta, leftoverTimeFromPreviousFrame, lastTick } midRoundState ->
@@ -165,7 +165,7 @@ update msg ({ config, pressedButtons } as model) =
                     MainLoop.consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRoundState
             in
             ( { model | appState = InGame (tickResultToGameState liveOrReplay tickResult) }
-            , drawingCmd whatToDraw
+            , maybeDrawingCmd whatToDraw
             )
 
         ButtonUsed Down button ->
@@ -304,7 +304,7 @@ update msg ({ config, pressedButtons } as model) =
                                             MainLoop.consumeAnimationFrame config (toFloat config.replay.skipStepInMs) leftoverTimeFromPreviousFrame lastTick midRoundState
                                     in
                                     ( { model | appState = InGame (tickResultToGameState Replay tickResult) }
-                                    , drawingCmd whatToDraw
+                                    , maybeDrawingCmd whatToDraw
                                     )
 
                         Key "KeyR" ->


### PR DESCRIPTION
This way, we don't need to take the detour via a `Maybe WhatToDraw` in the case where we have a `WhatToDraw`, namely in the `SpawnTick` branch.

In addition, the name `maybeDrawingCmd` should make it slightly more clear that the returned `Cmd` may be a complete no-op.

💡 `git show --ignore-space-change --color-words='\w+|.'`