### PR TITLE
Refactor how speed is set in test-case scenarios

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -5,6 +5,7 @@ module Config exposing
     , SpawnConfig
     , WorldConfig
     , default
+    , withSpeed
     )
 
 import Types.Distance exposing (Distance(..))
@@ -86,4 +87,19 @@ type alias HoleConfig =
     , maxInterval : Distance
     , minSize : Distance
     , maxSize : Distance
+    }
+
+
+withSpeed : Speed -> Config -> Config
+withSpeed speed config =
+    let
+        kurveConfig : KurveConfig
+        kurveConfig =
+            config.kurves
+    in
+    { config
+        | kurves =
+            { kurveConfig
+                | speed = speed
+            }
     }

--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -4,7 +4,6 @@ module TestScenarioHelpers exposing
     , RefreshRate
     , RoundEndingInterpretation
     , RoundOutcome
-    , defaultConfigWithSpeed
     , makeUserInteractions
     , makeZombieKurve
     , playerIds
@@ -13,7 +12,6 @@ module TestScenarioHelpers exposing
     )
 
 import Color
-import Config exposing (Config, KurveConfig)
 import Effect exposing (Effect)
 import Holes exposing (HoleStatus(..))
 import Random
@@ -22,7 +20,6 @@ import Set
 import Types.Angle exposing (Angle(..))
 import Types.Kurve as Kurve exposing (Kurve, UserInteraction(..))
 import Types.PlayerId exposing (PlayerId)
-import Types.Speed exposing (Speed)
 import Types.Tick as Tick exposing (Tick)
 import Types.TurningState exposing (TurningState)
 import World exposing (DrawingPosition)
@@ -146,22 +143,3 @@ type EffectsExpectation
 
 type alias RefreshRate =
     Int
-
-
-defaultConfigWithSpeed : Speed -> Config
-defaultConfigWithSpeed speed =
-    let
-        defaultConfig : Config
-        defaultConfig =
-            Config.default
-
-        defaultKurveConfig : KurveConfig
-        defaultKurveConfig =
-            defaultConfig.kurves
-    in
-    { defaultConfig
-        | kurves =
-            { defaultKurveConfig
-                | speed = speed
-            }
-    }

--- a/src/TestScenarios/CrashSomewhatSoon.elm
+++ b/src/TestScenarios/CrashSomewhatSoon.elm
@@ -4,7 +4,7 @@ import Colors
 import Config exposing (Config)
 import Effect exposing (Effect(..))
 import Holes exposing (HoleStatus(..))
-import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, defaultConfigWithSpeed, makeZombieKurve, playerIds, tickNumber)
+import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (Kurve)
 import Types.Speed exposing (Speed(..))
@@ -12,7 +12,8 @@ import Types.Speed exposing (Speed(..))
 
 config : Config
 config =
-    defaultConfigWithSpeed (Speed 180)
+    Config.default
+        |> Config.withSpeed (Speed 180)
 
 
 green : Kurve

--- a/src/TestScenarios/SpeedEffectOnGame.elm
+++ b/src/TestScenarios/SpeedEffectOnGame.elm
@@ -3,7 +3,7 @@ module TestScenarios.SpeedEffectOnGame exposing (config, expectedOutcome, spawne
 import Colors
 import Config exposing (Config)
 import Holes exposing (HoleStatus(..))
-import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, defaultConfigWithSpeed, makeZombieKurve, playerIds)
+import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds)
 import Types.Angle exposing (Angle(..))
 import Types.Kurve exposing (Kurve)
 import Types.Speed exposing (Speed)
@@ -11,8 +11,9 @@ import Types.Tick exposing (Tick)
 
 
 config : Speed -> Config
-config =
-    defaultConfigWithSpeed
+config speed =
+    Config.default
+        |> Config.withSpeed speed
 
 
 green : Kurve


### PR DESCRIPTION
Instead of having a function that returns the _default_ config with the given speed, let's have a function that returns _any_ given config with the given speed. That composes nicely with other similar hypothetical functions like `withWorldSize` or `withSpawnMargin`.

The new-ish function lives in the `Config` module, because it seems like a reasonable home for it.

💡 `git show --color-words='\w+|.'`