### PR TITLE
Move test-scenario configs to scenario modules

### DIFF
--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -4,6 +4,7 @@ module TestScenarioHelpers exposing
     , RefreshRate
     , RoundEndingInterpretation
     , RoundOutcome
+    , defaultConfigWithSpeed
     , makeUserInteractions
     , makeZombieKurve
     , playerIds
@@ -12,6 +13,7 @@ module TestScenarioHelpers exposing
     )
 
 import Color
+import Config exposing (Config, KurveConfig)
 import Effect exposing (Effect)
 import Random
 import Round exposing (RoundInitialState)
@@ -19,6 +21,7 @@ import Set
 import Types.Angle exposing (Angle(..))
 import Types.Kurve as Kurve exposing (HoleStatus(..), Kurve, UserInteraction(..))
 import Types.PlayerId exposing (PlayerId)
+import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
 import Types.TurningState exposing (TurningState)
 import World exposing (DrawingPosition)
@@ -142,3 +145,22 @@ type EffectsExpectation
 
 type alias RefreshRate =
     Int
+
+
+defaultConfigWithSpeed : Speed -> Config
+defaultConfigWithSpeed speed =
+    let
+        defaultConfig : Config
+        defaultConfig =
+            Config.default
+
+        defaultKurveConfig : KurveConfig
+        defaultKurveConfig =
+            defaultConfig.kurves
+    in
+    { defaultConfig
+        | kurves =
+            { defaultKurveConfig
+                | speed = speed
+            }
+    }

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -1,10 +1,16 @@
-module TestScenarios.AroundTheWorld exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.AroundTheWorld exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeUserInteractions, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
+
+
+config : Config
+config =
+    Config.default
 
 
 greenZombie : Kurve

--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoKurveTiming exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoKurveTiming exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 red : Float -> Kurve

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoTailEnd90Degrees exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoTailEnd90Degrees exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 red : Kurve

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoTipOfTailEnd exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoTipOfTailEnd exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 red : Kurve

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoWallBottom exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoWallBottom exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 green : Kurve

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoWallExactTiming exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoWallExactTiming exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 green : Kurve

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoWallLeft exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoWallLeft exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 green : Kurve

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CrashIntoWallRight exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoWallRight exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 green : Kurve

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -1,10 +1,16 @@
-module TestScenarios.CrashIntoWallTop exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CrashIntoWallTop exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import Effect exposing (Effect(..))
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 green : Kurve

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CuttingCornersBasic exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CuttingCornersBasic exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 red : Kurve

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -1,9 +1,15 @@
-module TestScenarios.CuttingCornersPerfectOverpainting exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.CuttingCornersPerfectOverpainting exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+
+
+config : Config
+config =
+    Config.default
 
 
 red : Kurve

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -1,10 +1,17 @@
-module TestScenarios.SpeedEffectOnGame exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.SpeedEffectOnGame exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
-import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds)
+import Config exposing (Config)
+import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, defaultConfigWithSpeed, makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
+import Types.Speed exposing (Speed)
 import Types.Tick exposing (Tick)
+
+
+config : Speed -> Config
+config =
+    defaultConfigWithSpeed
 
 
 green : Kurve

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -1,10 +1,16 @@
-module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (expectedOutcome, spawnedKurves)
+module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (config, expectedOutcome, spawnedKurves)
 
 import Color
+import Config exposing (Config)
 import TestScenarioHelpers exposing (CumulativeInteraction, EffectsExpectation(..), RoundOutcome, makeUserInteractions, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
+
+
+config : Config
+config =
+    Config.default
 
 
 greenZombie : Kurve

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -1,9 +1,8 @@
 module AchtungTest exposing (tests)
 
-import Config
 import String
 import Test exposing (Test, describe, test)
-import TestHelpers exposing (defaultConfigWithSpeed, expectRoundOutcome)
+import TestHelpers exposing (expectRoundOutcome)
 import TestScenarioHelpers exposing (roundWith, tickNumber)
 import TestScenarios.AroundTheWorld
 import TestScenarios.CrashIntoKurveTiming
@@ -41,7 +40,7 @@ basicTests =
             \_ ->
                 roundWith TestScenarios.AroundTheWorld.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.AroundTheWorld.config
                         TestScenarios.AroundTheWorld.expectedOutcome
         ]
 
@@ -53,13 +52,13 @@ crashingIntoKurveTests =
             \_ ->
                 roundWith TestScenarios.CrashIntoTailEnd90Degrees.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CrashIntoTailEnd90Degrees.config
                         TestScenarios.CrashIntoTailEnd90Degrees.expectedOutcome
         , test "Hitting a Kurve's tail end at a 45-degree angle is a crash" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoTipOfTailEnd.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CrashIntoTipOfTailEnd.config
                         TestScenarios.CrashIntoTipOfTailEnd.expectedOutcome
         ]
 
