### PR TITLE
Improve drawing performance in long frames

### DIFF
--- a/src/Drawing.elm
+++ b/src/Drawing.elm
@@ -1,4 +1,4 @@
-module Drawing exposing (WhatToDraw, drawSpawnsPermanently, drawSpawnsTemporarily, getColorAndDrawingPosition, mergeWhatToDraw)
+module Drawing exposing (DrawingAccumulator, WhatToDraw, accumulate, drawSpawnsPermanently, drawSpawnsTemporarily, finalize, getColorAndDrawingPosition, initialize, mergeWhatToDraw)
 
 import Color exposing (Color)
 import Types.Kurve exposing (Kurve)
@@ -9,6 +9,48 @@ type alias WhatToDraw =
     { headDrawing : List ( Color, DrawingPosition )
     , bodyDrawing : List ( Color, DrawingPosition )
     }
+
+
+{-| Used to efficiently accumulate what to draw, even in extremely long frames (such as when fast-forwarding/rewinding a replay).
+-}
+type DrawingAccumulator
+    = Empty
+    | Accum
+        { headDrawing : List ( Color, DrawingPosition )
+        , reversedBodyDrawings : List (List ( Color, DrawingPosition ))
+        }
+
+
+initialize : DrawingAccumulator
+initialize =
+    Empty
+
+
+accumulate : DrawingAccumulator -> WhatToDraw -> DrawingAccumulator
+accumulate acc new =
+    Accum
+        { headDrawing = new.headDrawing
+        , reversedBodyDrawings =
+            case acc of
+                Empty ->
+                    [ new.bodyDrawing ]
+
+                Accum accumulated ->
+                    new.bodyDrawing :: accumulated.reversedBodyDrawings
+        }
+
+
+finalize : DrawingAccumulator -> Maybe WhatToDraw
+finalize acc =
+    case acc of
+        Empty ->
+            Nothing
+
+        Accum accumulated ->
+            Just
+                { headDrawing = accumulated.headDrawing
+                , bodyDrawing = accumulated.reversedBodyDrawings |> List.reverse |> List.concat
+                }
 
 
 mergeWhatToDraw : WhatToDraw -> WhatToDraw -> WhatToDraw


### PR DESCRIPTION
As mentioned in #323, fast-forwarding performance is terrible when skipping ahead more than a few seconds. That makes rewinding (which is really just going back to the beginning and then fast-forwarding) extremely slow in large rounds, as shown by the benchmark devised in that PR.

The problem is that we accumulate `WhatToDraw`s by naively concatenating their `bodyDrawing` lists with `(++)`. As the frame time to consume increases, so does the length of the _first_ argument to `(++)`, resulting in quadratic asymptotic time complexity.

This PR is an attempt at accumulating `WhatToDraw`s efficiently instead, using a new `DrawingAccumulator` type and its accompanying functions `initialize`, `accumulate` and `finalize`. Together, they are used to construct the `Maybe WhatToDraw` in the tuple returned by `consumeAnimationFrame`.

## Performance improvement

The same patch as in #323 can be applied with these changes. Results on my Ubuntu laptop with a Core i7-7500U:

|        | Browser    | `npm test`  |
|--------|------------|-------------|
| Before | ~5 seconds | >11 seconds |
| After  | ~1 second  | <4 seconds  |

Notes:

  * The browser results refer to the approximate time from when the Kurve has finished spawning to when the entire round has been rendered, with _Compilation mode_ set to _Optimize_ in elm-watch's GUI.
  * `npm test` expectedly fails with the benchmark patch applied, but it fails much faster with the changes in this PR.

As for `npm test` without any benchmark patch applied, it seems to be slightly faster as well, based on `for i in $(seq 1 20); do npm test; sleep 1; done | grep Duration: | grep -E -o '[0-9]+' | sort`.

## Is `List.reverse |> List.concat` inefficient?

Both @lydell and I had the intuition that `List.foldl List.append []` might be more efficient, but I was unable to show any measurable difference. If `List.foldl List.append []` can be shown to be faster, then we can make that change later; otherwise I prefer `reverse` followed by `concat` because it's clearer.

💡 `git show --color-words='Drawing\.accumulate drawingAccumulator|\w+|.'`