### PR TITLE
Make test scenarios replayable

### DIFF
--- a/src/TestScenarioHelpers.elm
+++ b/src/TestScenarioHelpers.elm
@@ -13,11 +13,9 @@ module TestScenarioHelpers exposing
 
 import Color
 import Effect exposing (Effect)
-import Holes exposing (HoleStatus(..))
 import Random
 import Round exposing (RoundInitialState)
 import Set
-import Types.Angle exposing (Angle(..))
 import Types.Kurve as Kurve exposing (Kurve, UserInteraction(..))
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick as Tick exposing (Tick)
@@ -51,11 +49,7 @@ makeZombieKurve { color, id, state } =
     , id = id
     , controls = ( Set.empty, Set.empty )
     , state = state
-    , stateAtSpawn =
-        { position = ( 0, 0 )
-        , direction = Angle (pi / 2)
-        , holeStatus = NoHoles
-        }
+    , stateAtSpawn = state
     , reversedInteractions = []
     }
 


### PR DESCRIPTION
## Problem

At least since #144, we've had the problem that a visualized test-case scenario cannot be replayed (after the first run, which is technically already a replay).

### Repro

Make these changes:

```diff
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -48,6 +48,7 @@ import Players
 import Random
 import Round exposing (Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)
+import TestScenarios.CuttingCornersPerfectOverpainting
 import Time
 import Types.FrameTime exposing (FrameTime)
 import Types.Kurve exposing (Kurve)
@@ -69,13 +70,23 @@ port focusLost : (() -> msg) -> Sub msg
 
 init : () -> ( Model, Cmd Msg )
 init _ =
-    ( { pressedButtons = Set.empty
-      , appState = InMenu SplashScreen (Random.initialSeed 1337)
-      , config = Config.default
-      , players = initialPlayers
-      }
-    , Cmd.none
-    )
+    let
+        model : Model
+        model =
+            { pressedButtons = Set.empty
+            , appState = InMenu SplashScreen (Random.initialSeed 1337)
+            , config = TestScenarios.CuttingCornersPerfectOverpainting.config
+            , players = initialPlayers
+            }
+    in
+    startRound Replay
+        model
+        (prepareReplayRound
+            { seedAfterSpawn = Random.initialSeed 0
+            , spawnedKurves = TestScenarios.CuttingCornersPerfectOverpainting.spawnedKurves
+            }
+        )
+        |> Tuple.mapSecond makeCmd
 
 
 startRound : LiveOrReplay -> Model -> Round -> ( Model, Effect )
```

When the round is over, press R to replay it. It doesn't work: the Kurves just spawn on top of each other in the top left corner instead of re-enacting the scenario again.

### Root cause

Since the introduction of `makeZombieKurve` in #135, it has always set the `stateAtSpawn` field to a useless dummy value. While that certainly looks weird in retrospect, back then it wasn't _that_ weird, for two reasons:

  * All but one of the Kurves DRYed up using `makeZombieKurve` already had useless dummy `stateAtSpawn` values.
  * Visualizing test cases (#144) wasn't yet established as a part of the workflow, so the `stateAtSpawn` of a Kurve in the test suite would never be used for anything.

## Solution

There's absolutely no reason for Kurves to get a dummy `stateAtSpawn` instead of the state they actually had. This PR fixes that.