### PR TITLE
Expect effects for crash-into-wall test cases

### DIFF
--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -2,6 +2,7 @@ module TestScenarios.CrashIntoWallBottom exposing (config, expectedOutcome, spaw
 
 import Colors
 import Config exposing (Config)
+import Effect exposing (Effect(..))
 import Holes exposing (HoleStatus(..))
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
@@ -43,5 +44,51 @@ expectedOutcome =
               }
             ]
         }
-    , effectsItShouldProduce = DoNotCare
+    , effectsItShouldProduce =
+        ExpectEffects
+            [ DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 475 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 475 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 476 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 476 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 99, y = 477 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 99, y = 477 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            ]
     }

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -2,6 +2,7 @@ module TestScenarios.CrashIntoWallLeft exposing (config, expectedOutcome, spawne
 
 import Colors
 import Config exposing (Config)
+import Effect exposing (Effect(..))
 import Holes exposing (HoleStatus(..))
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
@@ -43,5 +44,55 @@ expectedOutcome =
               }
             ]
         }
-    , effectsItShouldProduce = DoNotCare
+    , effectsItShouldProduce =
+        ExpectEffects
+            [ DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 2, y = 99 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 2, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 1, y = 99 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 1, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 0, y = 99 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 0, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 0, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            ]
     }

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -2,6 +2,7 @@ module TestScenarios.CrashIntoWallRight exposing (config, expectedOutcome, spawn
 
 import Colors
 import Config exposing (Config)
+import Effect exposing (Effect(..))
 import Holes exposing (HoleStatus(..))
 import TestScenarioHelpers exposing (EffectsExpectation(..), RoundOutcome, makeZombieKurve, playerIds, tickNumber)
 import Types.Angle exposing (Angle(..))
@@ -43,5 +44,51 @@ expectedOutcome =
               }
             ]
         }
-    , effectsItShouldProduce = DoNotCare
+    , effectsItShouldProduce =
+        ExpectEffects
+            [ DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
+                , headDrawing = []
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 554, y = 99 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 554, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 555, y = 99 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 555, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = [ ( Colors.green, { x = 556, y = 99 } ) ]
+                , headDrawing = [ ( Colors.green, { x = 556, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
+                }
+            ]
     }


### PR DESCRIPTION
While working on #259 (which was [recently] re-opened), we realized that we want to expect effects for how Kurves crash into walls. Note in particular that the top and left walls are fundamentally different from the bottom and right walls; see #263. That's why `CrashIntoWallTop` and `CrashIntoWallLeft` have an "extra" `DrawSomething` whose `bodyDrawing` is empty.

[recently]: https://github.com/SimonAlling/kurve/issues/259#issuecomment-3800842263

Co-authored-by: Simon Lydell <simon.lydell@gmail.com>