### PR TITLE
Make meaning of numberOfFlickerTicks more intuitive

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -33,7 +33,7 @@ default =
         , desiredMinimumDistanceTurningRadiusFactor = 1
         , protectionAudacity = 0.25 -- Closer to 1 ⇔ less risk of spawn kills but higher risk of no solution
         , flickerTicksPerSecond = 20 -- At each tick, the spawning Kurve is toggled between visible and invisible.
-        , numberOfFlickerTicks = 5
+        , numberOfFlickerTicks = 6
         , angleInterval = ( 0, pi )
         }
     , world =

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -31,7 +31,7 @@ makeSpawnState : Int -> Round -> SpawnState
 makeSpawnState numberOfFlickerTicks round =
     { kurvesLeft = round |> .kurves |> .alive
     , alreadySpawnedKurves = []
-    , ticksLeft = numberOfFlickerTicks
+    , ticksLeft = numberOfFlickerTicks - 1
     }
 
 
@@ -59,7 +59,7 @@ stepSpawnState config { kurvesLeft, alreadySpawnedKurves, ticksLeft } =
                 newSpawnState : SpawnState
                 newSpawnState =
                     if ticksLeft == 0 then
-                        { kurvesLeft = waiting, alreadySpawnedKurves = spawnedAndSpawning, ticksLeft = config.spawn.numberOfFlickerTicks }
+                        { kurvesLeft = waiting, alreadySpawnedKurves = spawnedAndSpawning, ticksLeft = config.spawn.numberOfFlickerTicks - 1 }
 
                     else
                         { kurvesLeft = spawning :: waiting, alreadySpawnedKurves = alreadySpawnedKurves, ticksLeft = ticksLeft - 1 }

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -175,4 +175,4 @@ refreshRateInTests =
 
 getNumberOfSpawnTicks : SpawnConfig -> Int
 getNumberOfSpawnTicks spawnConfig =
-    spawnConfig.numberOfFlickerTicks + 2
+    spawnConfig.numberOfFlickerTicks + 1


### PR DESCRIPTION
As mentioned in #375:

> For some reason (two off-by-one errors?), it seems like the number of `SpawnTick` messages is always 2 greater than the `numberOfFlickerTicks` value.

The meaning of `numberOfFlickerTicks` is indeed unintuitive. Consider these definitions:

```elm
flickerEffects =
    [ visible
    , invisible
    , visible
    , invisible
    , visible
    , invisible
    ]


visible =
    DrawSomething
        { bodyDrawing = []
        , headDrawing = [ ( Colors.red, { x = 100, y = 100 } ) ]
        }


invisible =
    DrawSomething
        { bodyDrawing = []
        , headDrawing = []
        }
```

How many flicker ticks does `flickerEffects` represent? I think the obvious answer is 6, and you'd also be forgiven for saying 3. But it's the result of setting `numberOfFlickerTicks` to `5`.

This PR modifies the meaning of the `numberOfFlickerTicks` field so that `6`, not `5`, corresponds to `flickerEffects` above. It does it by subtracting 1, analogously to how `updateRandomHoleStatus` was modified in #319.

I think there's still one spawn-related off-by-one-ish error left, as mentioned in #376:

> […] there shouldn't be a […] delay from pressing Space until the first Kurve appears; that should be instant.

But this is a step in the right direction.

💡 `git show --color-words=.`