### PR TITLE
Make crash-into-wall tests slightly more intuitive

### DIFF
--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 99.5, 476.5 )
+            { position = ( 99.5, 474.5 )
             , direction = Angle 0
             , holeStatus = Unholy 60000
             }
@@ -26,7 +26,7 @@ spawnedKurves =
 
 expectedOutcome : RoundOutcome
 expectedOutcome =
-    { tickThatShouldEndIt = tickNumber 2
+    { tickThatShouldEndIt = tickNumber 4
     , howItShouldEnd =
         { aliveAtTheEnd = []
         , deadAtTheEnd =

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 1.5, 99.5 )
+            { position = ( 3.5, 99.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -26,7 +26,7 @@ spawnedKurves =
 
 expectedOutcome : RoundOutcome
 expectedOutcome =
-    { tickThatShouldEndIt = tickNumber 3
+    { tickThatShouldEndIt = tickNumber 5
     , howItShouldEnd =
         { aliveAtTheEnd = []
         , deadAtTheEnd =

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 555.5, 99.5 )
+            { position = ( 553.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus = Unholy 60000
             }
@@ -26,7 +26,7 @@ spawnedKurves =
 
 expectedOutcome : RoundOutcome
 expectedOutcome =
-    { tickThatShouldEndIt = tickNumber 2
+    { tickThatShouldEndIt = tickNumber 4
     , howItShouldEnd =
         { aliveAtTheEnd = []
         , deadAtTheEnd =

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -12,7 +12,7 @@ green =
         { color = Color.green
         , id = playerIds.green
         , state =
-            { position = ( 99.5, 1.5 )
+            { position = ( 99.5, 3.5 )
             , direction = Angle pi
             , holeStatus = Unholy 60000
             }
@@ -26,7 +26,7 @@ spawnedKurves =
 
 expectedOutcome : RoundOutcome
 expectedOutcome =
-    { tickThatShouldEndIt = tickNumber 3
+    { tickThatShouldEndIt = tickNumber 5
     , howItShouldEnd =
         { aliveAtTheEnd = []
         , deadAtTheEnd =


### PR DESCRIPTION
The very short distance from the spawn to the wall makes it just a little bit difficult to intuitively understand what's going on when visualizing a test case like this:

```elm
init : () -> ( Model, Cmd Msg )
init _ =
    let
        model : Model
        model =
            { pressedButtons = Set.empty
            , appState = InMenu SplashScreen (Random.initialSeed 1337)
            , config = Config.default
            , players = initialPlayers
            }
    in
    startRound Replay
        model
        (prepareReplayRound
            { seedAfterSpawn = Random.initialSeed 0
            , spawnedKurves = TestScenarios.CrashIntoWallTop.spawnedKurves
            }
        )
        |> Tuple.mapSecond makeCmd
```

This PR moves the Kurve 2 pixels further away from the wall in each of the four crash-into-wall test cases, thereby making it somewhat more obvious what happens.

💡 `git show --color-words='\w+|.'`