### PR TITLE
Define and use OccupiedPixels type

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -36,7 +36,7 @@ import Types.Speed as Speed
 import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
 import Types.TurningState exposing (TurningState)
-import World exposing (DrawingPosition, Pixel, Position)
+import World exposing (DrawingPosition, OccupiedPixels, Pixel, Position)
 
 
 type GameState
@@ -146,10 +146,10 @@ prepareRoundFromKnownInitialState initialState =
     round
 
 
-initialOccupiedPixels : List Kurve -> Set Pixel
+initialOccupiedPixels : List Kurve -> OccupiedPixels
 initialOccupiedPixels =
     let
-        placeKurve : Kurve -> Set Pixel -> Set Pixel
+        placeKurve : Kurve -> OccupiedPixels -> OccupiedPixels
         placeKurve kurve =
             kurve.state.position
                 |> World.drawingPosition
@@ -209,10 +209,10 @@ checkIndividualKurve :
     Config
     -> Tick
     -> Kurve
-    -> ( Kurves, Set World.Pixel, List ( Color, DrawingPosition ) )
+    -> ( Kurves, OccupiedPixels, List ( Color, DrawingPosition ) )
     ->
         ( Kurves
-        , Set World.Pixel
+        , OccupiedPixels
         , List ( Color, DrawingPosition )
         )
 checkIndividualKurve config tick kurve ( checkedKurves, occupiedPixels, coloredDrawingPositions ) =
@@ -224,7 +224,7 @@ checkIndividualKurve config tick kurve ( checkedKurves, occupiedPixels, coloredD
         ( newKurveDrawingPositions, checkedKurve, fate ) =
             updateKurve config turningState occupiedPixels kurve
 
-        occupiedPixelsAfterCheckingThisKurve : Set Pixel
+        occupiedPixelsAfterCheckingThisKurve : OccupiedPixels
         occupiedPixelsAfterCheckingThisKurve =
             List.foldl
                 World.occupyDrawingPosition
@@ -256,7 +256,7 @@ type alias HolinessTransition =
     }
 
 
-evaluateMove : Config -> Position -> Position -> Set Pixel -> HolinessTransition -> ( List DrawingPosition, Fate )
+evaluateMove : Config -> Position -> Position -> OccupiedPixels -> HolinessTransition -> ( List DrawingPosition, Fate )
 evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransition =
     let
         startingPointAsDrawingPosition : DrawingPosition
@@ -349,7 +349,7 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransit
     ( positionsToDraw |> List.reverse, evaluatedStatus )
 
 
-updateKurve : Config -> TurningState -> Set Pixel -> Kurve -> ( List DrawingPosition, Kurve, Fate )
+updateKurve : Config -> TurningState -> OccupiedPixels -> Kurve -> ( List DrawingPosition, Kurve, Fate )
 updateKurve config turningState occupiedPixels kurve =
     let
         distanceTraveledSinceLastTick : Float

--- a/src/Round.elm
+++ b/src/Round.elm
@@ -12,16 +12,15 @@ module Round exposing
 
 import Dict exposing (Dict)
 import Random
-import Set exposing (Set)
 import Types.Kurve as Kurve exposing (Kurve)
 import Types.PlayerId exposing (PlayerId)
 import Types.Score exposing (Score(..))
-import World exposing (Pixel)
+import World exposing (OccupiedPixels)
 
 
 type alias Round =
     { kurves : Kurves
-    , occupiedPixels : Set Pixel
+    , occupiedPixels : OccupiedPixels
     , initialState : RoundInitialState
     , seed : Random.Seed
     }

--- a/src/World.elm
+++ b/src/World.elm
@@ -1,5 +1,6 @@
 module World exposing
     ( DrawingPosition
+    , OccupiedPixels
     , Pixel
     , Position
     , desiredDrawingPositions
@@ -30,7 +31,11 @@ type alias Pixel =
     ( Int, Int )
 
 
-occupyDrawingPosition : DrawingPosition -> Set Pixel -> Set Pixel
+type alias OccupiedPixels =
+    Set Pixel
+
+
+occupyDrawingPosition : DrawingPosition -> OccupiedPixels -> OccupiedPixels
 occupyDrawingPosition drawingPos occupiedPixels =
     Set.union (pixelsToOccupy drawingPos) occupiedPixels
 


### PR DESCRIPTION
This makes it slightly easier to replace it with a different type (#336), and decouples/distinguishes it from other `Set Pixel` values, like those returned by `hitbox` and `pixelsToOccupy`.

💡 `git show --color-words='OccupiedPixels|.'`