### PR TITLE
Draw Kurves in correct order when moving

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -232,7 +232,7 @@ checkIndividualKurve config tick kurve ( checkedKurvesGenerator, occupiedPixels,
 
         coloredDrawingPositionsAfterCheckingThisKurve : List ( Color, DrawingPosition )
         coloredDrawingPositionsAfterCheckingThisKurve =
-            coloredDrawingPositions ++ List.map (Tuple.pair kurve.color) newKurveDrawingPositions
+            List.map (Tuple.pair kurve.color) newKurveDrawingPositions ++ coloredDrawingPositions
 
         kurvesAfterCheckingThisKurve : Kurve -> Kurves -> Kurves
         kurvesAfterCheckingThisKurve checkedKurve =

--- a/src/TestScenarios/CrashSomewhatSoon.elm
+++ b/src/TestScenarios/CrashSomewhatSoon.elm
@@ -1,0 +1,101 @@
+module TestScenarios.CrashSomewhatSoon exposing (config, expectedOutcome, spawnedKurves)
+
+import Colors
+import Config exposing (Config)
+import Effect exposing (Effect(..))
+import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, defaultConfigWithSpeed, makeZombieKurve, playerIds, tickNumber)
+import Types.Angle exposing (Angle(..))
+import Types.Kurve exposing (HoleStatus(..), Kurve)
+import Types.Speed exposing (Speed(..))
+
+
+config : Config
+config =
+    defaultConfigWithSpeed (Speed 180)
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Colors.green
+        , id = playerIds.green
+        , state =
+            { position = ( 100.5, 460.5 )
+            , direction = Angle 0
+            , holeStatus = Unholy 60000
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 6
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { x = 100, y = 478 }
+              }
+            ]
+        }
+    , effectsItShouldProduce =
+        ExpectEffects
+            [ DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 461 } ), ( Colors.green, { x = 100, y = 462 } ), ( Colors.green, { x = 100, y = 463 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 463 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 464 } ), ( Colors.green, { x = 100, y = 465 } ), ( Colors.green, { x = 100, y = 466 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 466 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 467 } ), ( Colors.green, { x = 100, y = 468 } ), ( Colors.green, { x = 100, y = 469 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 469 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 470 } ), ( Colors.green, { x = 100, y = 471 } ), ( Colors.green, { x = 100, y = 472 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 472 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 473 } ), ( Colors.green, { x = 100, y = 474 } ), ( Colors.green, { x = 100, y = 475 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 475 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 476 } ), ( Colors.green, { x = 100, y = 477 } ) ]
+                , headDrawing = []
+                }
+            ]
+    }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -195,7 +195,7 @@ expectedOutcome =
 
             -- The Kurves start moving:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 19, y = 46 } ), ( Colors.orange, { x = 21, y = 24 } ), ( Colors.yellow, { x = 36, y = 36 } ), ( Colors.red, { x = 30, y = 30 } ) ]
+                { bodyDrawing = [ ( Colors.red, { x = 30, y = 30 } ), ( Colors.yellow, { x = 36, y = 36 } ), ( Colors.orange, { x = 21, y = 24 } ), ( Colors.green, { x = 19, y = 46 } ) ]
                 , headDrawing = [ ( Colors.red, { x = 30, y = 30 } ), ( Colors.yellow, { x = 36, y = 36 } ), ( Colors.orange, { x = 21, y = 24 } ), ( Colors.green, { x = 19, y = 46 } ) ]
                 }
             , DrawSomething
@@ -205,19 +205,19 @@ expectedOutcome =
 
             -- Red's last position is drawn:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 20, y = 45 } ), ( Colors.orange, { x = 23, y = 24 } ), ( Colors.yellow, { x = 35, y = 35 } ), ( Colors.red, { x = 31, y = 31 } ) ]
+                { bodyDrawing = [ ( Colors.red, { x = 31, y = 31 } ), ( Colors.yellow, { x = 35, y = 35 } ), ( Colors.orange, { x = 23, y = 24 } ), ( Colors.green, { x = 20, y = 45 } ) ]
                 , headDrawing = [ ( Colors.red, { x = 31, y = 31 } ), ( Colors.yellow, { x = 35, y = 35 } ), ( Colors.orange, { x = 23, y = 24 } ), ( Colors.green, { x = 20, y = 45 } ) ]
                 }
 
             -- Yellow's last position is drawn:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 21, y = 44 } ), ( Colors.orange, { x = 24, y = 24 } ), ( Colors.yellow, { x = 34, y = 34 } ) ]
