### PR TITLE
Replace "unholy" with "solid"

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -303,7 +303,7 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransit
                     -- The Kurve lives and is holy. Nothing to draw.
                     []
 
-                ( Lives, Unholy ) ->
+                ( Lives, Solid ) ->
                     -- The Kurve lives and is solid. Draw everything it wanted to draw.
                     checkedPositionsReversed
 
@@ -315,11 +315,11 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransit
                             -- Otherwise, the last position where the Kurve could be is the last checked position before death occurred.
                             List.singleton <| Maybe.withDefault startingPointAsDrawingPosition <| List.head checkedPositionsReversed
 
-                        Unholy ->
+                        Solid ->
                             -- The Kurve died as it opened a hole. Draw the last position it could be at, but no need to default to the starting point because it must have been drawn in the previous tick.
                             List.take 1 checkedPositionsReversed
 
-                ( Dies, Unholy ) ->
+                ( Dies, Solid ) ->
                     case oldHoliness of
                         Holy ->
                             -- The Kurve died as it closed a hole. Draw all positions it could be at.
@@ -330,7 +330,7 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransit
                             else
                                 checkedPositionsReversed
 
-                        Unholy ->
+                        Solid ->
                             -- The Kurve died in the middle of a solid segment. Draw all positions it could be at.
                             checkedPositionsReversed
     in

--- a/src/Holes.elm
+++ b/src/Holes.elm
@@ -2,7 +2,7 @@ module Holes exposing
     ( HoleStatus(..)
     , Holiness(..)
     , RandomHoleStatus
-    , generateUnholyTicks
+    , generateSolidTicks
     , getHoliness
     , updateHoleStatus
     )
@@ -32,12 +32,12 @@ getHoliness holeStatus =
             holiness
 
         NoHoles ->
-            Unholy
+            Solid
 
 
 type Holiness
     = Holy
-    | Unholy
+    | Solid
 
 
 updateHoleStatus : KurveConfig -> HoleStatus -> HoleStatus
@@ -55,22 +55,22 @@ updateRandomHoleStatus kurveConfig randomHoleStatus =
     case ( randomHoleStatus.holiness, randomHoleStatus.ticksLeft ) of
         ( Holy, 0 ) ->
             let
-                ( unholyTicks, newSeed ) =
-                    Random.step (generateUnholyTicks kurveConfig) randomHoleStatus.holeSeed
+                ( solidTicks, newSeed ) =
+                    Random.step (generateSolidTicks kurveConfig) randomHoleStatus.holeSeed
             in
-            { holiness = Unholy, ticksLeft = unholyTicks, holeSeed = newSeed }
+            { holiness = Solid, ticksLeft = solidTicks, holeSeed = newSeed }
 
         ( Holy, ticksLeft ) ->
             { randomHoleStatus | ticksLeft = ticksLeft - 1 }
 
-        ( Unholy, 0 ) ->
+        ( Solid, 0 ) ->
             let
                 ( holyTicks, newSeed ) =
                     Random.step (generateHolyTicks kurveConfig) randomHoleStatus.holeSeed
             in
             { holiness = Holy, ticksLeft = holyTicks, holeSeed = newSeed }
 
-        ( Unholy, ticksLeft ) ->
+        ( Solid, ticksLeft ) ->
             { randomHoleStatus | ticksLeft = ticksLeft - 1 }
 
 
@@ -84,8 +84,8 @@ generateHoleSize holeConfig =
     Distance.generate holeConfig.minSize holeConfig.maxSize
 
 
-generateUnholyTicks : KurveConfig -> Random.Generator Int
-generateUnholyTicks { tickrate, speed, holes } =
+generateSolidTicks : KurveConfig -> Random.Generator Int
+generateSolidTicks { tickrate, speed, holes } =
     generateHoleSpacing holes |> Random.map (distanceToTicks tickrate speed)
 
 

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -2,7 +2,7 @@ module Spawn exposing (generateKurves)
 
 import Config exposing (Config, SpawnConfig, WorldConfig)
 import Dict
