### PR TITLE
Add hole size and spacing test

### DIFF
--- a/src/TestScenarios/HoleSizeAndSpacing.elm
+++ b/src/TestScenarios/HoleSizeAndSpacing.elm
@@ -1,0 +1,186 @@
+module TestScenarios.HoleSizeAndSpacing exposing (config, expectedOutcome, spawnedKurves)
+
+import Colors
+import Config exposing (Config)
+import Effect exposing (Effect(..))
+import Holes exposing (HoleStatus(..), Holiness(..))
+import Random
+import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
+import Types.Angle exposing (Angle(..))
+import Types.Distance exposing (Distance(..))
+import Types.Kurve exposing (Kurve)
+
+
+holeInterval : Distance
+holeInterval =
+    Distance 4
+
+
+holeSize : Distance
+holeSize =
+    Distance 1
+
+
+config : Config
+config =
+    Config.default
+        |> Config.withHardcodedHoles holeInterval holeSize
+
+
+green : Kurve
+green =
+    makeZombieKurve
+        { color = Colors.green
+        , id = playerIds.green
+        , state =
+            { position = ( 100, 458 )
+            , direction = Angle 0
+            , holeStatus =
+                RandomHoles
+                    { holiness = Solid
+                    , ticksLeft = 0
+                    , holeSeed = Random.initialSeed 0
+                    }
+            }
+        }
+
+
+spawnedKurves : List Kurve
+spawnedKurves =
+    [ green ]
+
+
+expectedOutcome : RoundOutcome
+expectedOutcome =
+    { tickThatShouldEndIt = tickNumber 20
+    , howItShouldEnd =
+        { aliveAtTheEnd = []
+        , deadAtTheEnd =
+            [ { id = playerIds.green
+              , theDrawingPositionItNeverMadeItTo = { x = 100, y = 478 }
+              }
+            ]
+        }
+    , effectsItShouldProduce =
+        ExpectEffects
+            [ -- Spawning:
+              DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 458 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 458 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 458 } ) ]
+                }
+
+            -- Spawn is drawn permanently:
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 458 } ) ]
+                , headDrawing = []
+                }
+
+            -- The Kurve starts moving and immediately opens a hole:
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 459 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 461 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 462 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 463 } ) ]
+                }
+
+            -- The Kurve closes the hole:
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 464 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 464 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 465 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 465 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 466 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 466 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 467 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 467 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 468 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 468 } ) ]
+                }
+
+            -- The Kurve opens a new hole:
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 469 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 470 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 471 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 472 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 100, y = 473 } ) ]
+                }
+
+            -- The Kurve closes the hole:
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 474 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 474 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 475 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 475 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 476 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 476 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 100, y = 477 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 100, y = 477 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            ]
+    }

--- a/tests/AchtungTest.elm
+++ b/tests/AchtungTest.elm
@@ -17,6 +17,7 @@ import TestScenarios.CrashSomewhatSoon
 import TestScenarios.CrashingWhileBecomingSolid
 import TestScenarios.CuttingCornersBasic
 import TestScenarios.CuttingCornersPerfectOverpainting
+import TestScenarios.HoleSizeAndSpacing
 import TestScenarios.SpeedEffectOnGame
 import TestScenarios.StressTestRealisticTurtleSurvivalRound
 import Types.Speed as Speed exposing (Speed(..))
@@ -243,4 +244,10 @@ holeTests =
                     |> expectRoundOutcome
                         TestScenarios.CrashingWhileBecomingSolid.config
                         TestScenarios.CrashingWhileBecomingSolid.expectedOutcome
+        , test "Hole size and spacing are correct" <|
+            \_ ->
+                roundWith TestScenarios.HoleSizeAndSpacing.spawnedKurves
+                    |> expectRoundOutcome
+                        TestScenarios.HoleSizeAndSpacing.config
+                        TestScenarios.HoleSizeAndSpacing.expectedOutcome
         ]


### PR DESCRIPTION
How holes should be implemented has been a headache since forever:

  * What exactly does "ticks left" mean? When exactly should a Kurve become holy/unholy, given how many ticks it has "left" in its current holiness? See #148.
  * What does "hole size" mean? Does it refer to the gap between the _edges_ of the hole, or something else?
  * What does "hole interval" mean? Does it refer to the length of the inter-hole segment from edge to edge, the distance from the start of a hole to the start of the next one, or something else?

In fact, I apparently pondered such questions as far back as 7156cccb144403db1e314686ac097f0c89491c6b. Back then, the game wasn't designed to  be deterministic by any stretch, so it's not obvious how exactly it worked, but yeah …

This PR adds a test case with a Kurve that moves straight down and draws 5-tick holes of length 3 (measured from edge to edge) and 5-tick inter-hole segments of length 7. The Kurve opens a hole as soon as it can: after drawing its spawn, it doesn't draw its body again until it has finished its first hole. During its second inter-hole segment (excluding the spawn), it crashes into the wall:

    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛
    ⬛⬛⬛⬛🟩🟩🟩⬛⬛⬛⬛

Somewhat counter-intuitively, this is achieved by setting a hole interval and size of 4 and 1, respectively. The purpose is not to claim that the current implementation is "correct", just to document what it _is_, so that the meaning and implications of future hole-related changes will be more obvious.