### PR TITLE
Make alternative controls optional

### DIFF
--- a/src/Config.elm
+++ b/src/Config.elm
@@ -7,6 +7,7 @@ module Config exposing
     , WorldConfig
     , default
     , getSettings
+    , withEnableAlternativeControls
     , withHardcodedHoles
     , withSettings
     , withSpawnkillProtection
@@ -48,6 +49,7 @@ default =
     , replay =
         { skipStepInMs = 5000
         }
+    , enableAlternativeControls = Settings.default.enableAlternativeControls
     }
 
 
@@ -56,6 +58,7 @@ type alias Config =
     , spawn : SpawnConfig
     , world : WorldConfig
     , replay : ReplayConfig
+    , enableAlternativeControls : Bool
     }
 
 
@@ -100,6 +103,7 @@ type alias HoleConfig =
 getSettings : Config -> Settings
 getSettings config =
     { spawnkillProtection = config.spawn.spawnkillProtection
+    , enableAlternativeControls = config.enableAlternativeControls
     }
 
 
@@ -107,6 +111,7 @@ withSettings : Settings -> Config -> Config
 withSettings settings config =
     config
         |> withSpawnkillProtection settings.spawnkillProtection
+        |> withEnableAlternativeControls settings.enableAlternativeControls
 
 
 withSpawnkillProtection : Bool -> Config -> Config
@@ -117,6 +122,11 @@ withSpawnkillProtection newValue config =
             config.spawn
     in
     { config | spawn = { spawnConfig | spawnkillProtection = newValue } }
+
+
+withEnableAlternativeControls : Bool -> Config -> Config
+withEnableAlternativeControls newValue config =
+    { config | enableAlternativeControls = newValue }
 
 
 withSpeed : Speed -> Config -> Config

--- a/src/GUI/Lobby.elm
+++ b/src/GUI/Lobby.elm
@@ -11,16 +11,16 @@ import Types.Player exposing (Player)
 import Types.PlayerStatus exposing (PlayerStatus(..))
 
 
-lobby : msg -> AllPlayers -> Html msg
-lobby onSettingsButtonClick players =
+lobby : Bool -> msg -> AllPlayers -> Html msg
+lobby enableAlternativeControls onSettingsButtonClick players =
     div
         [ Attr.id "lobby"
         ]
-        (settingsButton onSettingsButtonClick :: (Dict.values players |> List.map playerEntry))
+        (settingsButton onSettingsButtonClick :: (Dict.values players |> List.map (playerEntry enableAlternativeControls)))
 
 
-playerEntry : ( Player, PlayerStatus ) -> Html msg
-playerEntry ( player, status ) =
+playerEntry : Bool -> ( Player, PlayerStatus ) -> Html msg
+playerEntry enableAlternativeControls ( player, status ) =
     let
         ( left, right ) =
             GUI.Controls.showControls player
@@ -36,6 +36,7 @@ playerEntry ( player, status ) =
             , p
                 [ Attr.class "alternative-controls"
                 , Attr.title "Alternative controls"
+                , Attr.hidden (not enableAlternativeControls)
                 ]
                 (Text.string (Text.Size 1) player.color (GUI.Controls.showAlternativeControls player))
             ]

--- a/src/GUI/Settings.elm
+++ b/src/GUI/Settings.elm
@@ -45,6 +45,7 @@ showEntry makeMsg ( settingId, settingLabel, currentValue ) =
 makeSettingsEntries : Config -> List SettingsEntry
 makeSettingsEntries config =
     [ ( SpawnProtection, "Prevent spawnkills", config.spawn.spawnkillProtection )
+    , ( EnableAlternativeControls, "Enable alternative controls", config.enableAlternativeControls )
     ]
 
 
@@ -65,3 +66,6 @@ idFor settingId =
     case settingId of
         SpawnProtection ->
             "spawn-protection"
+
+        EnableAlternativeControls ->
+            "enable-alternative-controls"

--- a/src/Input.elm
+++ b/src/Input.elm
@@ -1,4 +1,4 @@
-module Input exposing (Button(..), ButtonDirection(..), buttonsWithSpecialMeaning, toStringSetControls, updatePressedButtons)
+module Input exposing (Button(..), ButtonDirection(..), buttonsWithSpecialMeaning, toStringSetControls, updatePressedButtons, withOnlyPrimaryUnless)
 
 import Set exposing (Set)
 
@@ -51,11 +51,20 @@ buttonToString button =
             "Mouse" ++ String.fromInt buttonNumber
 
 