-import Holes exposing (HoleStatus(..), Holiness(..), generateUnholyTicks)
+import Holes exposing (HoleStatus(..), Holiness(..), generateSolidTicks)
 import Input exposing (toStringSetControls)
 import Players exposing (ParticipatingPlayers)
 import Random
@@ -87,20 +87,20 @@ generateKurveState config numberOfPlayers existingPositions =
             generateSpawnPosition config.spawn config.world |> Random.filter (isSafeNewPosition config numberOfPlayers existingPositions)
     in
     Random.map4
-        (\generatedPosition generatedAngle generatedUnholyTicks generatedHoleSeed ->
+        (\generatedPosition generatedAngle generatedSolidTicks generatedHoleSeed ->
             { position = generatedPosition
             , direction = generatedAngle
             , holeStatus =
                 RandomHoles
-                    { holiness = Unholy
-                    , ticksLeft = generatedUnholyTicks
+                    { holiness = Solid
+                    , ticksLeft = generatedSolidTicks
                     , holeSeed = generatedHoleSeed
                     }
             }
         )
         safeSpawnPosition
         (generateSpawnAngle config.spawn.angleInterval)
-        (generateUnholyTicks config.kurves)
+        (generateSolidTicks config.kurves)
         Random.independentSeed
 
 

--- a/src/TestScenarios/CrashingWhileBecomingSolid.elm
+++ b/src/TestScenarios/CrashingWhileBecomingSolid.elm
@@ -1,4 +1,4 @@
-module TestScenarios.CrashingWhileBecomingUnholy exposing (config, expectedOutcome, spawnedKurves)
+module TestScenarios.CrashingWhileBecomingSolid exposing (config, expectedOutcome, spawnedKurves)
 
 import Colors
 import Config exposing (Config)
@@ -27,7 +27,7 @@ green =
             , direction = Angle (pi / 2)
             , holeStatus =
                 RandomHoles
-                    { holiness = Unholy
+                    { holiness = Solid
                     , ticksLeft = 2
                     , holeSeed = Random.initialSeed 0
                     }

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -14,7 +14,7 @@ import TestScenarios.CrashIntoWallLeft
 import TestScenarios.CrashIntoWallRight
 import TestScenarios.CrashIntoWallTop
 import TestScenarios.CrashSomewhatSoon
-import TestScenarios.CrashingWhileBecomingUnholy
+import TestScenarios.CrashingWhileBecomingSolid
 import TestScenarios.CuttingCornersBasic
 import TestScenarios.CuttingCornersPerfectOverpainting
 import TestScenarios.SpeedEffectOnGame
@@ -237,10 +237,10 @@ drawingTests =
 holeTests : Test
 holeTests =
     describe "Hole tests"
-        [ test "Final head position is drawn when simultaneously crashing and becoming unholy" <|
+        [ test "Final head position is drawn when simultaneously crashing and becoming solid" <|
             \_ ->
-                roundWith TestScenarios.CrashingWhileBecomingUnholy.spawnedKurves
+                roundWith TestScenarios.CrashingWhileBecomingSolid.spawnedKurves
                     |> expectRoundOutcome
-                        TestScenarios.CrashingWhileBecomingUnholy.config
-                        TestScenarios.CrashingWhileBecomingUnholy.expectedOutcome
+                        TestScenarios.CrashingWhileBecomingSolid.config
+                        TestScenarios.CrashingWhileBecomingSolid.expectedOutcome
         ]


### PR DESCRIPTION
I've started to feel more and more lately that "unholy" is a strange and confusing word, weirdly negated as if being holy is the default, and also somewhat easy to straight up misread as "holy" at a glance.

## How the changes were made

```bash
for f in $(git ls-files); do
  sed -i -e s/Unholy/Solid/g -e s/unholy/solid/g $f
done

git mv src/TestScenarios/CrashingWhileBecomingUnholy.elm src/TestScenarios/CrashingWhileBecomingSolid.elm 
```

💡 `git show --color-words='Unholy|unholy|.'`