### PR TITLE
Discard leftover frame time when seeking in replay

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -334,13 +334,13 @@ buttonUsed button ({ config, pressedButtons } as model) =
                         Spawning _ _ ->
                             ( model, DoNothing )
 
-                        Moving leftoverTimeFromPreviousFrame lastTick midRoundState ->
+                        Moving _ lastTick midRoundState ->
                             let
                                 ( tickResult, whatToDraw ) =
                                     MainLoop.consumeAnimationFrame
                                         config
                                         (toFloat config.replay.skipStepInMs)
-                                        leftoverTimeFromPreviousFrame
+                                        MainLoop.noLeftoverFrameTime
                                         lastTick
                                         midRoundState
                             in
@@ -370,13 +370,13 @@ buttonUsed button ({ config, pressedButtons } as model) =
                         Spawning _ _ ->
                             ( model, DoNothing )
 
-                        Moving leftoverTimeFromPreviousFrame lastTick midRoundState ->
+                        Moving _ lastTick midRoundState ->
                             let
                                 ( tickResult, whatToDraw ) =
                                     MainLoop.consumeAnimationFrame
                                         config
                                         (toFloat config.replay.skipStepInMs)
-                                        leftoverTimeFromPreviousFrame
+                                        MainLoop.noLeftoverFrameTime
                                         lastTick
                                         midRoundState
                             in
@@ -436,7 +436,7 @@ stepOneTick activeGameState finishedRound model =
         Spawning _ _ ->
             ( model, DoNothing )
 
-        Moving leftoverTimeFromPreviousFrame lastTick midRoundState ->
+        Moving _ lastTick midRoundState ->
             let
                 timeToSkipInMs : FrameTime
                 timeToSkipInMs =
@@ -446,7 +446,7 @@ stepOneTick activeGameState finishedRound model =
                     MainLoop.consumeAnimationFrame
                         model.config
                         timeToSkipInMs
-                        leftoverTimeFromPreviousFrame
+                        MainLoop.noLeftoverFrameTime
                         lastTick
                         midRoundState
             in


### PR DESCRIPTION
I don't think it's important when seeking, and I think it's easier to reason about seeking if it's always done from a "clean slate".

For what it's worth, the leftover frame time is always less than ~16.7 ms, so it's completely dwarfed by the skip step (5000 ms).

💡 `git show --color-words='\w+|.'`