### PR TITLE
Show gray border around lobby

### DIFF
--- a/src/GUI/Scoreboard.elm
+++ b/src/GUI/Scoreboard.elm
@@ -1,4 +1,4 @@
-module GUI.Scoreboard exposing (scoreboard)
+module GUI.Scoreboard exposing (scoreboard, scoreboardContainer)
 
 import Dict
 import GUI.Digits
@@ -14,11 +14,16 @@ import Types.Score exposing (Score(..))
 
 scoreboard : GameState -> AllPlayers -> Html msg
 scoreboard gameState players =
+    scoreboardContainer
+        (content players (Game.getCurrentRound gameState))
+
+
+scoreboardContainer : List (Html msg) -> Html msg
+scoreboardContainer =
     div
         [ Attr.id "scoreboard"
         , Attr.class "canvasHeight"
         ]
-        (content players (Game.getCurrentRound gameState))
 
 
 content : AllPlayers -> Round -> List (Html msg)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -12,7 +12,7 @@ import Events
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
-import GUI.Scoreboard exposing (scoreboard)
+import GUI.Scoreboard exposing (scoreboard, scoreboardContainer)
 import GUI.SplashScreen exposing (splashScreen)
 import GUI.TextOverlay exposing (textOverlay)
 import Game
@@ -584,7 +584,20 @@ view : Model -> Html Msg
 view model =
     case model.appState of
         InMenu Lobby _ ->
-            elmRoot Events.AllowDefault [] [ lobby model.players ]
+            elmRoot Events.AllowDefault
+                [ Attr.class "in-game-ish"
+                ]
+                [ div
+                    [ Attr.id "wrapper"
+                    ]
+                    [ div
+                        [ Attr.id "border"
+                        ]
+                        [ lobby model.players
+                        ]
+                    , scoreboardContainer []
+                    ]
+                ]
 
         InMenu GameOver _ ->
             elmRoot Events.AllowDefault [] [ endScreen model.players ]
@@ -595,7 +608,7 @@ view model =
         InGame gameState ->
             elmRoot
                 (Game.eventPrevention gameState)
-                [ Attr.class "in-game"
+                [ Attr.class "in-game-ish"
                 , Attr.class magicClassNameToPreventUnload
                 ]
                 [ div

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -33,7 +33,7 @@ body {
     align-items: center;
     justify-content: center;
 
-    &.in-game {
+    &.in-game-ish {
         background-color: #3C3C3C;
     }
 }
@@ -89,13 +89,13 @@ $minWidthForCenteredCanvas: (
 );
 
 @media (max-width: $minWidthForCenteredCanvas) {
-    #elm-root.in-game {
+    #elm-root.in-game-ish {
         justify-content: flex-end; // Prioritizes visible scoreboard over centered canvas.
     }
 }
 
 @media (min-width: $minWidthForCenteredCanvas) {
-    #elm-root.in-game {
+    #elm-root.in-game-ish {
         justify-content: center;
     }
 }


### PR DESCRIPTION
The lobby used to have the same gray border as the in-game view until #74. While the all-black lobby certainly looks nice and stays true to the original game, it makes it difficult to adjust the zoom level before starting the game.

The `in-game` CSS class is renamed to `in-game-ish` since it's no longer exclusively used for `InGame` app states.

Resolves #368.

💡 `git show --color-words=.`