### PR TITLE
Hotfix floating-point rounding error when seeking in replay

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -339,7 +339,7 @@ buttonUsed button ({ config, pressedButtons } as model) =
                                 ( tickResult, whatToDraw ) =
                                     MainLoop.consumeAnimationFrame
                                         config
-                                        (toFloat config.replay.skipStepInMs)
+                                        (toFloat config.replay.skipStepInMs |> MainLoop.withFloatingPointRoundingErrorCompensation)
                                         MainLoop.noLeftoverFrameTime
                                         lastTick
                                         midRoundState
@@ -375,7 +375,7 @@ buttonUsed button ({ config, pressedButtons } as model) =
                                 ( tickResult, whatToDraw ) =
                                     MainLoop.consumeAnimationFrame
                                         config
-                                        (toFloat config.replay.skipStepInMs)
+                                        (toFloat config.replay.skipStepInMs |> MainLoop.withFloatingPointRoundingErrorCompensation)
                                         MainLoop.noLeftoverFrameTime
                                         lastTick
                                         midRoundState
@@ -485,7 +485,7 @@ rewindReplay pausedOrNot activeGameState finishedRound model =
 
                 millisecondsToSkipAhead : FrameTime
                 millisecondsToSkipAhead =
-                    ((tickToGoTo |> Tick.toInt |> toFloat) / tickrateInHz) * 1000
+                    ((tickToGoTo |> Tick.toInt |> toFloat) / tickrateInHz) * 1000 |> MainLoop.withFloatingPointRoundingErrorCompensation
 
                 whatToDrawForSpawns : WhatToDraw
                 whatToDrawForSpawns =

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -1,4 +1,4 @@
-module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime)
+module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime, withFloatingPointRoundingErrorCompensation)
 
 {-| Based on Isaac Sukin's `MainLoop.js`.
 
@@ -73,3 +73,8 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
 noLeftoverFrameTime : LeftoverFrameTime
 noLeftoverFrameTime =
     0
+
+
+withFloatingPointRoundingErrorCompensation : Float -> Float
+withFloatingPointRoundingErrorCompensation skipStepInMs =
+    skipStepInMs + 1

--- a/tests/ReplayTest.elm
+++ b/tests/ReplayTest.elm
@@ -568,14 +568,11 @@ expectedEffects =
             , ( Colors.green, { x = 100, y = 117 } )
             , ( Colors.green, { x = 100, y = 118 } )
             , ( Colors.green, { x = 100, y = 119 } )
+            , ( Colors.green, { x = 100, y = 120 } )
             ]
-        , headDrawing = [ ( Colors.green, { x = 100, y = 119 } ) ]
-        }
-    , DoNothing
-    , DrawSomething
-        { bodyDrawing = [ ( Colors.green, { x = 100, y = 120 } ) ]
         , headDrawing = [ ( Colors.green, { x = 100, y = 120 } ) ]
         }
+    , DoNothing
     , DrawSomething
         { bodyDrawing = [ ( Colors.green, { x = 100, y = 121 } ) ]
         , headDrawing = [ ( Colors.green, { x = 100, y = 121 } ) ]
@@ -611,6 +608,10 @@ expectedEffects =
     , DrawSomething
         { bodyDrawing = [ ( Colors.green, { x = 100, y = 129 } ) ]
         , headDrawing = [ ( Colors.green, { x = 100, y = 129 } ) ]
+        }
+    , DrawSomething
+        { bodyDrawing = [ ( Colors.green, { x = 100, y = 130 } ) ]
+        , headDrawing = [ ( Colors.green, { x = 100, y = 130 } ) ]
         }
     ]
 


### PR DESCRIPTION
## Problem

  1. Play a round longer than 5 seconds.
  2. Replay it.
  3. More than 5 seconds into the round, pause by pressing Enter or E.
  4. Repeatedly go back and forward in the replay using the arrow keys.

You'll notice that the Kurve slowly creeps back towards its spawn with every repetition, instead of just oscillating between two fixed positions.

### Root cause

It seems like this happens due to floating-point rounding errors. Each `recurse` call in `consumeAnimationFrame` subtracts `timestep`, which is `1000 / 60`. That introduces floating-point rounding errors, resulting in these values for `timeLeftToConsume`:

  * `5000`
  * `4983.333333333333`
  * `4966.666666666666`
  * `4949.999999999999`
  * `4933.333333333332`
  * `4916.666666666665`
  * `4899.999999999998`
  * `4883.333333333331`
  * `4866.666666666664`
  * `4849.999999999997`
  * `4833.33333333333`
  * `4816.666666666663`
  * `4799.999999999996`
  * `4783.333333333329`
  * […]
  * `99.99999999999861`
  * `83.33333333333194`
  * `66.66666666666526`
  * `49.99999999999859`
  * `33.33333333333192`
  * `16.666666666665254`

Each `timeLeftToConsume` value is compared to `timestep` to determine whether `consumeAnimationFrame` is done. The last value, `16.666666666665254`, _should_ be equal to 1000 / 60 in theory, but is in fact slightly smaller, so the would-be last tick isn't processed.

## Solution

I'm not sure exactly how to think "correctly" about this, but adding 1 to the initial `delta` is enough for the should-be-one-sixtieth-of-a-second `timeLeftToConsume` value to be greater than 1000 / 60 even with the compounded floating-point rounding errors. So I'm going with that as a hotfix. We'll end up with a leftover frame time of `0.999999999998586` or something, which I think is negligible, and in any case much smaller than today (~16.7 ms).

💡 `git show --color-words=.`