### PR TITLE
Ask for confirmation before leaving page

### DIFF
--- a/_site/index.js
+++ b/_site/index.js
@@ -67,3 +67,13 @@ document.addEventListener("contextmenu", event => {
 window.addEventListener("blur", () => {
     app.ports.focusLost.send(null);
 });
+
+window.addEventListener("beforeunload", event => {
+    if (shouldPreventUnload()) {
+        event.preventDefault();
+    }
+});
+
+function shouldPreventUnload() {
+    return document.getElementsByClassName("magic-class-name-to-prevent-unload").length > 0;
+}

--- a/src/JavaScript.elm
+++ b/src/JavaScript.elm
@@ -1,0 +1,9 @@
+module JavaScript exposing (magicClassNameToPreventUnload)
+
+{-| The JavaScript code should look for elements with this class name to determine whether to prevent unload.
+-}
+
+
+magicClassNameToPreventUnload : String
+magicClassNameToPreventUnload =
+    "magic-class-name-to-prevent-unload"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -33,6 +33,7 @@ import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
 import Input exposing (Button(..), ButtonDirection(..), inputSubscriptions, updatePressedButtons)
 import IsGameOver exposing (isGameOver)
+import JavaScript exposing (magicClassNameToPreventUnload)
 import MainLoop
 import Menu exposing (MenuState(..))
 import Players
@@ -631,6 +632,7 @@ view model =
         InGame gameState ->
             elmRoot
                 [ Attr.class "in-game"
+                , Attr.class magicClassNameToPreventUnload
                 ]
                 [ div
                     [ Attr.id "wrapper"


### PR DESCRIPTION
It completely sucks to lose an entire game due to accidentally unloading the page in whatever way.

It's worth mentioning that some common ways to reload the page have been whitelisted since 0b43ead86751cdccaf9a030b7de4d4bf003b49f6; see `isDeveloperCommand`. The concept of "developer commands" probably isn't something that should be a part of production builds, and this PR is orthogonal to that anyway, because there are many other ways to unload.