### PR TITLE
Add comments in expected-effects lists

### DIFF
--- a/src/TestScenarios/CrashIntoWallBottom.elm
+++ b/src/TestScenarios/CrashIntoWallBottom.elm
@@ -46,7 +46,8 @@ expectedOutcome =
         }
     , effectsItShouldProduce =
         ExpectEffects
-            [ DrawSomething
+            [ -- Spawning:
+              DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
                 }
@@ -70,10 +71,14 @@ expectedOutcome =
                 { bodyDrawing = []
                 , headDrawing = []
                 }
+
+            -- Draw spawn position permanently:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 99, y = 474 } ) ]
                 , headDrawing = []
                 }
+
+            -- Start moving:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 99, y = 475 } ) ]
                 , headDrawing = [ ( Colors.green, { x = 99, y = 475 } ) ]

--- a/src/TestScenarios/CrashIntoWallLeft.elm
+++ b/src/TestScenarios/CrashIntoWallLeft.elm
@@ -46,7 +46,8 @@ expectedOutcome =
         }
     , effectsItShouldProduce =
         ExpectEffects
-            [ DrawSomething
+            [ -- Spawning:
+              DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
                 }
@@ -70,10 +71,14 @@ expectedOutcome =
                 { bodyDrawing = []
                 , headDrawing = []
                 }
+
+            -- Draw spawn position permanently:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 3, y = 99 } ) ]
                 , headDrawing = []
                 }
+
+            -- Start moving:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 2, y = 99 } ) ]
                 , headDrawing = [ ( Colors.green, { x = 2, y = 99 } ) ]

--- a/src/TestScenarios/CrashIntoWallRight.elm
+++ b/src/TestScenarios/CrashIntoWallRight.elm
@@ -46,7 +46,8 @@ expectedOutcome =
         }
     , effectsItShouldProduce =
         ExpectEffects
-            [ DrawSomething
+            [ -- Spawning:
+              DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
                 }
@@ -70,10 +71,14 @@ expectedOutcome =
                 { bodyDrawing = []
                 , headDrawing = []
                 }
+
+            -- Draw spawn position permanently:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 553, y = 99 } ) ]
                 , headDrawing = []
                 }
+
+            -- Start moving:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 554, y = 99 } ) ]
                 , headDrawing = [ ( Colors.green, { x = 554, y = 99 } ) ]

--- a/src/TestScenarios/CrashIntoWallTop.elm
+++ b/src/TestScenarios/CrashIntoWallTop.elm
@@ -46,7 +46,8 @@ expectedOutcome =
         }
     , effectsItShouldProduce =
         ExpectEffects
-            [ DrawSomething
+            [ -- Spawning:
+              DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 }
@@ -70,10 +71,14 @@ expectedOutcome =
                 { bodyDrawing = []
                 , headDrawing = []
                 }
+
+            -- Draw spawn position permanently:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 99, y = 3 } ) ]
                 , headDrawing = []
                 }
+
+            -- Start moving:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 99, y = 2 } ) ]
                 , headDrawing = [ ( Colors.green, { x = 99, y = 2 } ) ]

--- a/src/TestScenarios/CrashSomewhatSoon.elm
+++ b/src/TestScenarios/CrashSomewhatSoon.elm
@@ -48,7 +48,8 @@ expectedOutcome =
         }
     , effectsItShouldProduce =
         ExpectEffects
-            [ DrawSomething
+            [ -- Spawning:
+              DrawSomething
                 { bodyDrawing = []
                 , headDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
                 }
@@ -72,10 +73,14 @@ expectedOutcome =
                 { bodyDrawing = []
                 , headDrawing = []
                 }
+
+            -- Draw spawn position permanently:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 100, y = 460 } ) ]
                 , headDrawing = []
                 }
+
+            -- Start moving:
             , DrawSomething
                 { bodyDrawing = [ ( Colors.green, { x = 100, y = 461 } ), ( Colors.green, { x = 100, y = 462 } ), ( Colors.green, { x = 100, y = 463 } ) ]
                 , headDrawing = [ ( Colors.green, { x = 100, y = 463 } ) ]

--- a/tests/FirstRoundTest.elm
+++ b/tests/FirstRoundTest.elm
@@ -60,6 +60,8 @@ expectedEffects =
     , DoNothing
     , ClearEverything
     , DoNothing
+
+    -- Spawning:
     , DrawSomething
         { bodyDrawing = []
         , headDrawing = [ ( Colors.green, { x = 211, y = 192 } ) ]
@@ -84,10 +86,14 @@ expectedEffects =
         { bodyDrawing = []
         , headDrawing = []
         }
+
+    -- Draw spawn position permanently:
     , DrawSomething
         { bodyDrawing = [ ( Colors.green, { x = 211, y = 192 } ) ]
         , headDrawing = []
         }
+
+    -- Start moving:
     , DrawSomething
         { bodyDrawing = [ ( Colors.green, { x = 212, y = 192 } ) ]
         , headDrawing = [ ( Colors.green, { x = 212, y = 192 } ) ]


### PR DESCRIPTION
The lists of expected effects tend to be quite verbose and difficult to parse mentally. Comments splitting them up into labeled sections tend to help a lot. Note that `elm-format` automatically adds an empty line before each comment, improving visual separation.

💡 `git show --color-words=.`