### PR TITLE
Show replay hint when round over

### DIFF
--- a/src/GUI/Hints.elm
+++ b/src/GUI/Hints.elm
@@ -1,0 +1,25 @@
+module GUI.Hints exposing (Hint(..), render)
+
+import Colors
+import GUI.Text
+import Html exposing (Html, span)
+import Html.Attributes as Attr
+
+
+type Hint
+    = ShowHowToReplay
+
+
+render : Hint -> Html msg
+render hint =
+    span
+        [ Attr.class "hint"
+        ]
+        (GUI.Text.string (GUI.Text.Size 1) Colors.white (show hint))
+
+
+show : Hint -> String
+show hint =
+    case hint of
+        ShowHowToReplay ->
+            "Press R to replay"

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -1,6 +1,7 @@
 module GUI.TextOverlay exposing (textOverlay)
 
 import Colors
+import GUI.Hints exposing (Hint(..))
 import GUI.Navigation.Replay
 import GUI.Text
 import Game exposing (GameState(..), LiveOrReplay(..), PausedOrNot(..))
@@ -34,7 +35,8 @@ content gameState =
             [ replayIndicator, GUI.Navigation.Replay.whenActive ]
 
         RoundOver Live _ _ _ _ ->
-            [ pressRToReplay ]
+            [ GUI.Hints.render ShowHowToReplay
+            ]
 
         RoundOver Replay _ _ _ _ ->
             [ replayIndicator, GUI.Navigation.Replay.whenRoundOver ]
@@ -51,11 +53,3 @@ replayIndicator =
         [ Attr.class "textInUpperLeftCorner"
         ]
         (GUI.Text.string (GUI.Text.Size 2) Colors.white "R")
-
-
-pressRToReplay : Html msg
-pressRToReplay =
-    p
-        [ Attr.id "roundOverReplayHint"
-        ]
-        (GUI.Text.string (GUI.Text.Size 1) Colors.white "Press R to replay")

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -274,7 +274,7 @@ button {
     width: 1px; /* so width of #wrapper is an even number */
 }
 
-#roundOverReplayHint {
+.hint {
     position: absolute;
     bottom: 16px;
 }


### PR DESCRIPTION
The replay mode is the most significant feature we bring to the table compared to the original game (unless being able to play in the browser counts as a feature), but it's not obvious how to use it. This PR adds a hint at the end of every round.

## Readability

As mentioned in #341, the overlay is quite hard to read when there's a lot of Kurve activity behind it, so future improvement is likely needed. However, it's likely that at least one of the first rounds in a match will be short enough for the hint to be clearly visible.

## Annoying?

It might be annoying for experienced users who already know how to replay to get the hint after every round. Ideas for future improvements:

  * Make it dismissable.
  * Make it appear after a delay.
  * Auto-dismiss it when a round is replayed.

💡 `git show --color-words=.`