### PR TITLE
Refactor WhatToDraw merging

### DIFF
--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -11,16 +11,11 @@ type alias WhatToDraw =
     }
 
 
-mergeWhatToDraw : Maybe WhatToDraw -> WhatToDraw -> WhatToDraw
-mergeWhatToDraw actionFirst whatToDrawThen =
-    case ( actionFirst, whatToDrawThen ) of
-        ( Nothing, whatToDraw ) ->
-            whatToDraw
-
-        ( Just whatFirst, whatThen ) ->
-            { headDrawing = whatThen.headDrawing
-            , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
-            }
+mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw
+mergeWhatToDraw whatFirst whatThen =
+    { headDrawing = whatThen.headDrawing
+    , bodyDrawing = whatFirst.bodyDrawing ++ whatThen.bodyDrawing
+    }
 
 
 drawSpawnsPermanently : List Kurve -> WhatToDraw

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -39,7 +39,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
             -> Round
             -> Maybe WhatToDraw
             -> ( TickResult ( LeftoverFrameTime, Tick, Round ), Maybe WhatToDraw )
-        recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar whatToDrawSoFar =
+        recurse timeLeftToConsume lastTickReactedTo midRoundStateSoFar maybeWhatToDrawSoFar =
             if timeLeftToConsume >= timestep then
                 let
                     incrementedTick : Tick
@@ -51,7 +51,12 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
 
                     newWhatToDraw : WhatToDraw
                     newWhatToDraw =
-                        mergeWhatToDraw whatToDrawSoFar whatToDrawForThisTick
+                        case maybeWhatToDrawSoFar of
+                            Nothing ->
+                                whatToDrawForThisTick
+
+                            Just whatToDrawSoFar ->
+                                mergeWhatToDraw whatToDrawSoFar whatToDrawForThisTick
                 in
                 case tickResult of
                     RoundKeepsGoing newMidRoundState ->
@@ -64,7 +69,7 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
 
             else
                 ( RoundKeepsGoing ( timeLeftToConsume, lastTickReactedTo, midRoundStateSoFar )
-                , whatToDrawSoFar
+                , maybeWhatToDrawSoFar
                 )
     in
     recurse timeToConsume lastTick midRoundState Nothing


### PR DESCRIPTION
We were a bit confused about why `mergeWhatToDraw` didn't just take two `WhatToDraw`s. It's obviously not without reason, but we think handling the `Nothing` case at the call site makes the code clearer.

It's also somewhat confusing that `whatToDrawSoFar` in `recurse` is a `Maybe WhatToDraw` and not a `WhatToDraw`. That's fixed in this PR.

💡 `git show --color-words='case .+|what|.'`

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>