### PR TITLE
DRY up confirmation dialog implementation

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -202,18 +202,23 @@ update msg ({ config } as model) =
             ( handleUserInteraction Up key model, DoNothing )
 
         DialogChoiceMade option ->
-            case model.appState of
-                InGame (RoundOver liveOrReplay pausedOrNot tickThatEndedIt finishedRound (Dialog.Open _)) ->
-                    case option of
-                        Dialog.Confirm ->
-                            goToLobby finishedRound.seed model
+            handleDialogChoice option model
 
-                        Dialog.Cancel ->
-                            ( { model | appState = InGame (RoundOver liveOrReplay pausedOrNot tickThatEndedIt finishedRound Dialog.NotOpen) }, DoNothing )
 
-                _ ->
-                    -- Not expected to ever happen.
-                    ( model, DoNothing )
+handleDialogChoice : Dialog.Option -> Model -> ( Model, Effect )
+handleDialogChoice option model =
+    case model.appState of
+        InGame (RoundOver liveOrReplay pausedOrNot tickThatEndedIt finishedRound (Dialog.Open _)) ->
+            case option of
+                Dialog.Confirm ->
+                    goToLobby finishedRound.seed model
+
+                Dialog.Cancel ->
+                    ( { model | appState = InGame (RoundOver liveOrReplay pausedOrNot tickThatEndedIt finishedRound Dialog.NotOpen) }, DoNothing )
+
+        _ ->
+            -- Not expected to ever happen.
+            ( model, DoNothing )
 
 
 buttonUsed : Button -> Model -> ( Model, Effect )
@@ -286,11 +291,11 @@ buttonUsed button ({ config, pressedButtons } as model) =
                     let
                         cancel : ( Model, Effect )
                         cancel =
-                            update (DialogChoiceMade Dialog.Cancel) model
+                            handleDialogChoice Dialog.Cancel model
 
                         confirm : ( Model, Effect )
                         confirm =
-                            update (DialogChoiceMade Dialog.Confirm) model
+                            handleDialogChoice Dialog.Confirm model
 
                         select : Dialog.Option -> ( Model, Effect )
                         select option =


### PR DESCRIPTION
While experimenting with adding a confirmation dialog for proceeding to the next round after the end of a replay, I got bitten by the dialog implementation not being DRY.

💡 `git show --ignore-space-change`