### PR TITLE
Replace leftEdge/topEdge with x/y in DrawingPosition

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -46,10 +46,10 @@
     <script>
         const app = Elm.Main.init({ node: document.getElementById("elm-node") });
 
-        function drawSquare(canvas, { position: { leftEdge, topEdge }, thickness, color }) {
+        function drawSquare(canvas, { position: { x, y }, thickness, color }) {
             const context = canvas.getContext("2d");
             context.fillStyle = color;
-            context.fillRect(leftEdge, topEdge, thickness, thickness);
+            context.fillRect(x, y, thickness, thickness);
         }
 
         function clearRectangleIfCanvasExists(canvas, { x, y, width, height }) {

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -275,10 +275,10 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holeStatus =
                         crashesIntoWall : Bool
                         crashesIntoWall =
                             List.member True
-                                [ current.leftEdge < 0
-                                , current.topEdge < 0
-                                , current.leftEdge > config.world.width - theThickness
-                                , current.topEdge > config.world.height - theThickness
+                                [ current.x < 0
+                                , current.y < 0
+                                , current.x > config.world.width - theThickness
+                                , current.y > config.world.height - theThickness
                                 ]
 
                         crashesIntoKurve : Bool

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -54,7 +54,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 0, topEdge = -1 }
+              , theDrawingPositionItNeverMadeItTo = { x = 0, y = -1 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -50,7 +50,7 @@ expectedOutcome =
         { aliveAtTheEnd = [ { id = playerIds.red } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 325, topEdge = 101 }
+              , theDrawingPositionItNeverMadeItTo = { x = 325, y = 101 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -50,7 +50,7 @@ expectedOutcome =
         { aliveAtTheEnd = [ { id = playerIds.red } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 97, topEdge = 101 }
+              , theDrawingPositionItNeverMadeItTo = { x = 97, y = 101 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -50,7 +50,7 @@ expectedOutcome =
         { aliveAtTheEnd = [ { id = playerIds.red } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 57, topEdge = 57 }
+              , theDrawingPositionItNeverMadeItTo = { x = 57, y = 57 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -37,7 +37,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 99, topEdge = 478 }
+              , theDrawingPositionItNeverMadeItTo = { x = 99, y = 478 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -37,7 +37,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 450, topEdge = -1 }
+              , theDrawingPositionItNeverMadeItTo = { x = 450, y = -1 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -37,7 +37,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = -1, topEdge = 99 }
+              , theDrawingPositionItNeverMadeItTo = { x = -1, y = 99 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -37,7 +37,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
+              , theDrawingPositionItNeverMadeItTo = { x = 557, y = 99 }
               }
             ]
         }

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -38,7 +38,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 99, topEdge = -1 }
+              , theDrawingPositionItNeverMadeItTo = { x = 99, y = -1 }
               }
             ]
         }
@@ -50,7 +50,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 3 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -58,7 +58,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 3 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -66,27 +66,27 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 3 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 3 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 , headDrawing = []
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 2 } ) ]
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 2 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 2 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 2 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 1 } ) ]
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 1 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 1 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 1 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 0 } ) ]
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 0 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 0 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 0 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 99, topEdge = 0 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 0 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -50,7 +50,7 @@ expectedOutcome =
         { aliveAtTheEnd = [ { id = playerIds.red } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 296, topEdge = -1 }
+              , theDrawingPositionItNeverMadeItTo = { x = 296, y = -1 }
               }
             ]
         }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -77,13 +77,13 @@ expectedOutcome =
         { aliveAtTheEnd = [ { id = playerIds.orange } ]
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 39, topEdge = 26 }
+              , theDrawingPositionItNeverMadeItTo = { x = 39, y = 26 }
               }
             , { id = playerIds.yellow
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 33, topEdge = 33 }
+              , theDrawingPositionItNeverMadeItTo = { x = 33, y = 33 }
               }
             , { id = playerIds.red
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 32, topEdge = 32 }
+              , theDrawingPositionItNeverMadeItTo = { x = 32, y = 32 }
               }
             ]
         }
