### PR TITLE
DRY up hole generation code

### DIFF
--- a/src/Holes.elm
+++ b/src/Holes.elm
@@ -2,7 +2,7 @@ module Holes exposing
     ( HoleStatus(..)
     , Holiness(..)
     , RandomHoleStatus
-    , generateInitialUnholyTicks
+    , generateUnholyTicks
     , getHoliness
     , updateHoleStatus
     )
@@ -55,12 +55,8 @@ updateRandomHoleStatus kurveConfig randomHoleStatus =
     case ( randomHoleStatus.holiness, randomHoleStatus.ticksLeft ) of
         ( Holy, 0 ) ->
             let
-                unholyTicksGenerator : Random.Generator Int
-                unholyTicksGenerator =
-                    generateHoleSpacing kurveConfig.holes |> Random.map (distanceToTicks kurveConfig.tickrate kurveConfig.speed)
-
                 ( unholyTicks, newSeed ) =
-                    Random.step unholyTicksGenerator randomHoleStatus.holeSeed
+                    Random.step (generateUnholyTicks kurveConfig) randomHoleStatus.holeSeed
             in
             { holiness = Unholy, ticksLeft = unholyTicks, holeSeed = newSeed }
 
@@ -69,12 +65,8 @@ updateRandomHoleStatus kurveConfig randomHoleStatus =
 
         ( Unholy, 0 ) ->
             let
-                holyTicksGenerator : Random.Generator Int
-                holyTicksGenerator =
-                    generateHoleSize kurveConfig.holes |> Random.map (computeDistanceBetweenCenters >> distanceToTicks kurveConfig.tickrate kurveConfig.speed)
-
                 ( holyTicks, newSeed ) =
-                    Random.step holyTicksGenerator randomHoleStatus.holeSeed
+                    Random.step (generateHolyTicks kurveConfig) randomHoleStatus.holeSeed
             in
             { holiness = Holy, ticksLeft = holyTicks, holeSeed = newSeed }
 
@@ -92,6 +84,11 @@ generateHoleSize holeConfig =
     Distance.generate holeConfig.minSize holeConfig.maxSize
 
 
-generateInitialUnholyTicks : KurveConfig -> Random.Generator Int
-generateInitialUnholyTicks { tickrate, speed, holes } =
+generateUnholyTicks : KurveConfig -> Random.Generator Int
+generateUnholyTicks { tickrate, speed, holes } =
     generateHoleSpacing holes |> Random.map (distanceToTicks tickrate speed)
+
+
+generateHolyTicks : KurveConfig -> Random.Generator Int
+generateHolyTicks { tickrate, speed, holes } =
+    generateHoleSize holes |> Random.map (computeDistanceBetweenCenters >> distanceToTicks tickrate speed)

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -2,7 +2,7 @@ module Spawn exposing (generateKurves)
 
 import Config exposing (Config, SpawnConfig, WorldConfig)
 import Dict
-import Holes exposing (HoleStatus(..), Holiness(..), generateInitialUnholyTicks)
+import Holes exposing (HoleStatus(..), Holiness(..), generateUnholyTicks)
 import Input exposing (toStringSetControls)
 import Players exposing (ParticipatingPlayers)
 import Random
@@ -100,7 +100,7 @@ generateKurveState config numberOfPlayers existingPositions =
         )
         safeSpawnPosition
         (generateSpawnAngle config.spawn.angleInterval)
-        (generateInitialUnholyTicks config.kurves)
+        (generateUnholyTicks config.kurves)
         Random.independentSeed
 
 


### PR DESCRIPTION
The implementation of `unholyTicksGenerator` is exactly identical to that of `generateInitialUnholyTicks`, so why aren't they just the same function? This PR merges them together and makes `holyTicksGenerator` its own top-level function for symmetry and consistency.

The repetition has arguably been present at least since e4e5908c8c4c3092b4f98c3d86e593ed54beec89, and became blatantly obvious in #308, when the two identical pieces of code were moved to the same module.

💡 `git show --color-words='(unholy|holy)TicksGenerator|.'`