@@ -71,25 +70,25 @@ crashingIntoWallTests =
             \_ ->
                 roundWith TestScenarios.CrashIntoWallTop.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CrashIntoWallTop.config
                         TestScenarios.CrashIntoWallTop.expectedOutcome
         , test "Right wall" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoWallRight.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CrashIntoWallRight.config
                         TestScenarios.CrashIntoWallRight.expectedOutcome
         , test "Bottom wall" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoWallBottom.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CrashIntoWallBottom.config
                         TestScenarios.CrashIntoWallBottom.expectedOutcome
         , test "Left wall" <|
             \_ ->
                 roundWith TestScenarios.CrashIntoWallLeft.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CrashIntoWallLeft.config
                         TestScenarios.CrashIntoWallLeft.expectedOutcome
         ]
 
@@ -143,7 +142,7 @@ crashingIntoWallTimingTest =
         \_ ->
             roundWith TestScenarios.CrashIntoWallExactTiming.spawnedKurves
                 |> expectRoundOutcome
-                    Config.default
+                    TestScenarios.CrashIntoWallExactTiming.config
                     TestScenarios.CrashIntoWallExactTiming.expectedOutcome
 
 
@@ -163,7 +162,7 @@ crashingIntoKurveTimingTests =
                         (\_ ->
                             roundWith (TestScenarios.CrashIntoKurveTiming.spawnedKurves y_red)
                                 |> expectRoundOutcome
-                                    Config.default
+                                    TestScenarios.CrashIntoKurveTiming.config
                                     TestScenarios.CrashIntoKurveTiming.expectedOutcome
                         )
                 )
@@ -177,13 +176,13 @@ cuttingCornersTests =
             \_ ->
                 roundWith TestScenarios.CuttingCornersBasic.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CuttingCornersBasic.config
                         TestScenarios.CuttingCornersBasic.expectedOutcome
         , test "The perfect overpainting (squeezing through a non-existent gap)" <|
             \_ ->
                 roundWith TestScenarios.CuttingCornersPerfectOverpainting.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.CuttingCornersPerfectOverpainting.config
                         TestScenarios.CuttingCornersPerfectOverpainting.expectedOutcome
         ]
 
@@ -201,7 +200,7 @@ speedTests =
                         \_ ->
                             roundWith TestScenarios.SpeedEffectOnGame.spawnedKurves
                                 |> expectRoundOutcome
-                                    (defaultConfigWithSpeed speed)
+                                    (TestScenarios.SpeedEffectOnGame.config speed)
                                     (TestScenarios.SpeedEffectOnGame.expectedOutcome expectedEndTick)
                 )
         )
@@ -214,6 +213,6 @@ stressTests =
             \_ ->
                 roundWith TestScenarios.StressTestRealisticTurtleSurvivalRound.spawnedKurves
                     |> expectRoundOutcome
-                        Config.default
+                        TestScenarios.StressTestRealisticTurtleSurvivalRound.config
                         TestScenarios.StressTestRealisticTurtleSurvivalRound.expectedOutcome
         ]

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -1,10 +1,7 @@
-module TestHelpers exposing
-    ( defaultConfigWithSpeed
-    , expectRoundOutcome
-    )
+module TestHelpers exposing (expectRoundOutcome)
 
 import App exposing (AppState(..))
-import Config exposing (Config, KurveConfig)
+import Config exposing (Config)
 import Effect exposing (Effect)
 import Expect
 import Game
@@ -29,7 +26,6 @@ import TestScenarioHelpers
         , RoundOutcome
         )
 import Types.FrameTime exposing (FrameTime)
-import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
 import World
 
@@ -172,25 +168,6 @@ playOutRoundWithEffects config initialState =
 showTick : Tick -> String
 showTick =
     Tick.toInt >> String.fromInt
-
-
-defaultConfigWithSpeed : Speed -> Config
-defaultConfigWithSpeed speed =
-    let
-        defaultConfig : Config
-        defaultConfig =
-            Config.default
-
-        defaultKurveConfig : KurveConfig
-        defaultKurveConfig =
-            defaultConfig.kurves
-    in
-    { defaultConfig
-        | kurves =
-            { defaultKurveConfig
-                | speed = speed
-            }
-    }
 
 
 refreshRateInTests : RefreshRate


### PR DESCRIPTION
This PR does for the configs what #195 did for the expected outcomes, namely moves them to their respective `TestScenarios` modules, so that each scenario and its config can more easily be viewed together.

The changes follow the same pattern throughout the test suite, save for these exceptions:

  * `defaultConfigWithSpeed` is moved to the `TestScenarioHelpers` module so that it can be used in `TestScenarios` modules.
  * Unlike all other existing test scenarios, the config of the `SpeedEffectOnGame` scenario depends on the desired speed, so its `config` has type `Speed -> Config` instead of `Config`.

💡 `git show --color-moved`