### PR TITLE
Shorten replay-navigation control descriptions

### DIFF
--- a/src/GUI/Navigation/Replay.elm
+++ b/src/GUI/Navigation/Replay.elm
@@ -37,9 +37,8 @@ replayNavigation =
 
 makeNavigationEntries : List GUI.Navigation.Entry
 makeNavigationEntries =
-    [ ( "Enter", "Pause/resume" )
-    , ( "L.Arrow", "Back" )
-    , ( "R.Arrow", "Forward" )
+    [ ( "Enter", "Pause" )
+    , ( "Arrows", "Seek" )
     , ( "E", "Step" )
     , ( "R", "Restart" )
     ]


### PR DESCRIPTION
I think we should strive toward short, concise descriptions, especially given that the font isn't exactly optimized for readability. This PR makes two changes:

  * Shortens "Pause/resume" to just "Pause". I think users will understand that the pause key also resumes.
  * Merges the separate lines for "L.Arrow" and "R.Arrow" into a single "Arrows" line with the description "Seek". I think both "Arrows" and "Seek" are improvements not just in length but also in clarity per se.

💡 `git show --color-words='.+Arrow.+|.'`