### PR TITLE
Use MainLoop.noLeftoverFrameTime instead of 0

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -433,7 +433,12 @@ rewindReplay activeGameState model =
                     drawSpawnsPermanently roundAtBeginning.kurves.alive
 
                 ( tickResult, maybeWhatToDrawForSkippingAhead ) =
-                    MainLoop.consumeAnimationFrame model.config millisecondsToSkipAhead 0 Tick.genesis roundAtBeginning
+                    MainLoop.consumeAnimationFrame
+                        model.config
+                        millisecondsToSkipAhead
+                        MainLoop.noLeftoverFrameTime
+                        Tick.genesis
+                        roundAtBeginning
 
                 whatToDraw : WhatToDraw
                 whatToDraw =


### PR DESCRIPTION
Ever since #150, the intention has been to use `MainLoop.noLeftoverFrameTime` rather than `0` as the third argument to `consumeAnimationFrame`, but I forgot that in #323.

Replacing `0` with `MainLoop.noLeftoverFrameTime` made the line so long that I decided to split it up as part of this PR.

💡 `git show --color-words=.`