### PR TITLE
DRY up drawing-position occupation code

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -153,8 +153,7 @@ initialOccupiedPixels =
         placeKurve kurve =
             kurve.state.position
                 |> World.drawingPosition
-                |> World.pixelsToOccupy
-                |> Set.union
+                |> World.occupyDrawingPosition
     in
     List.foldl placeKurve Set.empty
 
@@ -228,7 +227,7 @@ checkIndividualKurve config tick kurve ( checkedKurves, occupiedPixels, coloredD
         occupiedPixelsAfterCheckingThisKurve : Set Pixel
         occupiedPixelsAfterCheckingThisKurve =
             List.foldl
-                (World.pixelsToOccupy >> Set.union)
+                World.occupyDrawingPosition
                 occupiedPixels
                 newKurveDrawingPositions
 

--- a/src/World.elm
+++ b/src/World.elm
@@ -6,7 +6,7 @@ module World exposing
     , distanceBetween
     , drawingPosition
     , hitbox
-    , pixelsToOccupy
+    , occupyDrawingPosition
     )
 
 import List.Cartesian
@@ -28,6 +28,11 @@ type alias DrawingPosition =
 
 type alias Pixel =
     ( Int, Int )
+
+
+occupyDrawingPosition : DrawingPosition -> Set Pixel -> Set Pixel
+occupyDrawingPosition drawingPos occupiedPixels =
+    Set.union (pixelsToOccupy drawingPos) occupiedPixels
 
 
 distanceBetween : Position -> Position -> Distance


### PR DESCRIPTION
Note that the order of the arguments to `Set.union` in `occupyDrawingPosition` actually is significant. With them swapped, `npm test` seems to hang indefinitely, and takes about 10 seconds with `Test.skip` applied to `stressTests`.