-toStringSetControls : ( List Button, List Button ) -> ( Set String, Set String )
-toStringSetControls =
-    Tuple.mapBoth buttonListToStringSet buttonListToStringSet
+toStringSetControls : Bool -> ( List Button, List Button ) -> ( Set String, Set String )
+toStringSetControls enableAlternativeControls =
+    withOnlyPrimaryUnless enableAlternativeControls >> Tuple.mapBoth buttonListToStringSet buttonListToStringSet
 
 
 buttonListToStringSet : List Button -> Set String
 buttonListToStringSet =
     List.map buttonToString >> Set.fromList
+
+
+withOnlyPrimaryUnless : Bool -> ( List Button, List Button ) -> ( List Button, List Button )
+withOnlyPrimaryUnless enableAlternativeControls =
+    if enableAlternativeControls then
+        identity
+
+    else
+        Tuple.mapBoth (List.take 1) (List.take 1)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -215,6 +215,9 @@ update msg ({ config } as model) =
                     case settingId of
                         SpawnProtection ->
                             Config.withSpawnkillProtection newValue model.config
+
+                        EnableAlternativeControls ->
+                            Config.withEnableAlternativeControls newValue model.config
             in
             ( { model | config = newConfig }, SaveSettings (Config.getSettings newConfig) )
 
@@ -260,7 +263,7 @@ buttonUsed button ({ config, pressedButtons } as model) =
                     startRound (Live ()) model <| prepareLiveRound config seed (participating model.players) pressedButtons
 
                 _ ->
-                    ( handleUserInteraction Down button { model | players = handlePlayerJoiningOrLeaving button model.players }, DoNothing )
+                    ( handleUserInteraction Down button { model | players = handlePlayerJoiningOrLeaving config.enableAlternativeControls button model.players }, DoNothing )
 
         InMenu SettingsScreen seed ->
             case button of
@@ -698,7 +701,7 @@ view model =
                     [ div
                         [ Attr.id "border"
                         ]
-                        [ lobby ToggleSettingsScreen model.players
+                        [ lobby model.config.enableAlternativeControls ToggleSettingsScreen model.players
                         ]
                     , scoreboardContainer []
                     ]

--- a/src/Players.elm
+++ b/src/Players.elm
@@ -28,13 +28,13 @@ type alias ParticipatingPlayers =
     Dict PlayerId ( Player, Score )
 
 
-handlePlayerJoiningOrLeaving : Button -> AllPlayers -> AllPlayers
-handlePlayerJoiningOrLeaving button =
+handlePlayerJoiningOrLeaving : Bool -> Button -> AllPlayers -> AllPlayers
+handlePlayerJoiningOrLeaving enableAlternativeControls button =
     Dict.map
         (\_ ( player, status ) ->
             let
                 ( leftButtons, rightButtons ) =
-                    player.controls
+                    player.controls |> Input.withOnlyPrimaryUnless enableAlternativeControls
 
                 newStatus : PlayerStatus
                 newStatus =

--- a/src/Settings.elm
+++ b/src/Settings.elm
@@ -6,16 +6,19 @@ import Json.Encode as Encode
 
 type SettingId
     = SpawnProtection
+    | EnableAlternativeControls
 
 
 type alias Settings =
     { spawnkillProtection : Bool
+    , enableAlternativeControls : Bool
     }
 
 
 default : Settings
 default =
     { spawnkillProtection = True
+    , enableAlternativeControls = True
     }
 
 
@@ -37,13 +40,15 @@ stringify settings =
 
 settingsDecoder : Decoder Settings
 settingsDecoder =
-    Decode.map
+    Decode.map2
         Settings
         (Decode.maybe (Decode.field "spawnkillProtectionSetting" Decode.bool) |> Decode.map (Maybe.withDefault default.spawnkillProtection))
+        (Decode.maybe (Decode.field "EnableAlternativeControlsSetting" Decode.bool) |> Decode.map (Maybe.withDefault default.enableAlternativeControls))
 
 
 settingsEncoder : Settings -> Encode.Value
 settingsEncoder settings =
     Encode.object
         [ ( "spawnkillProtectionSetting", Encode.bool settings.spawnkillProtection )
+        , ( "EnableAlternativeControlsSetting", Encode.bool settings.enableAlternativeControls )
         ]

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -137,7 +137,7 @@ generateKurve config id numberOfPlayers existingPositions player =
             (\state ->
                 { color = player.color
                 , id = id
-                , controls = toStringSetControls player.controls
+                , controls = toStringSetControls config.enableAlternativeControls player.controls
                 , state = state
                 , stateAtSpawn = state
                 , reversedInteractions = []


### PR DESCRIPTION
The original game doesn't have any alternative controls, so here we make the True Original Experience available to the user, just in time for the official release (just like in #407).

💡 `git show --color-words='Bool|.'`