@@ -96,7 +96,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -104,7 +104,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -112,213 +112,213 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 18, topEdge = 47 } ), ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 18, y = 47 } ), ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 18, topEdge = 47 } ), ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 18, y = 47 } ), ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.green, { leftEdge = 18, topEdge = 47 } ), ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 18, y = 47 } ), ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 }
 
             -- Spawns are drawn permanently:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 18, topEdge = 47 } ), ( Colors.orange, { leftEdge = 20, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 37, topEdge = 37 } ), ( Colors.red, { leftEdge = 29, topEdge = 29 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 18, y = 47 } ), ( Colors.orange, { x = 20, y = 24 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.red, { x = 29, y = 29 } ) ]
                 , headDrawing = []
                 }
 
             -- The Kurves start moving:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 19, topEdge = 46 } ), ( Colors.orange, { leftEdge = 21, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 36, topEdge = 36 } ), ( Colors.red, { leftEdge = 30, topEdge = 30 } ) ]
-                , headDrawing = [ ( Colors.red, { leftEdge = 30, topEdge = 30 } ), ( Colors.yellow, { leftEdge = 36, topEdge = 36 } ), ( Colors.orange, { leftEdge = 21, topEdge = 24 } ), ( Colors.green, { leftEdge = 19, topEdge = 46 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 19, y = 46 } ), ( Colors.orange, { x = 21, y = 24 } ), ( Colors.yellow, { x = 36, y = 36 } ), ( Colors.red, { x = 30, y = 30 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 30, y = 30 } ), ( Colors.yellow, { x = 36, y = 36 } ), ( Colors.orange, { x = 21, y = 24 } ), ( Colors.green, { x = 19, y = 46 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 22, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.red, { leftEdge = 30, topEdge = 30 } ), ( Colors.yellow, { leftEdge = 36, topEdge = 36 } ), ( Colors.orange, { leftEdge = 22, topEdge = 24 } ), ( Colors.green, { leftEdge = 19, topEdge = 46 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 22, y = 24 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 30, y = 30 } ), ( Colors.yellow, { x = 36, y = 36 } ), ( Colors.orange, { x = 22, y = 24 } ), ( Colors.green, { x = 19, y = 46 } ) ]
                 }
 
             -- Red's last position is drawn:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 20, topEdge = 45 } ), ( Colors.orange, { leftEdge = 23, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 35, topEdge = 35 } ), ( Colors.red, { leftEdge = 31, topEdge = 31 } ) ]
-                , headDrawing = [ ( Colors.red, { leftEdge = 31, topEdge = 31 } ), ( Colors.yellow, { leftEdge = 35, topEdge = 35 } ), ( Colors.orange, { leftEdge = 23, topEdge = 24 } ), ( Colors.green, { leftEdge = 20, topEdge = 45 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 20, y = 45 } ), ( Colors.orange, { x = 23, y = 24 } ), ( Colors.yellow, { x = 35, y = 35 } ), ( Colors.red, { x = 31, y = 31 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 31, y = 31 } ), ( Colors.yellow, { x = 35, y = 35 } ), ( Colors.orange, { x = 23, y = 24 } ), ( Colors.green, { x = 20, y = 45 } ) ]
                 }
 
             -- Yellow's last position is drawn:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 21, topEdge = 44 } ), ( Colors.orange, { leftEdge = 24, topEdge = 24 } ), ( Colors.yellow, { leftEdge = 34, topEdge = 34 } ) ]
