### PR TITLE
Add settings presets

### DIFF
--- a/src/GUI/ConfirmQuitDialog.elm
+++ b/src/GUI/ConfirmQuitDialog.elm
@@ -29,7 +29,12 @@ dialogBox makeMsg question selectedOption =
     let
         optionButton : Dialog.Option -> String -> Html msg
         optionButton option label =
-            button (onClick (makeMsg option) :: focusedIf selectedOption option) (smallWhiteText label)
+            button
+                (onClick (makeMsg option)
+                    :: Attr.class "buttony-button"
+                    :: focusedIf selectedOption option
+                )
+                (smallWhiteText label)
     in
     div [ Attr.class "dialog" ]
         [ p [] (smallWhiteText question)

--- a/src/GUI/Settings.elm
+++ b/src/GUI/Settings.elm
@@ -3,17 +3,20 @@ module GUI.Settings exposing (settings)
 import Colors
 import Config exposing (Config)
 import GUI.Text as Text
-import Html exposing (Html, button, div, input, label)
+import Html exposing (Html, button, div, footer, h2, input, label)
 import Html.Attributes as Attr
 import Html.Events
-import Settings exposing (SettingId(..))
+import Settings exposing (SettingId(..), Settings)
 
 
-settings : (SettingId -> Bool -> msg) -> msg -> Config -> Html msg
-settings makeMsg closeMsg config =
+settings : (SettingId -> Bool -> msg) -> (Settings -> msg) -> msg -> Config -> Html msg
+settings makeMsg makeApplyPresetMsg closeMsg config =
     div
         [ Attr.id "settings-screen" ]
-        (closeButton closeMsg :: (makeSettingsEntries config |> List.map (showEntry makeMsg)))
+        (closeButton closeMsg
+            :: (makeSettingsEntries config |> List.map (showEntry makeMsg))
+            ++ [ presetsFooter makeApplyPresetMsg thePresets ]
+        )
 
 
 type alias SettingsEntry =
@@ -48,6 +51,48 @@ makeSettingsEntries config =
     , ( PersistHoleStatus, "Persist hole status between rounds", config.kurves.holes.persistBetweenRounds )
     , ( EnableAlternativeControls, "Enable alternative controls", config.enableAlternativeControls )
     ]
+
+
+thePresets : List Preset
+thePresets =
+    [ ( Settings.default, "Sane defaults" )
+    , ( Settings.trueOriginalExperience, "True Original Experience(tm)" )
+    ]
+
+
+type alias Preset =
+    ( Settings, String )
+
+
+presetsFooter : (Settings -> msg) -> List Preset -> Html msg
+presetsFooter makeMsg presets =
+    footer
+        []
+        [ presetsHeading, presetButtons makeMsg presets ]
+
+
+presetsHeading : Html msg
+presetsHeading =
+    h2
+        []
+        (Text.string (Text.Size 1) Colors.white "Presets")
+
+
+presetButtons : (Settings -> msg) -> List Preset -> Html msg
+presetButtons makeMsg presets =
+    div
+        [ Attr.id "preset-buttons"
+        ]
+        (List.map (makeButton makeMsg) presets)
+
+
+makeButton : (Settings -> msg) -> Preset -> Html msg
+makeButton makeMsg ( settingsRecord, buttonLabel ) =
+    button
+        [ Attr.class "buttony-button"
+        , Html.Events.onClick (makeMsg settingsRecord)
+        ]
+        (Text.string (Text.Size 1) Colors.white buttonLabel)
 
 
 closeButton : msg -> Html msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -55,7 +55,7 @@ import Players
 import Random
 import Round exposing (FinishedRound, Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)
-import Settings exposing (SettingId(..))
+import Settings exposing (SettingId(..), Settings)
 import Spawn exposing (flickerFrequencyToTicksPerSecond, makeSpawnState, stepSpawnState)
 import Time
 import Types.FrameTime exposing (FrameTime)
@@ -113,6 +113,7 @@ type Msg
     | ButtonUsed ButtonDirection Button
     | ToggleSettingsScreen
     | SettingChanged SettingId Bool
+    | SettingsPresetApplied Settings
     | DialogChoiceMade Dialog.Option
     | FocusLost
     | RequestToggleFullscreen
@@ -228,6 +229,9 @@ update msg ({ config } as model) =
                             Config.withEnableAlternativeControls newValue model.config
             in
             ( { model | config = newConfig }, SaveSettings (Config.getSettings newConfig) )
+
+        SettingsPresetApplied newSettings ->
+            ( { model | config = Config.withSettings newSettings config }, SaveSettings newSettings )
 
         DialogChoiceMade option ->
             handleDialogChoice option model
@@ -735,7 +739,7 @@ view model =
                     [ div
                         [ Attr.id "border"
                         ]
-                        [ GUI.Settings.settings SettingChanged ToggleSettingsScreen model.config
+                        [ GUI.Settings.settings SettingChanged SettingsPresetApplied ToggleSettingsScreen model.config
                         ]
                     , scoreboardContainer []
                     ]

--- a/src/Settings.elm
+++ b/src/Settings.elm
@@ -1,4 +1,4 @@
-module Settings exposing (SettingId(..), Settings, default, parse, stringify)
+module Settings exposing (SettingId(..), Settings, default, parse, stringify, trueOriginalExperience)
 
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
@@ -22,6 +22,14 @@ default =
     { spawnkillProtection = True
     , persistHoleStatus = False
     , enableAlternativeControls = True
+    }
+
+
+trueOriginalExperience : Settings
+trueOriginalExperience =
+    { spawnkillProtection = False
+    , persistHoleStatus = True
+    , enableAlternativeControls = False
     }
 
 

--- a/src/css/Zatacka.scss
+++ b/src/css/Zatacka.scss
@@ -252,21 +252,21 @@ $minWidthForCenteredCanvas: (
     button:not(:last-child) {
         margin-right: 8px;
     }
+}
 
-    button {
-        background-color: black;
-        border: 1px solid rgba(255, 255, 255, 0.5);
-        color: white;
-        height: 32px;
+button.buttony-button {
+    background-color: black;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: white;
+    height: 32px;
 
-        &.focused {
-            border-color: white;
-        }
+    &.focused {
+        border-color: white;
+    }
 
-        &:hover {
-            border-color: white;
-            background-color: rgba(255, 255, 255, 0.1);
-        }
+    &:hover {
+        border-color: white;
+        background-color: rgba(255, 255, 255, 0.1);
     }
 }
 
@@ -328,6 +328,11 @@ $minWidthForCenteredCanvas: (
 #settings-screen {
     padding-top: 50px;
     padding-left: 80px;
+    padding-right: 80px;
+    padding-bottom: 50px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 #settings-screen > div {
@@ -338,6 +343,24 @@ $minWidthForCenteredCanvas: (
 
 #settings-screen > div:hover {
     opacity: 1;
+}
+
+#settings-screen footer {
+    margin-top: auto;
+
+    h2 {
+        border-bottom: 1px solid white;
+        margin-bottom: 8px;
+    }
+
+    #preset-buttons {
+        display: flex;
+        gap: 12px;
+
+        button {
+            flex-grow: 1;
+        }
+    }
 }
 
 #scoreboard {


### PR DESCRIPTION
This PR adds buttons for two settings presets. I think this will help users understand the purpose and context of the settings in a fun way.

The currently dialog-specific button styling is extracted into a `buttony-button` class and re-used on the settings screen.

💡 `git show --ignore-space-change --color-words='buttony-button|.'`