### PR TITLE
Refactor tick logic slightly in playOutRound

### DIFF
--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -62,27 +62,22 @@ playOutRound : Config -> RoundInitialState -> ( Tick, Round )
 playOutRound config initialState =
     let
         recurse : Tick -> Round -> ( Tick, Round )
-        recurse tick midRoundState =
+        recurse lastTick midRoundState =
             let
-                nextTick : Tick
-                nextTick =
-                    Tick.succ tick
+                incrementedTick : Tick
+                incrementedTick =
+                    Tick.succ lastTick
 
                 tickResult : TickResult Round
                 tickResult =
-                    reactToTick config nextTick midRoundState |> Tuple.first
+                    reactToTick config incrementedTick midRoundState |> Tuple.first
             in
             case tickResult of
                 RoundKeepsGoing nextMidRoundState ->
-                    recurse nextTick nextMidRoundState
+                    recurse incrementedTick nextMidRoundState
 
                 RoundEnds actualRoundResult ->
-                    let
-                        actualEndTick : Tick
-                        actualEndTick =
-                            Tick.succ tick
-                    in
-                    ( actualEndTick, actualRoundResult )
+                    ( incrementedTick, actualRoundResult )
 
         round : Round
         round =


### PR DESCRIPTION
I'm fighting a never-ending struggle to wrap my head around the _meaning_ of a tick: what it means to "be at" a tick or "perform" a tick, what the "current" tick means, etc. I feel like I'm walking through a minefield of off-by-one errors every time.

This PR makes these renamings in `playOutRound`:

  * `tick` → `lastTick`
  * `nextTick` → `incrementedTick`

That makes `recurse` in `playOutRound` more similar to its namesake in `consumeAnimationFrame`.

This PR also reuses the incremented tick in the base case, instead of computing it again.

💡 `git show --color-words='\w+|.'`