### PR TITLE
Use true number of spawn ticks in tests

### DIFF
--- a/tests/FirstRoundTest.elm
+++ b/tests/FirstRoundTest.elm
@@ -7,6 +7,7 @@ import Input exposing (Button(..))
 import List exposing (repeat)
 import Main exposing (Model, Msg(..), init)
 import Test
+import TestHelpers exposing (getNumberOfSpawnTicks)
 import TestHelpers.EndToEnd exposing (endToEndTest)
 import TestHelpers.PlayerInput exposing (pressAndRelease)
 import Types.FrameTime exposing (FrameTime)
@@ -16,7 +17,7 @@ theTest : Test.Test
 theTest =
     let
         ( _, actualEffects ) =
-            endToEndTest initialModel messages
+            endToEndTest initialModel (messages (getNumberOfSpawnTicks initialModel.config.spawn))
     in
     Test.test "How the first round starts" <|
         \_ ->
@@ -29,8 +30,8 @@ initialModel =
     init () |> Tuple.first
 
 
-messages : List Msg
-messages =
+messages : Int -> List Msg
+messages numberOfSpawnTicks =
     List.concat
         [ -- User proceeds to lobby:
           pressAndRelease (Key "Space")
@@ -42,7 +43,7 @@ messages =
         , pressAndRelease (Key "Space")
 
         -- Kurve spawns:
-        , repeat 7 SpawnTick
+        , repeat numberOfSpawnTicks SpawnTick
 
         -- Kurve moves for a while, preferably until it has created at least one hole:
         , repeat 240 (AnimationFrame frameDeltaInMs)

--- a/tests/FullSessionTest.elm
+++ b/tests/FullSessionTest.elm
@@ -11,6 +11,7 @@ import Players exposing (initialPlayers)
 import Random
 import Set
 import Test
+import TestHelpers exposing (getNumberOfSpawnTicks)
 import TestHelpers.Effects exposing (clearsEverything, drawsBodySquares)
 import TestHelpers.EndToEnd exposing (endToEndTest)
 import TestHelpers.ListLength exposing (expectAtLeast, expectExactly)
@@ -23,7 +24,7 @@ theTest : Test.Test
 theTest =
     let
         ( actualModel, actualEffects ) =
-            endToEndTest initialModel messages
+            endToEndTest initialModel (messages (getNumberOfSpawnTicks initialModel.config.spawn))
     in
     Test.describe "End-to-end test of an entire session"
         [ Test.test "Resulting model is correct" <|
@@ -58,8 +59,8 @@ initialModel =
     }
 
 
-messages : List Msg
-messages =
+messages : Int -> List Msg
+messages numberOfSpawnTicks =
     List.concat
         [ -- User proceeds to lobby:
           pressAndRelease (Key "Space")
@@ -71,7 +72,7 @@ messages =
         , pressAndRelease (Key "Space")
 
         -- Kurves spawn:
-        , repeat 12 SpawnTick
+        , repeat numberOfSpawnTicks SpawnTick
 
         -- A short while passes by:
         , repeat 20 (AnimationFrame frameDeltaInMs)
@@ -87,7 +88,7 @@ messages =
         , pressAndRelease (Key "KeyR")
 
         -- User waits for the replay to finish:
-        , repeat 12 SpawnTick
+        , repeat numberOfSpawnTicks SpawnTick
         , repeat 20 (AnimationFrame frameDeltaInMs)
         , repeat 166 (AnimationFrame frameDeltaInMs)
 

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -1,7 +1,7 @@
-module TestHelpers exposing (expectRoundOutcome, playOutRound)
+module TestHelpers exposing (expectRoundOutcome, getNumberOfSpawnTicks, playOutRound)
 
 import App exposing (AppState(..))
-import Config exposing (Config)
+import Config exposing (Config, SpawnConfig)
 import Effect exposing (Effect)
 import Expect
 import Game
@@ -173,3 +173,8 @@ showTick =
 refreshRateInTests : RefreshRate
 refreshRateInTests =
     60
+
+
+getNumberOfSpawnTicks : SpawnConfig -> Int
+getNumberOfSpawnTicks spawnConfig =
+    spawnConfig.numberOfFlickerTicks + 2


### PR DESCRIPTION
For some reason (two off-by-one errors?), it seems like the number of `SpawnTick` messages is always 2 greater than the `numberOfFlickerTicks` value. This PR replaces three hardcoded numbers of `SpawnTick` messages in tests with numbers computed from `numberOfFlickerTicks`:

  * `FirstRoundTest`: `7` is already correct; this PR just un-hardcodes it.
  * `FullSessionTest`: `12` is incorrect, but the test case doesn't check anything affected by that. When the test case was added in #290, any number greater than or equal to 7 would work. That's still the case, except that numbers less than 7 now cause the test case to hang instead of fail.

💡 `git show --color-words=.`