+                { bodyDrawing = [ ( Colors.yellow, { x = 34, y = 34 } ), ( Colors.orange, { x = 24, y = 24 } ), ( Colors.green, { x = 21, y = 44 } ) ]
                 , headDrawing = [ ( Colors.yellow, { x = 34, y = 34 } ), ( Colors.orange, { x = 24, y = 24 } ), ( Colors.green, { x = 21, y = 44 } ) ]
                 }
 
             -- Only Orange and Green left:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 22, y = 43 } ), ( Colors.orange, { x = 25, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 25, y = 24 } ), ( Colors.green, { x = 22, y = 43 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 25, y = 24 } ), ( Colors.green, { x = 22, y = 43 } ) ]
                 }
             , DrawSomething
@@ -225,11 +225,11 @@ expectedOutcome =
                 , headDrawing = [ ( Colors.orange, { x = 26, y = 24 } ), ( Colors.green, { x = 22, y = 43 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 23, y = 42 } ), ( Colors.orange, { x = 27, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 27, y = 24 } ), ( Colors.green, { x = 23, y = 42 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 27, y = 24 } ), ( Colors.green, { x = 23, y = 42 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 24, y = 41 } ), ( Colors.orange, { x = 28, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 28, y = 24 } ), ( Colors.green, { x = 24, y = 41 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 28, y = 24 } ), ( Colors.green, { x = 24, y = 41 } ) ]
                 }
             , DrawSomething
@@ -237,11 +237,11 @@ expectedOutcome =
                 , headDrawing = [ ( Colors.orange, { x = 29, y = 24 } ), ( Colors.green, { x = 24, y = 41 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 25, y = 40 } ), ( Colors.orange, { x = 30, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 30, y = 24 } ), ( Colors.green, { x = 25, y = 40 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 30, y = 24 } ), ( Colors.green, { x = 25, y = 40 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 26, y = 39 } ), ( Colors.orange, { x = 31, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 31, y = 24 } ), ( Colors.green, { x = 26, y = 39 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 31, y = 24 } ), ( Colors.green, { x = 26, y = 39 } ) ]
                 }
             , DrawSomething
@@ -249,15 +249,15 @@ expectedOutcome =
                 , headDrawing = [ ( Colors.orange, { x = 32, y = 24 } ), ( Colors.green, { x = 26, y = 39 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 27, y = 38 } ), ( Colors.orange, { x = 33, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 33, y = 24 } ), ( Colors.green, { x = 27, y = 38 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 33, y = 24 } ), ( Colors.green, { x = 27, y = 38 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 28, y = 37 } ), ( Colors.orange, { x = 34, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 34, y = 24 } ), ( Colors.green, { x = 28, y = 37 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 34, y = 24 } ), ( Colors.green, { x = 28, y = 37 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 29, y = 36 } ), ( Colors.orange, { x = 35, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 35, y = 24 } ), ( Colors.green, { x = 29, y = 36 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 35, y = 24 } ), ( Colors.green, { x = 29, y = 36 } ) ]
                 }
             , DrawSomething
@@ -265,11 +265,11 @@ expectedOutcome =
                 , headDrawing = [ ( Colors.orange, { x = 36, y = 24 } ), ( Colors.green, { x = 29, y = 36 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 30, y = 35 } ), ( Colors.orange, { x = 37, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 37, y = 24 } ), ( Colors.green, { x = 30, y = 35 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 37, y = 24 } ), ( Colors.green, { x = 30, y = 35 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 31, y = 34 } ), ( Colors.orange, { x = 38, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 38, y = 24 } ), ( Colors.green, { x = 31, y = 34 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 38, y = 24 } ), ( Colors.green, { x = 31, y = 34 } ) ]
                 }
             , DrawSomething
@@ -279,17 +279,17 @@ expectedOutcome =
 
             -- Green starts painting over Red and Yellow:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 32, y = 33 } ), ( Colors.orange, { x = 40, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 40, y = 24 } ), ( Colors.green, { x = 32, y = 33 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 40, y = 24 } ), ( Colors.green, { x = 32, y = 33 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 33, y = 32 } ), ( Colors.orange, { x = 41, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 41, y = 24 } ), ( Colors.green, { x = 33, y = 32 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 41, y = 24 } ), ( Colors.green, { x = 33, y = 32 } ) ]
                 }
 
             -- Green stops painting over Red and Yellow:
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 34, y = 31 } ), ( Colors.orange, { x = 42, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 42, y = 24 } ), ( Colors.green, { x = 34, y = 31 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 42, y = 24 } ), ( Colors.green, { x = 34, y = 31 } ) ]
                 }
             , DrawSomething
