### PR TITLE
Hardcode game-over logic

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,6 +1,5 @@
 module Config exposing
     ( Config
-    , GameConfig
     , HoleConfig
     , KurveConfig
     , SpawnConfig
@@ -8,11 +7,8 @@ module Config exposing
     , default
     )
 
-import Dict
-import Players exposing (ParticipatingPlayers)
 import Types.Distance exposing (Distance(..))
 import Types.Radius exposing (Radius(..))
-import Types.Score exposing (Score(..), isAtLeast)
 import Types.Speed exposing (Speed(..))
 import Types.Tickrate exposing (Tickrate(..))
 
@@ -42,40 +38,16 @@ default =
         { width = 559
         , height = 480
         }
-    , game =
-        { isGameOver = defaultGameOverCondition
-        }
     , replay =
         { skipStepInMs = 5000
         }
     }
 
 
-defaultGameOverCondition : ParticipatingPlayers -> Bool
-defaultGameOverCondition participatingPlayers =
-    let
-        numberOfPlayers : Int
-        numberOfPlayers =
-            Dict.size participatingPlayers
-
-        targetScore : Score
-        targetScore =
-            Score ((numberOfPlayers - 1) * 10)
-
-        someoneHasReachedTargetScore : Bool
-        someoneHasReachedTargetScore =
-            not <|
-                Dict.isEmpty <|
-                    Dict.filter (always (Tuple.second >> isAtLeast targetScore)) participatingPlayers
-    in
-    numberOfPlayers > 1 && someoneHasReachedTargetScore
-
-
 type alias Config =
     { kurves : KurveConfig
     , spawn : SpawnConfig
     , world : WorldConfig
-    , game : GameConfig
     , replay : ReplayConfig
     }
 
@@ -101,11 +73,6 @@ type alias SpawnConfig =
 type alias WorldConfig =
     { width : Int
     , height : Int
-    }
-
-
-type alias GameConfig =
-    { isGameOver : ParticipatingPlayers -> Bool
     }
 
 

--- a/src/IsGameOver.elm
+++ b/src/IsGameOver.elm
@@ -1,0 +1,25 @@
+module IsGameOver exposing (isGameOver)
+
+import Dict
+import Players exposing (ParticipatingPlayers)
+import Types.Score exposing (Score(..), isAtLeast)
+
+
+isGameOver : ParticipatingPlayers -> Bool
+isGameOver participatingPlayers =
+    let
+        numberOfPlayers : Int
+        numberOfPlayers =
+            Dict.size participatingPlayers
+
+        targetScore : Score
+        targetScore =
+            Score ((numberOfPlayers - 1) * 10)
+
+        someoneHasReachedTargetScore : Bool
+        someoneHasReachedTargetScore =
+            not <|
+                Dict.isEmpty <|
+                    Dict.filter (always (Tuple.second >> isAtLeast targetScore)) participatingPlayers
+    in
+    numberOfPlayers > 1 && someoneHasReachedTargetScore

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -32,6 +32,7 @@ import Game
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
 import Input exposing (Button(..), ButtonDirection(..), inputSubscriptions, updatePressedButtons)
+import IsGameOver exposing (isGameOver)
 import MainLoop
 import Menu exposing (MenuState(..))
 import Players
@@ -197,7 +198,7 @@ update msg ({ config, pressedButtons } as model) =
 
                                 gameIsOver : Bool
                                 gameIsOver =
-                                    config.game.isGameOver (participating newModel.players)
+                                    isGameOver (participating newModel.players)
                             in
                             case button of
                                 Key "KeyR" ->


### PR DESCRIPTION
Ever since it became possible for the game to end in #59, it has been defined in the `Config` _when_ it ends. However, it's defined as a function, which is potentially problematic in the context of end-to-end testing. If we're going to expect an initial model and a sequence of messages to result in some model, then if the model contains a function, we cannot describe the expected model, at least not without having access to the exact function.

This PR hardcodes the game-over logic. We might still want to make it more customizable in the future, but until then: [YAGNI].

[YAGNI]: https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it