### PR TITLE
Optimize hitbox implementation

### DIFF
--- a/src/World.elm
+++ b/src/World.elm
@@ -121,17 +121,17 @@ computePointInFront oldPosition newPosition =
 isCloseTo : ( Float, Float ) -> Pixel -> Bool
 isCloseTo ( x_front, y_front ) ( x_candidate, y_candidate ) =
     let
-        squareDistanceBetweenPoints : Float
-        squareDistanceBetweenPoints =
+        squaredDistanceBetweenPoints : Float
+        squaredDistanceBetweenPoints =
             (x_front - toFloat x_candidate) ^ 2 + (y_front - toFloat y_candidate) ^ 2
     in
-    squareDistanceBetweenPoints <= maxSquareDistance
+    squaredDistanceBetweenPoints <= maxSquaredDistance
 
 
 {-| Must be at least 5/4 (inclusive) and at most (3/2)² = 9/4 (exclusive); see the PR that added this comment.
 -}
-maxSquareDistance : Float
-maxSquareDistance =
+maxSquaredDistance : Float
+maxSquaredDistance =
     2
 
 


### PR DESCRIPTION
## Problem

Profiling the `ReplayStraightVerticalLine` scenario in Firefox on my Ubuntu laptop reveals that `reactToTick` consumes about 20 % of the execution time, almost half of which is spent in `hitbox`.

The current hitbox implementation is quite crude: we compute all the pixels for the two involved drawing positions using `pixelsToOccupy` (which seems quite inefficient in itself, based on my profiling). Then we either do some probably-not-so-efficient filtering stuff if the atomic drawing-position step being processed is a so-called 45-degree draw, or we take the set difference.

## Solution

I presented this problem to @LouiseEngberg, who came up with a clever and elegant solution:

  1. Compute a point in front of the Kurve that represents the destination of the drawing-position step in question.
  2. Keep precisely those pixels in `newPixels` that are within a certain distance from that point.

This way, we only need to call `pixelsToOccupy` once, and we need not perform any operations on `oldPixels`.

Furthermore, we don't even need to treat "45-degree draws" as a special case; we end up with a single clean, consistent implementation, which basically just boils down to "check if there is an obstacle within a small area right in front of the Kurve".

### Algorithm

To understand the algorithm, it helps to think of the center point of each pixel, rather than its upper left corner.

  1. Let 𝐶 be the center point of the center pixel of the old drawing position.

  2. Let 𝒗 be the vector representing the direction and length of the drawing-position step. Note that the length of 𝒗 will always be either 1 (in the 0-degree case) or √2 (in the 45-degree case).

  3. Let 𝐹 = 𝐶 + 2.5𝒗 be the so-called point in front of the Kurve. It will be either of these:

       * In the 0-degree case: the center point of the outward-facing _edge_ of the pixel right in front of the Kurve.
       * In the 45-degree case: the outward-facing _corner_ of the pixel right in front of the Kurve.
 
     These illustrations depict 𝐹 (pointed at by an arrow) in relation to the old drawing position in each of the two cases:

     #### 0-degree case

         🟥🟥🟥
         🟥🟥🟥➡️
         🟥🟥🟥

     #### 45-degree case

               ↗️
         🟥🟥🟥
         🟥🟥🟥
         🟥🟥🟥

  4. Choose some 𝑟 such that a circle centered at 𝐹 with radius 𝑟 contains the center point(s) of precisely these pixels out of those occupied by the new drawing position:

       * In the 0-degree case: the _three_ pixels right in front of the Kurve's leading _edge_.
       * In the 45-degree case: the _single_ pixel right in front of the Kurve's leading _corner_.

     These illustrations depict the pixels to include in the hitbox in each of the two cases:

     #### 0-degree case

         🟥🟥🟥⬜
         🟥🟥🟥⬜
         🟥🟥🟥⬜

     #### 45-degree case

               ⬜
         🟥🟥🟥
         🟥🟥🟥
         🟥🟥🟥

  5. Let the hitbox consist of all pixels occupied by the new drawing position whose distance to 𝐹 is less than or equal to 𝑟.

#### Choosing 𝑟

It can be shown using basic geometry that √(5/4) ≤ 𝑟 < 3/2 is necessary and sufficient to satisfy the criterion in (4) above (if a circle is said to "contain" the points on its circumference):

  * √(5/4) is the distance to the two "flank" pixels that should be included in the hitbox in the 0-degree case.
  * 3/2 is the distance to the center pixel of the new drawing position in the 0-degree case, which must _not_ be included in the hitbox because then the Kurve would crash into itself.
  * The distance to the closest pixels that should _not_ be included in the 45-degree case is √(5/2), which is greater than 3/2.

The actual implementation doesn't explicitly use so-called center points of pixels; everything's essentially translated left by 1/2 and up by 1/2 compared to the description above.

### Performance improvement

Running the test suite 20 times can serve as a benchmark:

    for i in $(seq 1 20); do npm test; sleep 1; done | grep Duration: | grep -E -o '[0-9]+' | sort

This PR improves the median execution time from ~1360 ms to ~1150 ms on my Ubuntu laptop with a Core i7-7500U.

The difference is unequivocal in the browser as well: the time spent in `hitbox` is almost cut in half, based on my profiling.

Co-authored-by: Louise Engberg <lo.engberg@gmail.com>