### PR TITLE
Generalize navigation-controls GUI code

### DIFF
--- a/src/GUI/Navigation.elm
+++ b/src/GUI/Navigation.elm
@@ -1,8 +1,32 @@
-module GUI.Navigation exposing (Entry, computeFirstColumnWidth, showEntry)
+module GUI.Navigation exposing (Entry, entries)
+
+import Colors
+import GUI.Text
+import Html exposing (p)
 
 
 type alias Entry =
     ( String, String )
+
+
+entries : List Entry -> List (Html.Html msg)
+entries navigationEntries =
+    let
+        firstColumnWidth : Int
+        firstColumnWidth =
+            computeFirstColumnWidth navigationEntries
+    in
+    navigationEntries
+        |> List.map
+            (\entry ->
+                p
+                    []
+                    (GUI.Text.string
+                        (GUI.Text.Size 1)
+                        Colors.white
+                        (showEntry firstColumnWidth entry)
+                    )
+            )
 
 
 showEntry : Int -> Entry -> String

--- a/src/GUI/Navigation/Replay.elm
+++ b/src/GUI/Navigation/Replay.elm
@@ -1,9 +1,7 @@
 module GUI.Navigation.Replay exposing (replayNavigation)
 
-import Colors
 import GUI.Navigation
-import GUI.Text
-import Html exposing (Html, div, p)
+import Html exposing (Html, div)
 import Html.Attributes as Attr
 
 
@@ -13,26 +11,11 @@ replayNavigation =
         navigationEntries : List GUI.Navigation.Entry
         navigationEntries =
             makeNavigationEntries
-
-        firstColumnWidth : Int
-        firstColumnWidth =
-            GUI.Navigation.computeFirstColumnWidth navigationEntries
     in
     div
         [ Attr.class "replayNavigation"
         ]
-        (navigationEntries
-            |> List.map
-                (\entry ->
-                    p
-                        []
-                        (GUI.Text.string
-                            (GUI.Text.Size 1)
-                            Colors.white
-                            (GUI.Navigation.showEntry firstColumnWidth entry)
-                        )
-                )
-        )
+        (GUI.Navigation.entries navigationEntries)
 
 
 makeNavigationEntries : List GUI.Navigation.Entry


### PR DESCRIPTION
I think we'll want to show controls in other contexts as well, so this PR generalizes the code in `replayNavigation` and makes it re-usable.

💡 `git show --color-moved --color-moved-ws=allow-indentation-change`