### PR TITLE
Clarify spawnkill-protection setting label

### DIFF
--- a/src/GUI/Settings.elm
+++ b/src/GUI/Settings.elm
@@ -44,7 +44,7 @@ showEntry makeMsg ( settingId, settingLabel, currentValue ) =
 
 makeSettingsEntries : Config -> List SettingsEntry
 makeSettingsEntries config =
-    [ ( SpawnProtection, "Spawnkill protection", config.spawn.spawnkillProtection )
+    [ ( SpawnProtection, "Prevent spawnkills", config.spawn.spawnkillProtection )
     ]
 
 


### PR DESCRIPTION
💡 `git show --color-words='[^"]+|.'`