### PR TITLE
Don't include state in Msg

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -158,6 +158,7 @@ update msg ({ config, pressedButtons } as model) =
                     )
 
                 _ ->
+                    -- Not expected to ever happen.
                     ( model, DoNothing )
 
         AnimationFrame delta ->
@@ -172,6 +173,7 @@ update msg ({ config, pressedButtons } as model) =
                     )
 
                 _ ->
+                    -- Not expected to ever happen.
                     ( model, DoNothing )
 
         ButtonUsed Down button ->


### PR DESCRIPTION
## Problem

A peculiar aspect of our `Msg` type is that it contains a lot of information that comes not from the outside world, but from the model. The idea has been to express invariants like:

> Whenever an `AnimationFrame` message is received, there must be, and always will be, a `Tick` and a `Round`, because we'll only ever receive `AnimationFrame` messages in the middle of a round.

While the intention may have been reasonable, it isn't obviously a great solution, or even correct.

### End-to-end testing

One major disadvantage becomes glaringly obvious as soon as one tries to express an end-to-end test (#287) like this:

> Folding `update` over a given sequence of messages, starting with a given model, should result in a certain model and sequence of effects.

Such a test makes no sense if the sequence of messages must contain intermediate state at every point, because then we're not testing that `update` really updates the state as expected.

### Stale messages

The other potential disadvantage is that `Msg` becomes a second source of truth. One may _think_ that a certain message variant can only ever occur together with a certain subset of the model, but that's not guaranteed.

Having read about this on Discourse and elsewhere (sources below), my takeaway is that **`Msg` shouldn't include state.**

## Solution

This PR removes all state from `Msg`, leaving only information directly inherent to what happened. As a consequence, the `SpawnTick` and `AnimationFrame` branches in `update` must inspect `model.appState` to determine whether the message makes sense in the current state. This is what I think @rupertlssmith means when [he talks about using a state machine to tame the uncontrolled events of the real world][rupert21]:

> Use a state machine to turn the real world event stream into a sufficiently ordered stream of allowed events. There is no need to totally order events in lock step, as that dissallows event orderings that will happen in the real world and that should be allowed by the application.

At that point in the discussion, [he has already been very clear about what's wrong and what's right][rupert19]:

> The solution is to not capture state from the `Model` in your `Msg`s. So instead of
>
> ```elm
> type Msg 
>     = MoveCursorTo Int -- Absolute value based off model. (value = model.pos + delta)
>     | ...
> ```
>
> Always work with deltas against the `Model`:
>
> ```elm
> type Msg
>     = MoveCursorBy Int -- Relative to the model. (value = delta)
>     | ...
> ```
>
> Then the problem is solved.

## Further reading

  * [Message types carrying new state](https://discourse.elm-lang.org/t/message-types-carrying-new-state/2177)
  * [Messages purpose](https://discourse.elm-lang.org/t/messages-purpose/6778)
  * [Preventing invalid states in update function](https://discourse.elm-lang.org/t/preventing-invalid-states-in-update-function/7060)
  * [A different API design for elm web that removes the need for `Msg` and `update`](https://discourse.elm-lang.org/t/a-different-api-design-for-elm-web-that-removes-the-need-for-msg-and-update/10400)
  * [The trickiest Elm bug I’ve ever seen](https://blog.realkinetic.com/the-trickiest-elm-bug-ive-ever-seen-988aff6cbbd7)

[rupert19]: https://discourse.elm-lang.org/t/preventing-invalid-states-in-update-function/7060/19
[rupert21]: https://discourse.elm-lang.org/t/preventing-invalid-states-in-update-function/7060/21

💡 `git show --ignore-space-change --color-words='delta : FrameTime|liveOrReplay [^(]+State|\) ->|\w+|.'`