-                , headDrawing = [ ( Colors.yellow, { leftEdge = 34, topEdge = 34 } ), ( Colors.orange, { leftEdge = 24, topEdge = 24 } ), ( Colors.green, { leftEdge = 21, topEdge = 44 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 21, y = 44 } ), ( Colors.orange, { x = 24, y = 24 } ), ( Colors.yellow, { x = 34, y = 34 } ) ]
+                , headDrawing = [ ( Colors.yellow, { x = 34, y = 34 } ), ( Colors.orange, { x = 24, y = 24 } ), ( Colors.green, { x = 21, y = 44 } ) ]
                 }
 
             -- Only Orange and Green left:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 22, topEdge = 43 } ), ( Colors.orange, { leftEdge = 25, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 25, topEdge = 24 } ), ( Colors.green, { leftEdge = 22, topEdge = 43 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 22, y = 43 } ), ( Colors.orange, { x = 25, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 25, y = 24 } ), ( Colors.green, { x = 22, y = 43 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 26, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 26, topEdge = 24 } ), ( Colors.green, { leftEdge = 22, topEdge = 43 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 26, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 26, y = 24 } ), ( Colors.green, { x = 22, y = 43 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 23, topEdge = 42 } ), ( Colors.orange, { leftEdge = 27, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 27, topEdge = 24 } ), ( Colors.green, { leftEdge = 23, topEdge = 42 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 23, y = 42 } ), ( Colors.orange, { x = 27, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 27, y = 24 } ), ( Colors.green, { x = 23, y = 42 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 24, topEdge = 41 } ), ( Colors.orange, { leftEdge = 28, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 28, topEdge = 24 } ), ( Colors.green, { leftEdge = 24, topEdge = 41 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 24, y = 41 } ), ( Colors.orange, { x = 28, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 28, y = 24 } ), ( Colors.green, { x = 24, y = 41 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 29, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 29, topEdge = 24 } ), ( Colors.green, { leftEdge = 24, topEdge = 41 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 29, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 29, y = 24 } ), ( Colors.green, { x = 24, y = 41 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 25, topEdge = 40 } ), ( Colors.orange, { leftEdge = 30, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 30, topEdge = 24 } ), ( Colors.green, { leftEdge = 25, topEdge = 40 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 25, y = 40 } ), ( Colors.orange, { x = 30, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 30, y = 24 } ), ( Colors.green, { x = 25, y = 40 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 26, topEdge = 39 } ), ( Colors.orange, { leftEdge = 31, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 31, topEdge = 24 } ), ( Colors.green, { leftEdge = 26, topEdge = 39 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 26, y = 39 } ), ( Colors.orange, { x = 31, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 31, y = 24 } ), ( Colors.green, { x = 26, y = 39 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 32, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 32, topEdge = 24 } ), ( Colors.green, { leftEdge = 26, topEdge = 39 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 32, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 32, y = 24 } ), ( Colors.green, { x = 26, y = 39 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 27, topEdge = 38 } ), ( Colors.orange, { leftEdge = 33, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 33, topEdge = 24 } ), ( Colors.green, { leftEdge = 27, topEdge = 38 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 27, y = 38 } ), ( Colors.orange, { x = 33, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 33, y = 24 } ), ( Colors.green, { x = 27, y = 38 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 28, topEdge = 37 } ), ( Colors.orange, { leftEdge = 34, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 34, topEdge = 24 } ), ( Colors.green, { leftEdge = 28, topEdge = 37 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 28, y = 37 } ), ( Colors.orange, { x = 34, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 34, y = 24 } ), ( Colors.green, { x = 28, y = 37 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 29, topEdge = 36 } ), ( Colors.orange, { leftEdge = 35, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 35, topEdge = 24 } ), ( Colors.green, { leftEdge = 29, topEdge = 36 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 29, y = 36 } ), ( Colors.orange, { x = 35, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 35, y = 24 } ), ( Colors.green, { x = 29, y = 36 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 36, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 36, topEdge = 24 } ), ( Colors.green, { leftEdge = 29, topEdge = 36 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 36, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 36, y = 24 } ), ( Colors.green, { x = 29, y = 36 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 30, topEdge = 35 } ), ( Colors.orange, { leftEdge = 37, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 37, topEdge = 24 } ), ( Colors.green, { leftEdge = 30, topEdge = 35 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 30, y = 35 } ), ( Colors.orange, { x = 37, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 37, y = 24 } ), ( Colors.green, { x = 30, y = 35 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 31, topEdge = 34 } ), ( Colors.orange, { leftEdge = 38, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 38, topEdge = 24 } ), ( Colors.green, { leftEdge = 31, topEdge = 34 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 31, y = 34 } ), ( Colors.orange, { x = 38, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 38, y = 24 } ), ( Colors.green, { x = 31, y = 34 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 39, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 39, topEdge = 24 } ), ( Colors.green, { leftEdge = 31, topEdge = 34 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 39, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 39, y = 24 } ), ( Colors.green, { x = 31, y = 34 } ) ]
                 }
 
             -- Green starts painting over Red and Yellow:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 32, topEdge = 33 } ), ( Colors.orange, { leftEdge = 40, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 40, topEdge = 24 } ), ( Colors.green, { leftEdge = 32, topEdge = 33 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 32, y = 33 } ), ( Colors.orange, { x = 40, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 40, y = 24 } ), ( Colors.green, { x = 32, y = 33 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 33, topEdge = 32 } ), ( Colors.orange, { leftEdge = 41, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 41, topEdge = 24 } ), ( Colors.green, { leftEdge = 33, topEdge = 32 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 33, y = 32 } ), ( Colors.orange, { x = 41, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 41, y = 24 } ), ( Colors.green, { x = 33, y = 32 } ) ]
                 }
 
             -- Green stops painting over Red and Yellow:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 34, topEdge = 31 } ), ( Colors.orange, { leftEdge = 42, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 42, topEdge = 24 } ), ( Colors.green, { leftEdge = 34, topEdge = 31 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 34, y = 31 } ), ( Colors.orange, { x = 42, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 42, y = 24 } ), ( Colors.green, { x = 34, y = 31 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 43, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 43, topEdge = 24 } ), ( Colors.green, { leftEdge = 34, topEdge = 31 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 43, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 43, y = 24 } ), ( Colors.green, { x = 34, y = 31 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 35, topEdge = 30 } ), ( Colors.orange, { leftEdge = 44, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 44, topEdge = 24 } ), ( Colors.green, { leftEdge = 35, topEdge = 30 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 35, y = 30 } ), ( Colors.orange, { x = 44, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 44, y = 24 } ), ( Colors.green, { x = 35, y = 30 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 36, topEdge = 29 } ), ( Colors.orange, { leftEdge = 45, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 45, topEdge = 24 } ), ( Colors.green, { leftEdge = 36, topEdge = 29 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 36, y = 29 } ), ( Colors.orange, { x = 45, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 45, y = 24 } ), ( Colors.green, { x = 36, y = 29 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 46, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 46, topEdge = 24 } ), ( Colors.green, { leftEdge = 36, topEdge = 29 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 46, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 46, y = 24 } ), ( Colors.green, { x = 36, y = 29 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 37, topEdge = 28 } ), ( Colors.orange, { leftEdge = 47, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 47, topEdge = 24 } ), ( Colors.green, { leftEdge = 37, topEdge = 28 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 37, y = 28 } ), ( Colors.orange, { x = 47, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 47, y = 24 } ), ( Colors.green, { x = 37, y = 28 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { leftEdge = 38, topEdge = 27 } ), ( Colors.orange, { leftEdge = 48, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 48, topEdge = 24 } ), ( Colors.green, { leftEdge = 38, topEdge = 27 } ) ]
