### PR TITLE
Simplify seed replacement in test suite

### DIFF
--- a/tests/FullSessionTest.elm
+++ b/tests/FullSessionTest.elm
@@ -15,7 +15,7 @@ import TestHelpers.Effects exposing (clearsEverything, drawsBodySquares)
 import TestHelpers.EndToEnd exposing (endToEndTest)
 import TestHelpers.ListLength exposing (expectAtLeast, expectExactly)
 import TestHelpers.PlayerInput exposing (press, pressAndRelease, release)
-import TestHelpers.Randomness exposing (withSeed)
+import TestHelpers.Randomness exposing (withSeedIfInMenu)
 import Types.FrameTime exposing (FrameTime)
 
 
@@ -29,7 +29,7 @@ theTest =
         [ Test.test "Resulting model is correct" <|
             \_ ->
                 actualModel
-                    |> withSeed dummySeed
+                    |> withSeedIfInMenu dummySeed
                     |> Expect.equal expectedModel
         , Test.test "Body squares were drawn a considerable number of times" <|
             \_ ->

--- a/tests/TestHelpers/Randomness.elm
+++ b/tests/TestHelpers/Randomness.elm
@@ -1,47 +1,20 @@
-module TestHelpers.Randomness exposing (withSeed)
+module TestHelpers.Randomness exposing (withSeedIfInMenu)
 
 import App exposing (AppState(..))
-import Game exposing (ActiveGameState(..), GameState(..))
 import Main exposing (Model)
 import Random
-import Round exposing (Round)
 
 
-withSeed : Random.Seed -> Model -> Model
-withSeed desiredSeed model =
-    { model | appState = appStateWithSeed desiredSeed model.appState }
+withSeedIfInMenu : Random.Seed -> Model -> Model
+withSeedIfInMenu desiredSeed model =
+    { model | appState = appStateWithSeedIfInMenu desiredSeed model.appState }
 
 
-appStateWithSeed : Random.Seed -> AppState -> AppState
-appStateWithSeed desiredSeed appState =
+appStateWithSeedIfInMenu : Random.Seed -> AppState -> AppState
+appStateWithSeedIfInMenu desiredSeed appState =
     case appState of
         InMenu menuState _ ->
             InMenu menuState desiredSeed
 
         InGame gameState ->
-            InGame (gameStateWithSeed desiredSeed gameState)
-
-
-gameStateWithSeed : Random.Seed -> GameState -> GameState
-gameStateWithSeed desiredSeed gameState =
-    case gameState of
-        Active liveOrReplay pausedOrNot activeGameState ->
-            Active liveOrReplay pausedOrNot (activeGameStateWithSeed desiredSeed activeGameState)
-
-        RoundOver liveOrReplay pausedOrNot tickThatEndedIt round dialogState ->
-            RoundOver liveOrReplay pausedOrNot tickThatEndedIt (roundWithSeed desiredSeed round) dialogState
-
-
-activeGameStateWithSeed : Random.Seed -> ActiveGameState -> ActiveGameState
-activeGameStateWithSeed desiredSeed activeGameState =
-    case activeGameState of
-        Spawning spawnState round ->
-            Spawning spawnState (roundWithSeed desiredSeed round)
-
-        Moving leftoverFrameTime tick round ->
-            Moving leftoverFrameTime tick (roundWithSeed desiredSeed round)
-
-
-roundWithSeed : Random.Seed -> Round -> Round
-roundWithSeed desiredSeed round =
-    { round | seed = desiredSeed }
+            InGame gameState


### PR DESCRIPTION
We only ever use `withSeed` to make an actual model comparable to an expected model whose `appState` field is `InMenu Lobby dummySeed` (where `dummySeed` is hardcoded). The logic for replacing the seed in `InGame` app states only comes into play if the actual model isn't even _close_ to being equal to the expected one anyway. This PR specializes `withSeed` to the `InMenu` use case and renames it accordingly.

💡 `git show --color-words=.`