### PR TITLE
Rename canvases from main/overlay to body/head

### DIFF
--- a/_site/index.js
+++ b/_site/index.js
@@ -13,26 +13,26 @@ function clearRectangleIfCanvasExists(canvas, { x, y, width, height }) {
     context?.clearRect(x, y, width, height);
 }
 
-app.ports.renderMain.subscribe(({ clearFirst, squares }) => {
-    const canvas_main = document.getElementById("canvas_main");
+app.ports.renderBodies.subscribe(({ clearFirst, squares }) => {
+    const bodyCanvas = document.getElementById("bodyCanvas");
     if (clearFirst) {
-        clearRectangleIfCanvasExists(canvas_main, { x: 0, y: 0, width: canvas_main?.width, height: canvas_main?.height });
+        clearRectangleIfCanvasExists(bodyCanvas, { x: 0, y: 0, width: bodyCanvas?.width, height: bodyCanvas?.height });
     }
     for (const square of squares) {
-        drawSquare(canvas_main, square);
+        drawSquare(bodyCanvas, square);
     }
 });
 
-app.ports.clearMain.subscribe(() => {
-    const canvas_main = document.getElementById("canvas_main");
-    clearRectangleIfCanvasExists(canvas_main, { x: 0, y: 0, width: canvas_main?.width, height: canvas_main?.height });
+app.ports.clearBodies.subscribe(() => {
+    const bodyCanvas = document.getElementById("bodyCanvas");
+    clearRectangleIfCanvasExists(bodyCanvas, { x: 0, y: 0, width: bodyCanvas?.width, height: bodyCanvas?.height });
 });
 
-app.ports.renderOverlay.subscribe(squares => {
-    const canvas_overlay = document.getElementById("canvas_overlay");
-    clearRectangleIfCanvasExists(canvas_overlay, { x: 0, y: 0, width: canvas_overlay?.width, height: canvas_overlay?.height }); // Very large numbers don't work; see the commit that added this comment.
+app.ports.renderHeads.subscribe(squares => {
+    const headCanvas = document.getElementById("headCanvas");
+    clearRectangleIfCanvasExists(headCanvas, { x: 0, y: 0, width: headCanvas?.width, height: headCanvas?.height }); // Very large numbers don't work; see the commit that added this comment.
     for (const square of squares) {
-        drawSquare(canvas_overlay, square);
+        drawSquare(headCanvas, square);
     }
 });
 

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -6,13 +6,13 @@ import Thickness exposing (theThickness)
 import World exposing (DrawingPosition)
 
 
-port renderMain : { clearFirst : Bool, squares : List { position : DrawingPosition, thickness : Int, color : String } } -> Cmd msg
+port renderBodies : { clearFirst : Bool, squares : List { position : DrawingPosition, thickness : Int, color : String } } -> Cmd msg
 
 
-port clearMain : () -> Cmd msg
+port clearBodies : () -> Cmd msg
 
 
-port renderOverlay : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
+port renderHeads : List { position : DrawingPosition, thickness : Int, color : String } -> Cmd msg
 
 
 drawingCmd : Bool -> WhatToDraw -> Cmd msg
@@ -25,7 +25,7 @@ drawingCmd clearFirst whatToDraw =
 
 bodyDrawingCmd : Bool -> List ( Color, DrawingPosition ) -> Cmd msg
 bodyDrawingCmd clearFirst coloredDrawingPositions =
-    renderMain
+    renderBodies
         { clearFirst = clearFirst
         , squares =
             List.map
@@ -41,7 +41,7 @@ bodyDrawingCmd clearFirst coloredDrawingPositions =
 
 headDrawingCmd : List ( Color, DrawingPosition ) -> Cmd msg
 headDrawingCmd =
-    renderOverlay
+    renderHeads
         << List.map
             (\( color, position ) ->
                 { position = position
@@ -54,6 +54,6 @@ headDrawingCmd =
 clearEverything : Cmd msg
 clearEverything =
     Cmd.batch
-        [ renderOverlay []
-        , clearMain ()
+        [ renderHeads []
+        , clearBodies ()
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -540,13 +540,13 @@ view model =
                         [ Attr.id "border"
                         ]
                         [ canvas
-                            [ Attr.id "canvas_main"
+                            [ Attr.id "bodyCanvas"
                             , Attr.width 559
                             , Attr.height 480
                             ]
                             []
                         , canvas
-                            [ Attr.id "canvas_overlay"
+                            [ Attr.id "headCanvas"
                             , Attr.width 559
                             , Attr.height 480
                             , Attr.class "overlay"

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -260,7 +260,7 @@ button {
     }
 }
 
-#canvas_main {
+#bodyCanvas {
     background-color: black;
     overflow: hidden;
 }


### PR DESCRIPTION
The current terminology doesn't really convey the purpose of the two canvases. "Overlay" for the head-drawing canvas is especially confusing when we have an unrelated "real" overlay/HUD (#86, #240).

This PR makes these renamings:

  * `canvas_main` → `bodyCanvas`
  * `canvas_overlay` → `headCanvas`
  * `renderMain` → `renderBodies`
  * `clearMain` → `clearBodies`
  * `renderOverlay` → `renderHeads`

💡 `git show --color-words='\w+|.'`