+                { bodyDrawing = [ ( Colors.green, { x = 38, y = 27 } ), ( Colors.orange, { x = 48, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 48, y = 24 } ), ( Colors.green, { x = 38, y = 27 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.orange, { leftEdge = 49, topEdge = 24 } ) ]
-                , headDrawing = [ ( Colors.orange, { leftEdge = 49, topEdge = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 49, y = 24 } ) ]
+                , headDrawing = [ ( Colors.orange, { x = 49, y = 24 } ) ]
                 }
             ]
     }

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -39,7 +39,7 @@ expectedOutcome expectedEndTick =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 557, topEdge = 99 }
+              , theDrawingPositionItNeverMadeItTo = { x = 557, y = 99 }
               }
             ]
         }

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -61,7 +61,7 @@ expectedOutcome =
         { aliveAtTheEnd = []
         , deadAtTheEnd =
             [ { id = playerIds.green
-              , theDrawingPositionItNeverMadeItTo = { leftEdge = 372, topEdge = 217 }
+              , theDrawingPositionItNeverMadeItTo = { x = 372, y = 217 }
               }
             ]
         }

--- a/src/World.elm
+++ b/src/World.elm
@@ -23,8 +23,10 @@ type alias Position =
     ( Float, Float )
 
 
+{-| The upper left corner of the drawn square.
+-}
 type alias DrawingPosition =