@@ -297,11 +297,11 @@ expectedOutcome =
                 , headDrawing = [ ( Colors.orange, { x = 43, y = 24 } ), ( Colors.green, { x = 34, y = 31 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 35, y = 30 } ), ( Colors.orange, { x = 44, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 44, y = 24 } ), ( Colors.green, { x = 35, y = 30 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 44, y = 24 } ), ( Colors.green, { x = 35, y = 30 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 36, y = 29 } ), ( Colors.orange, { x = 45, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 45, y = 24 } ), ( Colors.green, { x = 36, y = 29 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 45, y = 24 } ), ( Colors.green, { x = 36, y = 29 } ) ]
                 }
             , DrawSomething
@@ -309,11 +309,11 @@ expectedOutcome =
                 , headDrawing = [ ( Colors.orange, { x = 46, y = 24 } ), ( Colors.green, { x = 36, y = 29 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 37, y = 28 } ), ( Colors.orange, { x = 47, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 47, y = 24 } ), ( Colors.green, { x = 37, y = 28 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 47, y = 24 } ), ( Colors.green, { x = 37, y = 28 } ) ]
                 }
             , DrawSomething
-                { bodyDrawing = [ ( Colors.green, { x = 38, y = 27 } ), ( Colors.orange, { x = 48, y = 24 } ) ]
+                { bodyDrawing = [ ( Colors.orange, { x = 48, y = 24 } ), ( Colors.green, { x = 38, y = 27 } ) ]
                 , headDrawing = [ ( Colors.orange, { x = 48, y = 24 } ), ( Colors.green, { x = 38, y = 27 } ) ]
                 }
             , DrawSomething

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -13,6 +13,7 @@ import TestScenarios.CrashIntoWallExactTiming
 import TestScenarios.CrashIntoWallLeft
 import TestScenarios.CrashIntoWallRight
 import TestScenarios.CrashIntoWallTop
+import TestScenarios.CrashSomewhatSoon
 import TestScenarios.CuttingCornersBasic
 import TestScenarios.CuttingCornersPerfectOverpainting
 import TestScenarios.SpeedEffectOnGame
@@ -30,6 +31,7 @@ tests =
         , cuttingCornersTests
         , speedTests
         , stressTests
+        , drawingTests
         ]
 
 
@@ -215,4 +217,16 @@ stressTests =
                     |> expectRoundOutcome
                         TestScenarios.StressTestRealisticTurtleSurvivalRound.config
                         TestScenarios.StressTestRealisticTurtleSurvivalRound.expectedOutcome
+        ]
+
+
+drawingTests : Test
+drawingTests =
+    describe "Drawing tests"
+        [ test "Drawing positions are described in chronological order" <|
+            \_ ->
+                roundWith TestScenarios.CrashSomewhatSoon.spawnedKurves
+                    |> expectRoundOutcome
+                        TestScenarios.CrashSomewhatSoon.config
+                        TestScenarios.CrashSomewhatSoon.expectedOutcome
         ]


### PR DESCRIPTION
This PR builds further upon #299 by addressing the third case listed in that PR, namely the order in which we describe what to draw when the Kurves are moving.

## Time complexity

If anything, this should be a (probably negligible) performance improvement, because the length of `coloredDrawingPositions` is 𝒪(𝑘 × 𝑠), while the length of the other list is only 𝒪(𝑠), where 𝑘 is the number of Kurves and 𝑠 is their speed. Barring any compiler optimizations or whatever, concatenating lists is linear in the length of the first list and constant in the length of the second list, so it's better to have the shorter list first.

## Test suite

The modified test case checks the order _between_ players: it should be Red, Yellow, and so on.

The new test case checks the order _within_ each player when more than one drawing position per player is added in a single tick, i.e. when the speed is greater than 60. For example, if Green claims (100, 461), (100, 462) and (100, 463) in the same tick, we want them to appear in that order in the `Effect`.

💡 `git show --color-words='\w+|.'`