### PR TITLE
Use new hole status/holiness when evaluating move

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -346,7 +346,7 @@ updateKurve config turningState occupiedPixels kurve =
                 kurve.state.position
                 newPosition
                 occupiedPixels
-                (getHoliness kurve.state.holeStatus)
+                (getHoliness newHoleStatus)
 
         newHoleStatus : HoleStatus
         newHoleStatus =

--- a/tests/FirstRoundTest.elm
+++ b/tests/FirstRoundTest.elm
@@ -480,7 +480,7 @@ expectedEffects =
         , headDrawing = [ ( Colors.green, { x = 306, y = 169 } ) ]
         }
     , DrawSomething
-        { bodyDrawing = [ ( Colors.green, { x = 307, y = 169 } ) ]
+        { bodyDrawing = []
         , headDrawing = [ ( Colors.green, { x = 307, y = 169 } ) ]
         }
     , DrawSomething
@@ -528,7 +528,7 @@ expectedEffects =
         , headDrawing = [ ( Colors.green, { x = 318, y = 167 } ) ]
         }
     , DrawSomething
-        { bodyDrawing = []
+        { bodyDrawing = [ ( Colors.green, { x = 319, y = 167 } ) ]
         , headDrawing = [ ( Colors.green, { x = 319, y = 167 } ) ]
         }
     , DrawSomething


### PR DESCRIPTION
## Background

In the effort to formalize exactly what a tick is (#292), I've come up with this so far:

  * Tick 0 is the point in time when the Kurves have been drawn at their spawn positions, but have not yet moved.
  * Tick 1 is the point in time when the Kurves have been moved one step from their spawn positions and been drawn at the new positions.
  * "Drawing in tick 𝑛" means drawing one's body at one's position at tick 𝑛.
  * "Being holy at tick 𝑛" means not attempting to draw in tick 𝑛.
  * A Kurve is always unholy at tick 0; the first tick at which it can be holy is tick 1.

## Problem

To define a Kurve that draws its spawn and then immediately opens a hole, one should reasonably start out with this `RandomHoleStatus` at tick 0:

```elm
{ holiness : Unholy
, ticksLeft : 0
, holeSeed : Random.initialSeed 0 -- or whatever
}
```

However, such a Kurve _doesn't_ immediately open a hole. It draws its spawn, then draws in tick 1 too, and _then_ opens a hole, as can be seen by making this change:

```diff
--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -102,3 +102,3 @@ generateKurveState config numberOfPlayers existingPositions =
         (generateSpawnAngle config.spawn.angleInterval)
-        (generateUnholyTicks config.kurves)
+        (Random.constant 0)
         Random.independentSeed
```

The reason is that we pass the _old_ holiness to `evaluateMove`. That seems strange to me: if `evaluateMove` is given `newPosition` (which in turn is defined in terms of `newDirection`), why shouldn't it also get a holiness derived from `newHoleStatus`?

## Solution

The solution is to use the new holiness instead, effectively making all holes start and end one tick earlier than today.

As for #259, this PR _doesn't_ fix it, but I think it takes us one step closer to fixing it.

💡 `git show --color-words='newHoleStatus|.'`