-    { leftEdge : Int, topEdge : Int }
+    { x : Int, y : Int }
 
 
 type alias Pixel =
@@ -41,19 +43,9 @@ distanceToTicks tickrate speed distance =
     round <| Tickrate.toFloat tickrate * Distance.toFloat distance / Speed.toFloat speed
 
 
-toBresenham : DrawingPosition -> RasterShapes.Position
-toBresenham { leftEdge, topEdge } =
-    { x = leftEdge, y = topEdge }
-
-
-fromBresenham : RasterShapes.Position -> DrawingPosition
-fromBresenham { x, y } =
-    { leftEdge = x, topEdge = y }
-
-
 drawingPosition : Position -> DrawingPosition
 drawingPosition ( x, y ) =
-    { leftEdge = edgeOfSquare x, topEdge = edgeOfSquare y }
+    { x = edgeOfSquare x, y = edgeOfSquare y }
 
 
 edgeOfSquare : Float -> Int
@@ -62,7 +54,7 @@ edgeOfSquare xOrY =
 
 
 pixelsToOccupy : DrawingPosition -> Set Pixel
-pixelsToOccupy { leftEdge, topEdge } =
+pixelsToOccupy { x, y } =
     let
         rangeFrom : Int -> List Int
         rangeFrom start =
@@ -70,11 +62,11 @@ pixelsToOccupy { leftEdge, topEdge } =
 
         xs : List Int
         xs =
-            rangeFrom leftEdge
+            rangeFrom x
 
         ys : List Int
         ys =
-            rangeFrom topEdge
+            rangeFrom y
     in
     List.Cartesian.map2 Tuple.pair xs ys
         |> Set.fromList
@@ -83,13 +75,12 @@ pixelsToOccupy { leftEdge, topEdge } =
 desiredDrawingPositions : Position -> Position -> List DrawingPosition
 desiredDrawingPositions position1 position2 =
     RasterShapes.line
-        (drawingPosition position1 |> toBresenham)
-        (drawingPosition position2 |> toBresenham)
+        (drawingPosition position1)
+        (drawingPosition position2)
         -- The RasterShapes library returns the positions in reverse order.
         |> List.reverse
         -- The first element in the list is the starting position, which is assumed to already have been drawn.
         |> List.drop 1
-        |> List.map fromBresenham
 
 
 hitbox : DrawingPosition -> DrawingPosition -> Set Pixel
@@ -97,7 +88,7 @@ hitbox oldPosition newPosition =
     let
         is45DegreeDraw : Bool
         is45DegreeDraw =
-            oldPosition.leftEdge /= newPosition.leftEdge && oldPosition.topEdge /= newPosition.topEdge
+            oldPosition.x /= newPosition.x && oldPosition.y /= newPosition.y
 
         oldPixels : Set Pixel
         oldPixels =


### PR DESCRIPTION
As @lydell noticed in #294, reading a list of expected effects in a test-case scenario, for example `CuttingCornersPerfectOverpainting`, is quite tedious and error-prone. We therefore started thinking about more compact encodings.

I feel like the field names in `DrawingPosition` might be the lowest hanging fruit. This PR replaces `leftEdge` and `topEdge` with `x` and `y`, respectively. The latter is shorter and, I think, more idiomatic and easier to process for a human reader.

As a consequence, `toBresenham` and `fromBresenham` are removed, because they are now just the identity function. This PR should therefore affect performance positively, if at all. (I checked `_site/ZATACKA.js` after running `npm run build` without the changes in this PR, and could confirm that the functions are _not_ optimized away.)

A comment is added to `DrawingPosition` with the information that isn't conveyed by the field names anymore.

💡 `git show --color-words=.`