### PR TITLE
Make spawn flickering more similar to original game

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -119,7 +119,7 @@ stepSpawnState config { kurvesLeft, alreadySpawnedKurves, ticksLeft } =
 
                 kurvesToDraw : List Kurve
                 kurvesToDraw =
-                    if isEven ticksLeft then
+                    if not (isEven ticksLeft) then
                         spawnedAndSpawning
 
                     else

--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -48,10 +48,6 @@ expectedOutcome =
         ExpectEffects
             [ DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
                 }
             , DrawSomething
@@ -69,6 +65,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -48,10 +48,6 @@ expectedOutcome =
         ExpectEffects
             [ DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
                 }
             , DrawSomething
@@ -69,6 +65,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -48,10 +48,6 @@ expectedOutcome =
         ExpectEffects
             [ DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
                 }
             , DrawSomething
@@ -69,6 +65,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -48,10 +48,6 @@ expectedOutcome =
         ExpectEffects
             [ DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 }
             , DrawSomething
@@ -69,6 +65,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]

--- a/src/TestScenarios/CrashSomewhatSoon.elm
+++ b/src/TestScenarios/CrashSomewhatSoon.elm
@@ -50,10 +50,6 @@ expectedOutcome =
         ExpectEffects
             [ DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
                 }
             , DrawSomething
@@ -71,6 +67,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]

--- a/src/TestScenarios/CrashingAfterBecomingSolidAtSameDrawingPosition_Bottom.elm
+++ b/src/TestScenarios/CrashingAfterBecomingSolidAtSameDrawingPosition_Bottom.elm
@@ -55,10 +55,6 @@ expectedOutcome =
             [ -- Spawning:
               DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 103, y = 473 } ) ]
                 }
             , DrawSomething
@@ -76,6 +72,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 103, y = 473 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
 
             -- Draw spawn position permanently:

--- a/src/TestScenarios/CrashingAfterBecomingSolidAtSameDrawingPosition_Top.elm
+++ b/src/TestScenarios/CrashingAfterBecomingSolidAtSameDrawingPosition_Top.elm
@@ -55,10 +55,6 @@ expectedOutcome =
             [ -- Spawning:
               DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 12 } ) ]
                 }
             , DrawSomething
@@ -76,6 +72,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 12 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
 
             -- Draw spawn position permanently:

--- a/src/TestScenarios/CrashingWhileBecomingSolid.elm
+++ b/src/TestScenarios/CrashingWhileBecomingSolid.elm
@@ -55,10 +55,6 @@ expectedOutcome =
             [ -- Spawning:
               DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 546, y = 100 } ) ]
                 }
             , DrawSomething
@@ -76,6 +72,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 546, y = 100 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
 
             -- Draw spawn position permanently:

--- a/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
+++ b/src/TestScenarios/CuttingCornersPerfectOverpainting.elm
@@ -97,10 +97,6 @@ expectedOutcome =
             [ -- Spawning:
               DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
@@ -121,7 +117,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
+                , headDrawing = []
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -145,7 +141,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ), ( Colors.yellow, { x = 37, y = 37 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -169,7 +165,7 @@ expectedOutcome =
                 }
             , DrawSomething
                 { bodyDrawing = []
-                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.orange, { x = 20, y = 24 } ) ]
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ), ( Colors.yellow, { x = 37, y = 37 } ) ]
                 }
             , DrawSomething
                 { bodyDrawing = []
@@ -190,6 +186,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.orange, { x = 20, y = 24 } ), ( Colors.green, { x = 18, y = 47 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = [ ( Colors.red, { x = 29, y = 29 } ), ( Colors.yellow, { x = 37, y = 37 } ), ( Colors.orange, { x = 20, y = 24 } ) ]
                 }
 
             -- Spawns are drawn permanently:

--- a/src/TestScenarios/HoleSizeAndSpacing.elm
+++ b/src/TestScenarios/HoleSizeAndSpacing.elm
@@ -65,10 +65,6 @@ expectedOutcome =
             [ -- Spawning:
               DrawSomething
                 { bodyDrawing = []
-                , headDrawing = []
-                }
-            , DrawSomething
-                { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 458 } ) ]
                 }
             , DrawSomething
@@ -86,6 +82,10 @@ expectedOutcome =
             , DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 458 } ) ]
+                }
+            , DrawSomething
+                { bodyDrawing = []
+                , headDrawing = []
                 }
 
             -- Spawn is drawn permanently:

--- a/tests/FirstRoundTest.elm
+++ b/tests/FirstRoundTest.elm
@@ -62,10 +62,6 @@ expectedEffects =
     , DoNothing
     , DrawSomething
         { bodyDrawing = []
-        , headDrawing = []
-        }
-    , DrawSomething
-        { bodyDrawing = []
         , headDrawing = [ ( Colors.green, { x = 211, y = 192 } ) ]
         }
     , DrawSomething
@@ -83,6 +79,10 @@ expectedEffects =
     , DrawSomething
         { bodyDrawing = []
         , headDrawing = [ ( Colors.green, { x = 211, y = 192 } ) ]
+        }
+    , DrawSomething
+        { bodyDrawing = []
+        , headDrawing = []
         }
     , DrawSomething
         { bodyDrawing = [ ( Colors.green, { x = 211, y = 192 } ) ]


### PR DESCRIPTION
## Background

I recorded a video (see #241) of the Kurves spawning in the original game and stepped through it frame by frame. The pattern I discovered was that each Kurve is visible for 3 frames and then invisible for 3 frames, and repeats that 8 times. Immediately thereafter, both of these happen _simultaneously_:

  * The Kurve that just completed its spawn flickering becomes permanently visible.
  * The next Kurve starts spawning, or tick 1 (see #292) of the round is drawn.

That is, the last thing to happen before the round starts is that the last Kurve is invisible for 3 frames. In the very next frame, the Kurves are already drawn at positions different from their spawn positions – there is no "draw all Kurves at their spawn positions" frame before the round starts!

So a round with Red, Yellow and Orange could be summarized like this:

  1. 8 × 2 × 3 frames of Red flickering
  2. 8 × 2 × 3 frames of Yellow flickering
  3. 8 × 2 × 3 frames of Orange flickering
  4. The round itself, starting with a frame in which the Kurves have already moved

## Problem

Our implementation differs in at least one significant way: **we start with invisible instead of visible**. One can think of it like this:

| Frames | Original game | Our implementation |
|--------|---------------|--------------------|
| 1–3    | Visible       |                    |
| 4–6    |               | Visible            |
| 7–9    | Visible       |                    |
| 10–12  |               | Visible            |
| …      | …             | …                  |

## Solution

This PR aligns our implementation with the original game with respect to the table above.

It's not exactly easy to notice the difference in real time, but it can be made obvious by setting `flickerTicksPerSecond` to `1` in `Config.elm` and observing how this PR affects the behavior then:

### Before

  * It takes **2 seconds** from pressing Space until the first Kurve appears.
  * The last thing that happens before the Kurves start moving is that the last Kurve to spawn is **visible** for 1 second.

### After

  * It takes **1 second** from pressing Space until the first Kurve appears.
  * The last thing that happens before the Kurves start moving is that the last Kurve to spawn is **invisible** for 1 second.

I think there's still an off-by-one error or similar even with this PR, because there shouldn't be a 1-second delay from pressing Space until the first Kurve appears; that should be instant. But this PR at least makes our implementation _more_ similar.

## About the diff

The test-case diffs can be thought of like this: in each Kurve's spawn-flickering series (currently of length 6), the first effect (in which the Kurve is invisible) is moved to the end.

💡 `git show --color-moved=plain`