### PR TITLE
Refactor holiness implementation

### DIFF
--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -90,18 +90,19 @@ generateKurveState config numberOfPlayers existingPositions =
             generateSpawnPosition config.spawn config.world |> Random.filter (isSafeNewPosition config numberOfPlayers existingPositions)
     in
     Random.map4
-        (\generatedPosition generatedAngle generatedHoliness generatedHoleSeed ->
+        (\generatedPosition generatedAngle generatedUnholyTicks generatedHoleSeed ->
             { position = generatedPosition
             , direction = generatedAngle
             , holeStatus =
-                { holiness = generatedHoliness
+                { holiness = Kurve.Unholy
+                , ticksLeft = generatedUnholyTicks
                 , holeSeed = generatedHoleSeed
                 }
             }
         )
         safeSpawnPosition
         (generateSpawnAngle config.spawn.angleInterval)
-        (generateInitialHoliness config.kurves)
+        (generateInitialUnholyTicks config.kurves)
         Random.independentSeed
 
 
@@ -147,6 +148,6 @@ generateHoleSize holeConfig =
     Distance.generate holeConfig.minSize holeConfig.maxSize
 
 
-generateInitialHoliness : KurveConfig -> Random.Generator Kurve.Holiness
-generateInitialHoliness { tickrate, speed, holes } =
-    generateHoleSpacing holes |> Random.map (distanceToTicks tickrate speed >> Kurve.Unholy)
+generateInitialUnholyTicks : KurveConfig -> Random.Generator Int
+generateInitialUnholyTicks { tickrate, speed, holes } =
+    generateHoleSpacing holes |> Random.map (distanceToTicks tickrate speed)

--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -56,7 +56,7 @@ makeZombieKurve { color, id, state } =
     , stateAtSpawn =
         { position = ( 0, 0 )
         , direction = Angle (pi / 2)
-        , holeStatus = { holiness = Unholy 0, holeSeed = Random.initialSeed 0 }
+        , holeStatus = { holiness = Unholy, ticksLeft = 0, holeSeed = Random.initialSeed 0 }
         }
     , reversedInteractions = []
     }

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -23,7 +23,8 @@ greenZombie =
             { position = ( 3.5, 0.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -22,7 +22,8 @@ red y_red =
             { position = ( 149.5, y_red )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -38,7 +39,8 @@ green =
             { position = ( 99.5, 106.5 )
             , direction = Angle (pi / 2 + 0.02)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -22,7 +22,8 @@ red =
             { position = ( 99.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -38,7 +39,8 @@ green =
             { position = ( 97.5, 109.5 )
             , direction = Angle pi
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -22,7 +22,8 @@ red =
             { position = ( 59.5, 59.5 )
             , direction = Angle (pi / 4)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -38,7 +39,8 @@ green =
             { position = ( 29.5, 29.5 )
             , direction = Angle (pi / 4)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -22,7 +22,8 @@ green =
             { position = ( 99.5, 474.5 )
             , direction = Angle 0
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -22,7 +22,8 @@ green =
             { position = ( 99.5, 2.5 )
             , direction = Angle (pi / 2 + 0.01)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -22,7 +22,8 @@ green =
             { position = ( 3.5, 99.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -22,7 +22,8 @@ green =
             { position = ( 553.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -23,7 +23,8 @@ green =
             { position = ( 99.5, 3.5 )
             , direction = Angle pi
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CrashSomewhatSoon.elm
+++ b/src/TestScenarios/CrashSomewhatSoon.elm
@@ -24,7 +24,8 @@ green =
             { position = ( 100.5, 460.5 )
             , direction = Angle 0
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -22,7 +22,8 @@ red =
             { position = ( 199.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -38,7 +39,8 @@ green =
             { position = ( 99.5, 195.5 )
             , direction = Angle (3 * pi / 4)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -23,7 +23,8 @@ red =
             { position = ( 29.5, 29.5 )
             , direction = Angle (pi / 4)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -39,7 +40,8 @@ yellow =
             { position = ( 37.5, 37.5 )
             , direction = Angle (5 * pi / 4)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -55,7 +57,8 @@ orange =
             { position = ( 20.5, 24.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }
@@ -71,7 +74,8 @@ green =
             { position = ( 18.5, 47.5 )
             , direction = Angle (3 * pi / 4)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -24,7 +24,8 @@ green =
             { position = ( 107.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -23,7 +23,8 @@ greenZombie =
             { position = ( 31.5, 2.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy 60000
+                { holiness = Unholy
+                , ticksLeft = 60000
                 , holeSeed = Random.initialSeed 0
                 }
             }

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -52,15 +52,14 @@ type Fate
 
 type alias HoleStatus =
     { holiness : Holiness
+    , ticksLeft : Int
     , holeSeed : Random.Seed
     }
 
 
-{-| In both cases, the integer represent the number of ticks left in the current state.
--}
 type Holiness
-    = Holy Int
-    | Unholy Int
+    = Holy
+    | Unholy
 
 
 reset : Kurve -> Kurve


### PR DESCRIPTION
This PR moves the number of ticks left out of the `Holiness` type and into the `HoleStatus` type. I think this will make it easier to introduce other hole behaviors in addition to random holes (#297). I also think it makes the transitions (and non-transitions) between `Holy` and `Unholy` slightly more obvious in the code.

💡 `git show --color-words='(new)?[Hh]oliness|.'`