### PR TITLE
Add first-class no-holes support

### DIFF
--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -94,10 +94,11 @@ generateKurveState config numberOfPlayers existingPositions =
             { position = generatedPosition
             , direction = generatedAngle
             , holeStatus =
-                { holiness = Kurve.Unholy
-                , ticksLeft = generatedUnholyTicks
-                , holeSeed = generatedHoleSeed
-                }
+                Kurve.RandomHoles
+                    { holiness = Kurve.Unholy
+                    , ticksLeft = generatedUnholyTicks
+                    , holeSeed = generatedHoleSeed
+                    }
             }
         )
         safeSpawnPosition

--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -19,7 +19,7 @@ import Random
 import Round exposing (RoundInitialState)
 import Set
 import Types.Angle exposing (Angle(..))
-import Types.Kurve as Kurve exposing (Holiness(..), Kurve, UserInteraction(..))
+import Types.Kurve as Kurve exposing (HoleStatus(..), Kurve, UserInteraction(..))
 import Types.PlayerId exposing (PlayerId)
 import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
@@ -56,7 +56,7 @@ makeZombieKurve { color, id, state } =
     , stateAtSpawn =
         { position = ( 0, 0 )
         , direction = Angle (pi / 2)
-        , holeStatus = { holiness = Unholy, ticksLeft = 0, holeSeed = Random.initialSeed 0 }
+        , holeStatus = NoHoles
         }
     , reversedInteractions = []
     }

