### PR TITLE
Refactor head drawing

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -3,7 +3,6 @@ port module Canvas exposing (clearEverything, drawingCmd)
 import Color exposing (Color)
 import Drawing exposing (WhatToDraw)
 import Thickness exposing (theThickness)
-import Types.Kurve exposing (Kurve)
 import World exposing (DrawingPosition)
 
 
@@ -36,14 +35,14 @@ bodyDrawingCmd =
             )
 
 
-headDrawingCmd : List Kurve -> Cmd msg
+headDrawingCmd : List ( Color, DrawingPosition ) -> Cmd msg
 headDrawingCmd =
     renderOverlay
         << List.map
-            (\kurve ->
-                { position = World.drawingPosition kurve.state.position
+            (\( color, position ) ->
+                { position = position
                 , thickness = theThickness
-                , color = Color.toCssString kurve.color
+                , color = Color.toCssString color
                 }
             )
 

--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -1,4 +1,4 @@
-module Drawing exposing (WhatToDraw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, mergeWhatToDraw)
+module Drawing exposing (WhatToDraw, drawSpawnIfAndOnlyIf, drawSpawnsPermanently, getColorAndDrawingPosition, mergeWhatToDraw)
 
 import Color exposing (Color)
 import Types.Kurve exposing (Kurve)
@@ -6,7 +6,7 @@ import World exposing (DrawingPosition)
 
 
 type alias WhatToDraw =
-    { headDrawing : List Kurve
+    { headDrawing : List ( Color, DrawingPosition )
     , bodyDrawing : List ( Color, DrawingPosition )
     }
 
@@ -26,19 +26,23 @@ mergeWhatToDraw actionFirst whatToDrawThen =
 drawSpawnsPermanently : List Kurve -> WhatToDraw
 drawSpawnsPermanently kurves =
     { headDrawing = []
-    , bodyDrawing =
-        kurves
-            |> List.map
-                (\kurve ->
-                    ( kurve.color, World.drawingPosition kurve.state.position )
-                )
+    , bodyDrawing = kurves |> List.map getColorAndDrawingPosition
     }
 
 
 drawSpawnIfAndOnlyIf : Bool -> Kurve -> List Kurve -> WhatToDraw
 drawSpawnIfAndOnlyIf shouldBeVisible kurve alreadySpawnedKurves =
     if shouldBeVisible then
-        { headDrawing = kurve :: alreadySpawnedKurves, bodyDrawing = [] }
+        { headDrawing = kurve :: alreadySpawnedKurves |> List.map getColorAndDrawingPosition
+        , bodyDrawing = []
+        }
 
     else
-        { headDrawing = alreadySpawnedKurves, bodyDrawing = [] }
+        { headDrawing = alreadySpawnedKurves |> List.map getColorAndDrawingPosition
+        , bodyDrawing = []
+        }
+
+
+getColorAndDrawingPosition : Kurve -> ( Color, DrawingPosition )
+getColorAndDrawingPosition kurve =
+    ( kurve.color, World.drawingPosition kurve.state.position )

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -20,7 +20,7 @@ module Game exposing
 import Color exposing (Color)
 import Config exposing (Config, KurveConfig)
 import Dialog
-import Drawing exposing (WhatToDraw)
+import Drawing exposing (WhatToDraw, getColorAndDrawingPosition)
 import Players exposing (ParticipatingPlayers)
 import Random
 import Round exposing (Kurves, Round, RoundInitialState, modifyAlive, modifyDead, roundIsOver)
@@ -181,7 +181,7 @@ reactToTick config tick currentRound =
                 RoundKeepsGoing newCurrentRound
     in
     ( tickResult
-    , { headDrawing = newKurves.alive
+    , { headDrawing = newKurves.alive |> List.map getColorAndDrawingPosition
       , bodyDrawing = newColoredDrawingPositions
       }
     )


### PR DESCRIPTION
It's a bit weird that a `DrawSomething` `Effect` contains a `List Kurve`, when it really only needs to contain drawing positions. If we're going to write tests for effects, then I think the `Effect` type needs to be more lightweight than that.

💡 `git show --color-words='\w+|.'`