### PR TITLE
Show alternative controls in lobby

### DIFF
--- a/src/GUI/Controls.elm
+++ b/src/GUI/Controls.elm
@@ -1,4 +1,4 @@
-module GUI.Controls exposing (showControls, showExtraControls)
+module GUI.Controls exposing (showAlternativeControls, showControls)
 
 import GUI.Buttons.Keyboard exposing (keyCodeRepresentation)
 import GUI.Buttons.Mouse exposing (mouseButtonRepresentation)
@@ -16,17 +16,17 @@ showControls { controls } =
     Tuple.mapBoth showFirst showFirst controls
 
 
-showExtraControls : Player -> String
-showExtraControls { controls } =
+showAlternativeControls : Player -> String
+showAlternativeControls { controls } =
     let
         ( left, right ) =
             controls
 
-        allExtra : List Button
-        allExtra =
+        allAlternative : List Button
+        allAlternative =
             List.drop 1 left ++ List.drop 1 right
     in
-    allExtra
+    allAlternative
         |> List.map showButton
         |> String.join " "
 

--- a/src/GUI/Lobby.elm
+++ b/src/GUI/Lobby.elm
@@ -34,10 +34,10 @@ playerEntry ( player, status ) =
                 []
                 (Text.string (Text.Size 1) player.color <| "(" ++ left ++ " " ++ right ++ ")")
             , p
-                [ Attr.class "extra-controls"
-                , Attr.title "Extra controls"
+                [ Attr.class "alternative-controls"
+                , Attr.title "Alternative controls"
                 ]
-                (Text.string (Text.Size 1) player.color (GUI.Controls.showExtraControls player))
+                (Text.string (Text.Size 1) player.color (GUI.Controls.showAlternativeControls player))
             ]
         , Html.div
             [ Attr.style "visibility"

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -8,7 +8,8 @@ $nativeHeight: 480px;
     image-rendering: pixelated;
 }
 
-html, body {
+html,
+body {
     width: 100%;
     height: 100%;
 }
@@ -317,7 +318,7 @@ $minWidthForCenteredCanvas: (
             width: 160px;
         }
 
-        .extra-controls {
+        .alternative-controls {
             opacity: 0.4;
             margin-top: 4px;
         }


### PR DESCRIPTION
There's currently no way for players to know that there are alternative controls or what they are. This PR is an attempt to make that information available in the UI.

💡 `git show --color-words='showControls|.'`