--- a/src/TestScenarios/AroundTheWorld.elm
+++ b/src/TestScenarios/AroundTheWorld.elm
@@ -2,10 +2,9 @@ module TestScenarios.AroundTheWorld exposing (config, expectedOutcome, spawnedKu
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeUserInteractions, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
 
 
@@ -23,10 +22,7 @@ greenZombie =
             { position = ( 3.5, 0.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoKurveTiming.elm
+++ b/src/TestScenarios/CrashIntoKurveTiming.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoKurveTiming exposing (config, expectedOutcome, spa
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ red y_red =
             { position = ( 149.5, y_red )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -39,10 +35,7 @@ green =
             { position = ( 99.5, 106.5 )
             , direction = Angle (pi / 2 + 0.02)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
+++ b/src/TestScenarios/CrashIntoTailEnd90Degrees.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoTailEnd90Degrees exposing (config, expectedOutcome
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ red =
             { position = ( 99.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -39,10 +35,7 @@ green =
             { position = ( 97.5, 109.5 )
             , direction = Angle pi
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoTipOfTailEnd.elm
+++ b/src/TestScenarios/CrashIntoTipOfTailEnd.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoTipOfTailEnd exposing (config, expectedOutcome, sp
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ red =
             { position = ( 59.5, 59.5 )
             , direction = Angle (pi / 4)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -39,10 +35,7 @@ green =
             { position = ( 29.5, 29.5 )
             , direction = Angle (pi / 4)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoWallBottom exposing (config, expectedOutcome, spaw
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ green =
             { position = ( 99.5, 474.5 )
             , direction = Angle 0
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoWallExactTiming.elm
+++ b/src/TestScenarios/CrashIntoWallExactTiming.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoWallExactTiming exposing (config, expectedOutcome,
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ green =
             { position = ( 99.5, 2.5 )
             , direction = Angle (pi / 2 + 0.01)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoWallLeft exposing (config, expectedOutcome, spawne
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ green =
             { position = ( 3.5, 99.5 )
             , direction = Angle (3 * pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -2,10 +2,9 @@ module TestScenarios.CrashIntoWallRight exposing (config, expectedOutcome, spawn
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ green =
             { position = ( 553.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -3,10 +3,9 @@ module TestScenarios.CrashIntoWallTop exposing (config, expectedOutcome, spawned
 import Colors
 import Config exposing (Config)
 import Effect exposing (Effect(..))
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -23,10 +22,7 @@ green =
             { position = ( 99.5, 3.5 )
             , direction = Angle pi
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CrashSomewhatSoon.elm
+++ b/src/TestScenarios/CrashSomewhatSoon.elm
@@ -3,10 +3,9 @@ module TestScenarios.CrashSomewhatSoon exposing (config, expectedOutcome, spawne
 import Colors
 import Config exposing (Config)
 import Effect exposing (Effect(..))
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, defaultConfigWithSpeed, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.Speed exposing (Speed(..))
 
 
@@ -24,10 +23,7 @@ green =
             { position = ( 100.5, 460.5 )
             , direction = Angle 0
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CuttingCornersBasic.elm
+++ b/src/TestScenarios/CuttingCornersBasic.elm
@@ -2,10 +2,9 @@ module TestScenarios.CuttingCornersBasic exposing (config, expectedOutcome, spaw
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -22,10 +21,7 @@ red =
             { position = ( 199.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -39,10 +35,7 @@ green =
             { position = ( 99.5, 195.5 )
             , direction = Angle (3 * pi / 4)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -3,10 +3,9 @@ module TestScenarios.CuttingCornersPerfectOverpainting exposing (config, expecte
 import Colors
 import Config exposing (Config)
 import Effect exposing (Effect(..))
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 
 
 config : Config
@@ -23,10 +22,7 @@ red =
             { position = ( 29.5, 29.5 )
             , direction = Angle (pi / 4)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -40,10 +36,7 @@ yellow =
             { position = ( 37.5, 37.5 )
             , direction = Angle (5 * pi / 4)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -57,10 +50,7 @@ orange =
             { position = ( 20.5, 24.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 
@@ -74,10 +64,7 @@ green =
             { position = ( 18.5, 47.5 )
             , direction = Angle (3 * pi / 4)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -2,10 +2,9 @@ module TestScenarios.SpeedEffectOnGame exposing (config, expectedOutcome, spawne
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, defaultConfigWithSpeed, makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.Speed exposing (Speed)
 import Types.Tick exposing (Tick)
 
@@ -24,10 +23,7 @@ green =
             { position = ( 107.5, 99.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
+++ b/src/TestScenarios/StressTestRealisticTurtleSurvivalRound.elm
@@ -2,10 +2,9 @@ module TestScenarios.StressTestRealisticTurtleSurvivalRound exposing (config, ex
 
 import Colors
 import Config exposing (Config)
-import Random
 import TestScenarioHelpers exposing (CumulativeInteraction, EffectsExpectation(..), RoundOutcome, makeUserInteractions, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
-import Types.Kurve exposing (Holiness(..), Kurve)
+import Types.Kurve exposing (HoleStatus(..), Kurve)
 import Types.TurningState exposing (TurningState(..))
 
 
@@ -23,10 +22,7 @@ greenZombie =
             { position = ( 31.5, 2.5 )
             , direction = Angle (pi / 2)
             , holeStatus =
-                { holiness = Unholy
-                , ticksLeft = 60000
-                , holeSeed = Random.initialSeed 0
-                }
+                NoHoles
             }
         }
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -1,10 +1,12 @@
 module Types.Kurve exposing
     ( Fate(..)
-    , HoleStatus
+    , HoleStatus(..)
     , Holiness(..)
     , Kurve
+    , RandomHoleStatus
     , State
     , UserInteraction(..)
+    , getHoliness
     , modifyReversedInteractions
     , reset
     )
@@ -50,11 +52,26 @@ type Fate
     | Dies
 
 
-type alias HoleStatus =
+type HoleStatus
+    = RandomHoles RandomHoleStatus
+    | NoHoles
+
+
+type alias RandomHoleStatus =
     { holiness : Holiness
     , ticksLeft : Int
     , holeSeed : Random.Seed
     }
+
+
+getHoliness : HoleStatus -> Holiness
+getHoliness holeStatus =
+    case holeStatus of
+        RandomHoles { holiness } ->
+            holiness
+
+        NoHoles ->
+            Unholy
 
 
 type Holiness


### PR DESCRIPTION
This PR makes it possible for a Kurve to literally never create any holes, and uses that capability everywhere we don't want any holes (instead of `Unholy` for 60000 ticks with a bogus placeholder seed).

Perhaps most importantly, this should set the stage for another `HoleStatus` variant representing preprogrammed holes (#297).

💡 `git show --color-words='case holeStatus.+|type HoleStatus|\w+|.'`