### PR TITLE
Refactor occupiedPixels initialization

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -138,12 +138,25 @@ prepareRoundFromKnownInitialState initialState =
         round : Round
         round =
             { kurves = { alive = theKurves, dead = [] }
-            , occupiedPixels = List.foldl (.state >> .position >> World.drawingPosition >> World.pixelsToOccupy >> Set.union) Set.empty theKurves
+            , occupiedPixels = initialOccupiedPixels theKurves
             , initialState = initialState
             , seed = initialState.seedAfterSpawn
             }
     in
     round
+
+
+initialOccupiedPixels : List Kurve -> Set Pixel
+initialOccupiedPixels =
+    let
+        placeKurve : Kurve -> Set Pixel -> Set Pixel
+        placeKurve kurve =
+            kurve.state.position
+                |> World.drawingPosition
+                |> World.pixelsToOccupy
+                |> Set.union
+    in
+    List.foldl placeKurve Set.empty
 
 
 reactToTick : Config -> Tick -> Round -> ( TickResult Round, WhatToDraw )


### PR DESCRIPTION
This PR de-inlines `List.foldl (.state >> .position >> World.drawingPosition >> World.pixelsToOccupy >> Set.union) Set.empty` to a standalone function, to improve readability and type-checker error messages.

💡 `git show --color-words='\w+|.'`