### PR TITLE
EXPERIMENT: Replays stored in query parameter

### DIFF
--- a/_site/index.js
+++ b/_site/index.js
@@ -18,6 +18,7 @@ const THE_SETTINGS_KEY = "zatacka_settings";
 const flags = {
     initialSeedValue: Math.floor(Math.random() * 0x100000000),
     settingsJsonFromLocalStorage: window.localStorage.getItem(THE_SETTINGS_KEY),
+    replayUrlParameter: new URLSearchParams(window.location.search).get("replay")?.replace(/ /g, "+") ?? null,
 };
 
 const app = Elm.Main.init({ node: document.getElementById("elm-node"), flags: flags });

--- a/_site/index.js
+++ b/_site/index.js
@@ -18,7 +18,7 @@ const THE_SETTINGS_KEY = "zatacka_settings";
 const flags = {
     initialSeedValue: Math.floor(Math.random() * 0x100000000),
     settingsJsonFromLocalStorage: window.localStorage.getItem(THE_SETTINGS_KEY),
-    replayQueryParameter: new URLSearchParams(window.location.search).get("replay"),
+    movieQueryParameter: new URLSearchParams(window.location.search).get("movie"),
 };
 
 const app = Elm.Main.init({ node: document.getElementById("elm-node"), flags: flags });

--- a/_site/index.js
+++ b/_site/index.js
@@ -18,6 +18,7 @@ const THE_SETTINGS_KEY = "zatacka_settings";
 const flags = {
     initialSeedValue: Math.floor(Math.random() * 0x100000000),
     settingsJsonFromLocalStorage: window.localStorage.getItem(THE_SETTINGS_KEY),
+    replayQueryParameter: new URLSearchParams(window.location.search).get("replay"),
 };
 
 const app = Elm.Main.init({ node: document.getElementById("elm-node"), flags: flags });

--- a/_site/index.js
+++ b/_site/index.js
@@ -18,7 +18,6 @@ const THE_SETTINGS_KEY = "zatacka_settings";
 const flags = {
     initialSeedValue: Math.floor(Math.random() * 0x100000000),
     settingsJsonFromLocalStorage: window.localStorage.getItem(THE_SETTINGS_KEY),
-    replayUrlParameter: new URLSearchParams(window.location.search).get("replay")?.replace(/ /g, "+") ?? null,
 };
 
 const app = Elm.Main.init({ node: document.getElementById("elm-node"), flags: flags });

--- a/elm.json
+++ b/elm.json
@@ -19,12 +19,14 @@
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm-community/random-extra": "3.2.0",
+            "folkertdev/elm-flate": "2.0.5",
             "tortus/elm-array-2d": "3.0.0"
         },
         "indirect": {
             "dwayne/elm-natural": "1.1.1",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.3"
+            "elm/virtual-dom": "1.0.3",
+            "elm-community/list-extra": "8.7.0"
         }
     },
     "test-dependencies": {

--- a/elm.json
+++ b/elm.json
@@ -9,8 +9,10 @@
         "direct": {
             "Elm-Canvas/raster-shapes": "1.1.2",
             "avh4/elm-color": "1.0.0",
+            "danfishgold/base64-bytes": "1.1.0",
             "dwayne/elm-integer": "1.0.0",
             "elm/browser": "1.0.2",
+            "elm/bytes": "1.0.8",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
@@ -29,8 +31,6 @@
         "direct": {
             "elm-explorations/test": "2.2.0"
         },
-        "indirect": {
-            "elm/bytes": "1.0.8"
-        }
+        "indirect": {}
     }
 }

--- a/src/App.elm
+++ b/src/App.elm
@@ -6,11 +6,13 @@ module App exposing
 import Game exposing (GameState)
 import Menu exposing (MenuState)
 import Random
+import Replay exposing (Replay2)
 
 
 type AppState
     = InMenu MenuState Random.Seed
     | InGame GameState
+    | InReplay Replay2
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState

--- a/src/App.elm
+++ b/src/App.elm
@@ -1,20 +1,98 @@
 module App exposing
     ( AppState(..)
+    , Move(..)
+    , PlayingMovie
+    , PlayingMovieKurve
     , modifyGameState
+    , toPlayingMovie
     )
 
+import Color exposing (Color)
+import Dict
 import Game exposing (GameState)
+import Holes exposing (Holiness)
 import Menu exposing (MenuState)
-import Movie exposing (Movie)
+import Movie exposing (Movie, MovieKurve)
+import Players
 import Random
 import Types.FrameTime exposing (LeftoverFrameTime)
-import Types.Tick exposing (Tick)
+import Types.Tick as Tick exposing (Tick)
+import World exposing (DrawingPosition)
 
 
 type AppState
     = InMenu MenuState Random.Seed
     | InGame GameState
-    | InMovie LeftoverFrameTime Tick Movie
+    | InMovie PlayingMovie
+
+
+type alias PlayingMovie =
+    { movesPerTick : Int
+    , kurves : List PlayingMovieKurve
+    , leftoverTimeFromPreviousFrame : LeftoverFrameTime
+    , lastTick : Tick
+    , isPlaying : Bool
+    }
+
+
+type alias PlayingMovieKurve =
+    { color : Color
+    , drawingPosition : DrawingPosition
+    , holiness : Holiness
+    , holinessChanges : List Tick
+    , moves : List Move
+    }
+
+
+type Move
+    = NoMove
+    | MoveDirection Movie.Direction
+
+
+toPlayingMovie : Movie -> PlayingMovie
+toPlayingMovie movie =
+    { movesPerTick = movie.movesPerTick
+    , kurves = movie.kurves |> List.filterMap toPlayingMovieKurve
+    , leftoverTimeFromPreviousFrame = 0
+    , lastTick = Tick.genesis
+    , isPlaying = True
+    }
+
+
+toPlayingMovieKurve : MovieKurve -> Maybe PlayingMovieKurve
+toPlayingMovieKurve kurve =
+    let
+        maybeColor =
+            Players.initialPlayers
+                |> Dict.get kurve.playerId
+                |> Maybe.map (Tuple.first >> .color)
+    in
+    case ( maybeColor, kurve.moves ) of
+        ( Just color, firstMove :: rest ) ->
+            Just
+                { color = color
+                , drawingPosition = kurve.initialDrawingPosition
+                , holiness = kurve.initialHoliness
+                , holinessChanges = kurve.holinessChanges
+                , moves = MoveDirection firstMove :: directionsToMoves firstMove rest
+                }
+
+        _ ->
+            Nothing
+
+
+directionsToMoves firstMove =
+    List.foldl
+        (\direction ( acc, previousDirection ) ->
+            if direction == Movie.opposite previousDirection then
+                ( NoMove :: acc, previousDirection )
+
+            else
+                ( MoveDirection direction :: acc, direction )
+        )
+        ( [], firstMove )
+        >> Tuple.first
+        >> List.reverse
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState

--- a/src/App.elm
+++ b/src/App.elm
@@ -5,14 +5,14 @@ module App exposing
 
 import Game exposing (GameState)
 import Menu exposing (MenuState)
+import Movie exposing (Movie)
 import Random
-import Replay exposing (Replay2)
 
 
 type AppState
     = InMenu MenuState Random.Seed
     | InGame GameState
-    | InReplay Replay2
+    | InMovie Movie
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState

--- a/src/App.elm
+++ b/src/App.elm
@@ -7,12 +7,14 @@ import Game exposing (GameState)
 import Menu exposing (MenuState)
 import Movie exposing (Movie)
 import Random
+import Types.FrameTime exposing (LeftoverFrameTime)
+import Types.Tick exposing (Tick)
 
 
 type AppState
     = InMenu MenuState Random.Seed
     | InGame GameState
-    | InMovie Movie
+    | InMovie LeftoverFrameTime Tick Movie
 
 
 modifyGameState : (GameState -> GameState) -> AppState -> AppState

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -36,11 +36,11 @@ content gameState =
         Active (Live _) NotPaused _ ->
             []
 
-        Active (Replay overlayState _ _) Paused _ ->
+        Active (Replay overlayState _) Paused _ ->
             -- Hint on how to continue deliberately omitted here. See the PR/commit that added this comment for details.
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
-        Active (Replay overlayState _ _) NotPaused _ ->
+        Active (Replay overlayState _) NotPaused _ ->
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
         RoundOver (Live finishedRound) _ _ _ ->
@@ -71,8 +71,6 @@ content gameState =
                         |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
             in
             [ GUI.Hints.render HowToReplay
-
-            -- It might make more sense having a hotkey in the replay that lets you copy the link?
             , Html.a [ Attr.href ("?replay=" ++ string) ]
                 [ Html.text "Replay link"
                 , Html.text " ("
@@ -91,7 +89,7 @@ content gameState =
                 ]
             ]
 
-        RoundOver (Replay overlayState _ _) _ _ _ ->
+        RoundOver (Replay overlayState _) _ _ _ ->
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
 

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -1,6 +1,7 @@
 module GUI.TextOverlay exposing (textOverlay)
 
 import Base64
+import Bytes.Decode
 import Bytes.Encode
 import Colors
 import GUI.Hints exposing (Hint(..))
@@ -57,10 +58,20 @@ content gameState =
 
                 string =
                     Base64.fromBytes bytes |> Maybe.withDefault ""
+
+                maybeDecodedReplay =
+                    Base64.toBytes string
+                        |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
             in
             [ GUI.Hints.render HowToReplay
             , Html.a [ Attr.href ("?replay=" ++ string) ]
-                [ Html.text "Replay link" ]
+                [ Html.text "Replay link"
+                , if Just (Debug.log "replay" replay) == Debug.log "maybeDecodedReplay" maybeDecodedReplay then
+                    Html.text " OK"
+
+                  else
+                    Html.text " not equal"
+                ]
             ]
 
         RoundOver (Replay overlayState _) _ _ _ ->

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -12,8 +12,8 @@ import GUI.Text
 import Game exposing (GameState(..), LiveOrReplay(..), PausedOrNot(..))
 import Html exposing (Html, div, p)
 import Html.Attributes as Attr
+import Movie
 import Overlay
-import Replay
 import Round
 import Types.Kurve exposing (Kurve)
 
@@ -52,11 +52,11 @@ content gameState =
                 theKurves =
                     round.kurves.alive ++ round.kurves.dead
 
-                replay =
-                    Replay.fromKurves theKurves
+                movie =
+                    Movie.fromKurves theKurves
 
                 bytes =
-                    Bytes.Encode.encode (Replay.encoder replay)
+                    Bytes.Encode.encode (Movie.encoder movie)
 
                 -- TODO: If we’re gonna do compression, I guess it should be behind the version number so we have the opportunity to improve or fix it in the future?
                 compressedBytes =
@@ -65,16 +65,16 @@ content gameState =
                 string =
                     Base64.fromBytes compressedBytes |> Maybe.withDefault ""
 
-                maybeDecodedReplay =
+                maybeDecodedMovie =
                     Base64.toBytes string
                         |> Maybe.andThen Flate.inflate
-                        |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
+                        |> Maybe.andThen (Bytes.Decode.decode Movie.decoder)
             in
             [ GUI.Hints.render HowToReplay
             , Html.a [ Attr.href ("?replay=" ++ string) ]
-                [ Html.text "Replay link"
+                [ Html.text "Movie link"
                 , Html.text " ("
-                , if Just (Debug.log "replay" replay) == Debug.log "maybeDecodedReplay" maybeDecodedReplay then
+                , if Just (Debug.log "movie" movie) == Debug.log "maybeDecodedMovie" maybeDecodedMovie then
                     Html.text "OK"
 
                   else

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -58,6 +58,7 @@ content gameState =
                 bytes =
                     Bytes.Encode.encode (Replay.encoder replay)
 
+                -- TODO: If we’re gonna do compression, I guess it should be behind the version number so we have the opportunity to improve or fix it in the future?
                 compressedBytes =
                     Flate.deflate bytes
 

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -1,5 +1,7 @@
 module GUI.TextOverlay exposing (textOverlay)
 
+import Base64
+import Bytes.Encode
 import Colors
 import GUI.Hints exposing (Hint(..))
 import GUI.Navigation.Replay
@@ -8,6 +10,9 @@ import Game exposing (GameState(..), LiveOrReplay(..), PausedOrNot(..))
 import Html exposing (Html, div, p)
 import Html.Attributes as Attr
 import Overlay
+import Replay
+import Round
+import Types.Kurve exposing (Kurve)
 
 
 textOverlay : GameState -> Html msg
@@ -35,8 +40,27 @@ content gameState =
         Active (Replay overlayState _) NotPaused _ ->
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
-        RoundOver (Live _) _ _ _ ->
+        RoundOver (Live finishedRound) _ _ _ ->
+            let
+                round =
+                    Round.unpackFinished finishedRound
+
+                theKurves : List Kurve
+                theKurves =
+                    round.kurves.alive ++ round.kurves.dead
+
+                replay =
+                    Replay.fromKurves theKurves
+
+                bytes =
+                    Bytes.Encode.encode (Replay.encoder replay)
+
+                string =
+                    Base64.fromBytes bytes |> Maybe.withDefault ""
+            in
             [ GUI.Hints.render HowToReplay
+            , Html.a [ Attr.href ("?replay=" ++ string) ]
+                [ Html.text "Replay link" ]
             ]
 
         RoundOver (Replay overlayState _) _ _ _ ->

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -71,7 +71,7 @@ content gameState =
                         |> Maybe.andThen (Bytes.Decode.decode Movie.decoder)
             in
             [ GUI.Hints.render HowToReplay
-            , Html.a [ Attr.href ("?replay=" ++ string) ]
+            , Html.a [ Attr.href ("?movie=" ++ string) ]
                 [ Html.text "Movie link"
                 , Html.text " ("
                 , if Just (Debug.log "movie" movie) == Debug.log "maybeDecodedMovie" maybeDecodedMovie then

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -1,6 +1,7 @@
 module GUI.TextOverlay exposing (textOverlay)
 
 import Base64
+import Bytes
 import Bytes.Decode
 import Bytes.Encode
 import Colors
@@ -66,11 +67,17 @@ content gameState =
             [ GUI.Hints.render HowToReplay
             , Html.a [ Attr.href ("?replay=" ++ string) ]
                 [ Html.text "Replay link"
+                , Html.text " ("
                 , if Just (Debug.log "replay" replay) == Debug.log "maybeDecodedReplay" maybeDecodedReplay then
-                    Html.text " OK"
+                    Html.text "OK"
 
                   else
-                    Html.text " not equal"
+                    Html.text "not equal"
+                , Html.text ", "
+                , Html.text (String.fromInt (Bytes.width bytes))
+                , Html.text ", "
+                , Html.text (String.fromInt (String.length string))
+                , Html.text ")"
                 ]
             ]
 

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -36,11 +36,11 @@ content gameState =
         Active (Live _) NotPaused _ ->
             []
 
-        Active (Replay overlayState _) Paused _ ->
+        Active (Replay overlayState _ _) Paused _ ->
             -- Hint on how to continue deliberately omitted here. See the PR/commit that added this comment for details.
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
-        Active (Replay overlayState _) NotPaused _ ->
+        Active (Replay overlayState _ _) NotPaused _ ->
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
         RoundOver (Live finishedRound) _ _ _ ->
@@ -71,6 +71,8 @@ content gameState =
                         |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
             in
             [ GUI.Hints.render HowToReplay
+
+            -- It might make more sense having a hotkey in the replay that lets you copy the link?
             , Html.a [ Attr.href ("?replay=" ++ string) ]
                 [ Html.text "Replay link"
                 , Html.text " ("
@@ -89,7 +91,7 @@ content gameState =
                 ]
             ]
 
-        RoundOver (Replay overlayState _) _ _ _ ->
+        RoundOver (Replay overlayState _ _) _ _ _ ->
             Overlay.ifVisible overlayState [ replayIndicator, GUI.Navigation.Replay.replayNavigation ]
 
 

--- a/src/GUI/TextOverlay.elm
+++ b/src/GUI/TextOverlay.elm
@@ -5,6 +5,7 @@ import Bytes
 import Bytes.Decode
 import Bytes.Encode
 import Colors
+import Flate
 import GUI.Hints exposing (Hint(..))
 import GUI.Navigation.Replay
 import GUI.Text
@@ -57,11 +58,15 @@ content gameState =
                 bytes =
                     Bytes.Encode.encode (Replay.encoder replay)
 
+                compressedBytes =
+                    Flate.deflate bytes
+
                 string =
-                    Base64.fromBytes bytes |> Maybe.withDefault ""
+                    Base64.fromBytes compressedBytes |> Maybe.withDefault ""
 
                 maybeDecodedReplay =
                     Base64.toBytes string
+                        |> Maybe.andThen Flate.inflate
                         |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
             in
             [ GUI.Hints.render HowToReplay
@@ -75,6 +80,8 @@ content gameState =
                     Html.text "not equal"
                 , Html.text ", "
                 , Html.text (String.fromInt (Bytes.width bytes))
+                , Html.text ", "
+                , Html.text (String.fromInt (Bytes.width compressedBytes))
                 , Html.text ", "
                 , Html.text (String.fromInt (String.length string))
                 , Html.text ")"

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -28,6 +28,7 @@ import Input exposing (Button)
 import Overlay
 import Players exposing (ParticipatingPlayers)
 import Random
+import Replay exposing (Move)
 import Round exposing (FinishedRound(..), Kurves, Round, RoundInitialState, modifyAlive, modifyDead, roundIsOver)
 import Set exposing (Set)
 import Spawn exposing (SpawnState, generateKurves)
@@ -446,9 +447,16 @@ updateKurve config turningState occupiedPixels kurve =
             , holeStatus = newHoleStatus
             }
 
+        newMoves : List Move
+        newMoves =
+            []
+
         newKurve : Kurve
         newKurve =
-            { kurve | state = newKurveState }
+            { kurve
+                | state = newKurveState
+                , reversedMoves = newMoves ++ kurve.reversedMoves
+            }
     in
     ( confirmedDrawingPositions
     , newKurve

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -28,7 +28,6 @@ import Input exposing (Button)
 import Overlay
 import Players exposing (ParticipatingPlayers)
 import Random
-import Replay exposing (Replay2)
 import Round exposing (FinishedRound(..), Kurves, Round, RoundInitialState, modifyAlive, modifyDead, roundIsOver)
 import Set exposing (Set)
 import Spawn exposing (SpawnState, generateKurves)
@@ -90,7 +89,7 @@ getFinishedRound liveOrReplay =
         Live finishedRound ->
             finishedRound
 
-        Replay _ finishedRound _ ->
+        Replay _ finishedRound ->
             finishedRound
 
 
@@ -109,7 +108,7 @@ modifyMidRoundState f gameState =
 
 type LiveOrReplay liveData
     = Live liveData
-    | Replay Overlay.State FinishedRound Replay2
+    | Replay Overlay.State FinishedRound
 
 
 isReplay : GameState -> Bool
@@ -120,7 +119,7 @@ isReplay gameState =
                 Live _ ->
                     False
 
-                Replay _ _ _ ->
+                Replay _ _ ->
                     True
 
         RoundOver liveOrReplay _ _ _ ->
@@ -128,7 +127,7 @@ isReplay gameState =
                 Live _ ->
                     False
 
-                Replay _ _ _ ->
+                Replay _ _ ->
                     True
 
 
@@ -237,10 +236,10 @@ tickResultToGameState liveOrReplay pausedOrNot tickResult =
                         Live () ->
                             Live finishedRound
 
-                        Replay overlayState originalFinishedRound replay ->
+                        Replay overlayState originalFinishedRound ->
                             -- The freshly computed finished round should™ be equal to the original one that we already have, so we should be able to use either one.
                             -- I think it feels more natural to keep the one we already have.
-                            Replay overlayState originalFinishedRound replay
+                            Replay overlayState originalFinishedRound
             in
             RoundOver liveOrReplayWithFinishedRound pausedOrNot tickThatEndedIt Dialog.NotOpen
 
@@ -504,7 +503,7 @@ eventPrevention playerButtons gameState =
                     -- * Player inputs clashing with keyboard shortcuts (e.g. Alt to open the menu bar or Ctrl + 1 to switch to the first tab)
                     PreventDefault
 
-                Replay _ _ _ ->
+                Replay _ _ ->
                     AllowDefaultExcept playerButtons
 
         RoundOver _ _ _ _ ->

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -28,6 +28,7 @@ import Input exposing (Button)
 import Overlay
 import Players exposing (ParticipatingPlayers)
 import Random
+import Replay exposing (Replay2)
 import Round exposing (FinishedRound(..), Kurves, Round, RoundInitialState, modifyAlive, modifyDead, roundIsOver)
 import Set exposing (Set)
 import Spawn exposing (SpawnState, generateKurves)
@@ -89,7 +90,7 @@ getFinishedRound liveOrReplay =
         Live finishedRound ->
             finishedRound
 
-        Replay _ finishedRound ->
+        Replay _ finishedRound _ ->
             finishedRound
 
 
@@ -108,7 +109,7 @@ modifyMidRoundState f gameState =
 
 type LiveOrReplay liveData
     = Live liveData
-    | Replay Overlay.State FinishedRound
+    | Replay Overlay.State FinishedRound Replay2
 
 
 isReplay : GameState -> Bool
@@ -119,7 +120,7 @@ isReplay gameState =
                 Live _ ->
                     False
 
-                Replay _ _ ->
+                Replay _ _ _ ->
                     True
 
         RoundOver liveOrReplay _ _ _ ->
@@ -127,7 +128,7 @@ isReplay gameState =
                 Live _ ->
                     False
 
-                Replay _ _ ->
+                Replay _ _ _ ->
                     True
 
 
@@ -236,10 +237,10 @@ tickResultToGameState liveOrReplay pausedOrNot tickResult =
                         Live () ->
                             Live finishedRound
 
-                        Replay overlayState originalFinishedRound ->
+                        Replay overlayState originalFinishedRound replay ->
                             -- The freshly computed finished round should™ be equal to the original one that we already have, so we should be able to use either one.
                             -- I think it feels more natural to keep the one we already have.
-                            Replay overlayState originalFinishedRound
+                            Replay overlayState originalFinishedRound replay
             in
             RoundOver liveOrReplayWithFinishedRound pausedOrNot tickThatEndedIt Dialog.NotOpen
 
@@ -503,7 +504,7 @@ eventPrevention playerButtons gameState =
                     -- * Player inputs clashing with keyboard shortcuts (e.g. Alt to open the menu bar or Ctrl + 1 to switch to the first tab)
                     PreventDefault
 
-                Replay _ _ ->
+                Replay _ _ _ ->
                     AllowDefaultExcept playerButtons
 
         RoundOver _ _ _ _ ->

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -429,7 +429,7 @@ updateKurve config turningState occupiedPixels kurve =
             , y + distanceTraveledSinceLastTick * Angle.cos newDirection
             )
 
-        ( allDrawingPositions, fate ) =
+        ( checkedPositionsReversed, fate ) =
             evaluateMove
                 config
                 kurve.state.position
@@ -443,7 +443,7 @@ updateKurve config turningState occupiedPixels kurve =
                 }
                 fate
                 kurve.state.position
-                allDrawingPositions
+                checkedPositionsReversed
 
         newHoleStatus : HoleStatus
         newHoleStatus =
@@ -456,16 +456,17 @@ updateKurve config turningState occupiedPixels kurve =
             , holeStatus = newHoleStatus
             }
 
-        newReversedDrawingPositions : List ( DrawingPosition, Holiness )
-        newReversedDrawingPositions =
-            allDrawingPositions
+        drawingPositionsThisTick : List ( DrawingPosition, Holiness )
+        drawingPositionsThisTick =
+            checkedPositionsReversed
+                |> List.reverse
                 |> List.map (\drawingPosition -> ( drawingPosition, Holes.getHoliness newHoleStatus ))
 
         newKurve : Kurve
         newKurve =
             { kurve
                 | state = newKurveState
-                , reversedDrawingPositions = newReversedDrawingPositions ++ kurve.reversedDrawingPositions
+                , reversedDrawingPositionsPerTick = drawingPositionsThisTick :: kurve.reversedDrawingPositionsPerTick
             }
     in
     ( confirmedDrawingPositions

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -28,7 +28,6 @@ import Input exposing (Button)
 import Overlay
 import Players exposing (ParticipatingPlayers)
 import Random
-import Replay exposing (Move)
 import Round exposing (FinishedRound(..), Kurves, Round, RoundInitialState, modifyAlive, modifyDead, roundIsOver)
 import Set exposing (Set)
 import Spawn exposing (SpawnState, generateKurves)
@@ -296,8 +295,8 @@ type alias HolinessTransition =
     }
 
 
-evaluateMove : Config -> Position -> Position -> OccupiedPixels -> HolinessTransition -> ( List DrawingPosition, Fate )
-evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransition =
+evaluateMove : Config -> Position -> Position -> OccupiedPixels -> ( List DrawingPosition, Fate )
+evaluateMove config startingPoint desiredEndPoint occupiedPixels =
     let
         startingPointAsDrawingPosition : DrawingPosition
         startingPointAsDrawingPosition =
@@ -341,12 +340,16 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransit
 
                     else
                         checkPositions (current :: checked) current rest
+    in
+    checkPositions [] startingPointAsDrawingPosition positionsToCheck
 
-        ( checkedPositionsReversed, evaluatedStatus ) =
-            checkPositions [] startingPointAsDrawingPosition positionsToCheck
 
-        { oldHoliness, newHoliness } =
-            holinessTransition
+getPositionsToDraw : HolinessTransition -> Fate -> Position -> List DrawingPosition -> List DrawingPosition
+getPositionsToDraw { oldHoliness, newHoliness } evaluatedStatus startingPoint checkedPositionsReversed =
+    let
+        startingPointAsDrawingPosition : DrawingPosition
+        startingPointAsDrawingPosition =
+            World.drawingPosition startingPoint
 
         positionsToDraw : List DrawingPosition
         positionsToDraw =
@@ -398,7 +401,7 @@ evaluateMove config startingPoint desiredEndPoint occupiedPixels holinessTransit
                             -- The Kurve died in the middle of a solid segment. Draw all positions it could be at.
                             checkedPositionsReversed
     in
-    ( positionsToDraw |> List.reverse, evaluatedStatus )
+    List.reverse positionsToDraw
 
 
 updateKurve : Config -> TurningState -> OccupiedPixels -> Kurve -> ( List DrawingPosition, Kurve, Fate )
@@ -426,15 +429,21 @@ updateKurve config turningState occupiedPixels kurve =
             , y + distanceTraveledSinceLastTick * Angle.cos newDirection
             )
 
-        ( confirmedDrawingPositions, fate ) =
+        ( allDrawingPositions, fate ) =
             evaluateMove
                 config
                 kurve.state.position
                 newPosition
                 occupiedPixels
+
+        confirmedDrawingPositions =
+            getPositionsToDraw
                 { oldHoliness = getHoliness kurve.state.holeStatus
                 , newHoliness = getHoliness newHoleStatus
                 }
+                fate
+                kurve.state.position
+                allDrawingPositions
 
         newHoleStatus : HoleStatus
         newHoleStatus =
@@ -447,15 +456,16 @@ updateKurve config turningState occupiedPixels kurve =
             , holeStatus = newHoleStatus
             }
 
-        newMoves : List Move
-        newMoves =
-            []
+        newReversedDrawingPositions : List ( DrawingPosition, Holiness )
+        newReversedDrawingPositions =
+            allDrawingPositions
+                |> List.map (\drawingPosition -> ( drawingPosition, Holes.getHoliness newHoleStatus ))
 
         newKurve : Kurve
         newKurve =
             { kurve
                 | state = newKurveState
-                , reversedMoves = newMoves ++ kurve.reversedMoves
+                , reversedDrawingPositions = newReversedDrawingPositions ++ kurve.reversedDrawingPositions
             }
     in
     ( confirmedDrawingPositions

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -456,17 +456,24 @@ updateKurve config turningState occupiedPixels kurve =
             , holeStatus = newHoleStatus
             }
 
+        withHoliness : DrawingPosition -> ( DrawingPosition, Holiness )
+        withHoliness drawingPosition =
+            ( drawingPosition, Holes.getHoliness newHoleStatus )
+
         drawingPositionsThisTick : List ( DrawingPosition, Holiness )
         drawingPositionsThisTick =
-            checkedPositionsReversed
-                |> List.reverse
-                |> List.map (\drawingPosition -> ( drawingPosition, Holes.getHoliness newHoleStatus ))
+            case ( fate, checkedPositionsReversed ) of
+                ( Dies, last :: rest ) ->
+                    ( last, Solid ) :: List.map withHoliness rest
+
+                _ ->
+                    List.map withHoliness checkedPositionsReversed
 
         newKurve : Kurve
         newKurve =
             { kurve
                 | state = newKurveState
-                , reversedDrawingPositionsPerTick = drawingPositionsThisTick :: kurve.reversedDrawingPositionsPerTick
+                , reversedDrawingPositionsPerTick = List.reverse drawingPositionsThisTick :: kurve.reversedDrawingPositionsPerTick
             }
     in
     ( confirmedDrawingPositions

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -261,7 +261,7 @@ checkIndividualKurve config tick kurve ( checkedKurves, occupiedPixels, coloredD
             turningStateFromHistory tick kurve
 
         ( newKurveDrawingPositions, checkedKurve, fate ) =
-            updateKurve config turningState occupiedPixels kurve
+            updateKurve config tick turningState occupiedPixels kurve
 
         occupiedPixelsAfterCheckingThisKurve : OccupiedPixels
         occupiedPixelsAfterCheckingThisKurve =
@@ -404,8 +404,8 @@ getPositionsToDraw { oldHoliness, newHoliness } evaluatedStatus startingPoint ch
     List.reverse positionsToDraw
 
 
-updateKurve : Config -> TurningState -> OccupiedPixels -> Kurve -> ( List DrawingPosition, Kurve, Fate )
-updateKurve config turningState occupiedPixels kurve =
+updateKurve : Config -> Tick -> TurningState -> OccupiedPixels -> Kurve -> ( List DrawingPosition, Kurve, Fate )
+updateKurve config tick turningState occupiedPixels kurve =
     let
         distanceTraveledSinceLastTick : Float
         distanceTraveledSinceLastTick =
@@ -436,11 +436,15 @@ updateKurve config turningState occupiedPixels kurve =
                 newPosition
                 occupiedPixels
 
+        holinessTransition : HolinessTransition
+        holinessTransition =
+            { oldHoliness = getHoliness kurve.state.holeStatus
+            , newHoliness = getHoliness newHoleStatus
+            }
+
         confirmedDrawingPositions =
             getPositionsToDraw
-                { oldHoliness = getHoliness kurve.state.holeStatus
-                , newHoliness = getHoliness newHoleStatus
-                }
+                holinessTransition
                 fate
                 kurve.state.position
                 checkedPositionsReversed
@@ -456,24 +460,20 @@ updateKurve config turningState occupiedPixels kurve =
             , holeStatus = newHoleStatus
             }
 
-        withHoliness : DrawingPosition -> ( DrawingPosition, Holiness )
-        withHoliness drawingPosition =
-            ( drawingPosition, Holes.getHoliness newHoleStatus )
+        newReversedHolinessChanges : List Tick
+        newReversedHolinessChanges =
+            if holinessTransition.oldHoliness /= holinessTransition.newHoliness then
+                tick :: kurve.reversedHolinessChanges
 
-        reversedDrawingPositionsThisTick : List ( DrawingPosition, Holiness )
-        reversedDrawingPositionsThisTick =
-            case ( fate, checkedPositionsReversed ) of
-                ( Dies, last :: rest ) ->
-                    ( last, Solid ) :: List.map withHoliness rest
-
-                _ ->
-                    List.map withHoliness checkedPositionsReversed
+            else
+                kurve.reversedHolinessChanges
 
         newKurve : Kurve
         newKurve =
             { kurve
                 | state = newKurveState
-                , reversedDrawingPositionsPerTick = reversedDrawingPositionsThisTick :: kurve.reversedDrawingPositionsPerTick
+                , reversedHolinessChanges = newReversedHolinessChanges
+                , reversedDrawingPositionsPerTick = checkedPositionsReversed :: kurve.reversedDrawingPositionsPerTick
             }
     in
     ( confirmedDrawingPositions

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -460,8 +460,8 @@ updateKurve config turningState occupiedPixels kurve =
         withHoliness drawingPosition =
             ( drawingPosition, Holes.getHoliness newHoleStatus )
 
-        drawingPositionsThisTick : List ( DrawingPosition, Holiness )
-        drawingPositionsThisTick =
+        reversedDrawingPositionsThisTick : List ( DrawingPosition, Holiness )
+        reversedDrawingPositionsThisTick =
             case ( fate, checkedPositionsReversed ) of
                 ( Dies, last :: rest ) ->
                     ( last, Solid ) :: List.map withHoliness rest
@@ -473,7 +473,7 @@ updateKurve config turningState occupiedPixels kurve =
         newKurve =
             { kurve
                 | state = newKurveState
-                , reversedDrawingPositionsPerTick = List.reverse drawingPositionsThisTick :: kurve.reversedDrawingPositionsPerTick
+                , reversedDrawingPositionsPerTick = reversedDrawingPositionsThisTick :: kurve.reversedDrawingPositionsPerTick
             }
     in
     ( confirmedDrawingPositions

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,6 +1,6 @@
 port module Main exposing (Model, Msg(..), init, main, update)
 
-import App exposing (AppState(..), modifyGameState)
+import App exposing (AppState(..), modifyGameState, toPlayingMovie)
 import Base64
 import Browser
 import Browser.Events
@@ -90,19 +90,19 @@ port saveToLocalStorage : String -> Cmd msg
 init : Flags -> ( Model, Cmd Msg )
 init flags =
     let
-        maybeReplay : Maybe Movie
-        maybeReplay =
+        maybeMovie =
             flags.movieQueryParameter
                 |> Maybe.andThen (String.replace " " "+" >> Base64.toBytes)
                 |> Maybe.andThen Flate.inflate
                 |> Maybe.andThen (Bytes.Decode.decode Movie.decoder)
+                |> Maybe.map toPlayingMovie
                 |> Debug.log "movie"
     in
     ( { pressedButtons = Set.empty
       , appState =
-            case maybeReplay of
-                Just replay ->
-                    InMovie MainLoop.noLeftoverFrameTime Tick.genesis replay
+            case maybeMovie of
+                Just movie ->
+                    InMovie movie
 
                 Nothing ->
                     InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
@@ -205,23 +205,21 @@ update msg ({ config } as model) =
                     , maybeDrawSomething whatToDraw
                     )
 
-                InMovie leftoverTimeFromPreviousFrame lastTick movie ->
+                InMovie movie ->
                     let
                         ( tickResult, whatToDraw ) =
                             MainLoop.consumeMovieAnimationFrame
                                 config
                                 delta
-                                leftoverTimeFromPreviousFrame
-                                lastTick
                                 movie
 
                         appState =
                             case tickResult of
-                                MainLoop.MovieKeepsGoing ( newLeftoverFrameTime, newTick, newMovie ) ->
-                                    InMovie newLeftoverFrameTime newTick newMovie
+                                MainLoop.MovieKeepsGoing newMovie ->
+                                    InMovie newMovie
 
-                                MainLoop.MovieEnds newTick newMovie ->
-                                    InMovie MainLoop.noLeftoverFrameTime newTick newMovie
+                                MainLoop.MovieEnds newMovie ->
+                                    InMovie newMovie
                     in
                     ( { model | appState = appState }
                     , maybeDrawSomething whatToDraw
@@ -257,7 +255,7 @@ update msg ({ config } as model) =
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
-                InMovie _ _ _ ->
+                InMovie _ ->
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
@@ -526,7 +524,7 @@ buttonUsed button ({ config, pressedButtons } as model) =
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
 
-        InMovie _ _ _ ->
+        InMovie _ ->
             let
                 _ =
                     Debug.log "keydown" button
@@ -764,8 +762,12 @@ subscriptions model =
             InMenu GameOver _ ->
                 Sub.none
 
-            InMovie _ _ _ ->
-                Browser.Events.onAnimationFrameDelta AnimationFrame
+            InMovie movie ->
+                if movie.isPlaying then
+                    Browser.Events.onAnimationFrameDelta AnimationFrame
+
+                else
+                    Sub.none
         , focusLost (always FocusLost)
         ]
 
@@ -849,7 +851,7 @@ view model =
                     ]
                 ]
 
-        InMovie _ _ _ ->
+        InMovie _ ->
             elmRoot
                 (Events.AllowDefaultExcept playerButtons)
                 [ Attr.class "in-game-ish"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,14 +1,17 @@
 port module Main exposing (Model, Msg(..), init, main, update)
 
 import App exposing (AppState(..), modifyGameState)
+import Base64
 import Browser
 import Browser.Events
+import Bytes.Decode
 import Canvas exposing (clearEverything, drawingCmd)
 import Config exposing (Config)
 import Dialog
 import Drawing exposing (WhatToDraw, drawSpawnsPermanently, mergeWhatToDraw)
 import Effect exposing (Effect(..), maybeDrawSomething)
 import Events
+import Flate
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
@@ -53,6 +56,7 @@ import Players
         , participating
         )
 import Random
+import Replay exposing (Replay2)
 import Round exposing (FinishedRound, Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)
 import Settings exposing (SettingId(..), Settings)
@@ -85,6 +89,15 @@ port saveToLocalStorage : String -> Cmd msg
 
 init : Flags -> ( Model, Cmd Msg )
 init flags =
+    let
+        maybeReplay : Maybe Replay2
+        maybeReplay =
+            flags.replayQueryParameter
+                |> Maybe.andThen (String.replace " " "+" >> Base64.toBytes)
+                |> Maybe.andThen Flate.inflate
+                |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
+                |> Debug.log "replay"
+    in
     ( { pressedButtons = Set.empty
       , appState = InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
       , config = Config.default |> Config.withSettings (Settings.parse flags.settingsJsonFromLocalStorage)
@@ -122,6 +135,7 @@ type Msg
 type alias Flags =
     { initialSeedValue : Int
     , settingsJsonFromLocalStorage : Maybe String
+    , replayQueryParameter : Maybe String
     }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,14 +1,18 @@
 port module Main exposing (Model, Msg(..), init, main, update)
 
 import App exposing (AppState(..), modifyGameState)
+import Base64
 import Browser
 import Browser.Events
+import Bytes.Decode
 import Canvas exposing (clearEverything, drawingCmd)
 import Config exposing (Config)
 import Dialog
+import Dict
 import Drawing exposing (WhatToDraw, drawSpawnsPermanently, mergeWhatToDraw)
 import Effect exposing (Effect(..), maybeDrawSomething)
 import Events
+import Flate
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
@@ -31,10 +35,10 @@ import Game
         , recordUserInteraction
         , tickResultToGameState
         )
-import Holes exposing (HoleStatus)
+import Holes exposing (HoleStatus(..))
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
-import Input exposing (Button(..), ButtonDirection(..), updatePressedButtons)
+import Input exposing (Button(..), ButtonDirection(..), toStringSetControls, updatePressedButtons)
 import IsGameOver exposing (isGameOver)
 import JavaScript exposing (magicClassNameToPreventUnload)
 import MainLoop
@@ -53,13 +57,15 @@ import Players
         , participating
         )
 import Random
-import Round exposing (FinishedRound, Round, initialStateForReplaying, modifyAlive, modifyKurves)
+import Replay exposing (Replay2)
+import Round exposing (FinishedRound(..), Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)
 import Settings exposing (SettingId(..), Settings)
 import Spawn exposing (flickerFrequencyToTicksPerSecond, makeSpawnState, stepSpawnState)
 import Time
+import Types.Angle exposing (Angle(..))
 import Types.FrameTime exposing (FrameTime)
-import Types.Kurve exposing (Kurve, getHoleStatus, hasPlayerId)
+import Types.Kurve as Kurve exposing (Kurve, getHoleStatus, hasPlayerId)
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
@@ -85,9 +91,63 @@ port saveToLocalStorage : String -> Cmd msg
 
 init : Flags -> ( Model, Cmd Msg )
 init flags =
+    let
+        maybeDecodedReplay =
+            flags.replayUrlParameter
+                |> Maybe.andThen Base64.toBytes
+                |> Maybe.andThen Flate.inflate
+                |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
+
+        seed =
+            Random.initialSeed flags.initialSeedValue
+
+        config =
+            Config.default |> Config.withSettings (Settings.parse flags.settingsJsonFromLocalStorage)
+
+        appState =
+            case maybeDecodedReplay of
+                Just replay ->
+                    let
+                        theKurves : List Kurve
+                        theKurves =
+                            replay.kurves
+                                |> List.filterMap
+                                    (\replayKurve ->
+                                        Dict.get replayKurve.playerId Players.initialPlayers
+                                            |> Maybe.map
+                                                (\( player, _ ) ->
+                                                    let
+                                                        state : Kurve.State
+                                                        state =
+                                                            { position = ( 0, 0 )
+                                                            , direction = Angle 0
+                                                            , holeStatus = NoHoles
+                                                            }
+                                                    in
+                                                    { color = player.color
+                                                    , id = replayKurve.playerId
+                                                    , controls = toStringSetControls config.enableAlternativeControls player.controls
+                                                    , state = state
+                                                    , stateAtSpawn = state
+                                                    , reversedInteractions = []
+                                                    , reversedHolinessChanges = []
+                                                    , reversedDrawingPositionsPerTick = []
+                                                    }
+                                                )
+                                    )
+
+                        round : Round
+                        round =
+                            prepareReplayRound config.world { seedAfterSpawn = seed, spawnedKurves = theKurves }
+                    in
+                    InGame (startRoundGameState (Replay Overlay.Visible (Finished round) replay) config round)
+
+                Nothing ->
+                    InMenu SplashScreen seed
+    in
     ( { pressedButtons = Set.empty
-      , appState = InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
-      , config = Config.default |> Config.withSettings (Settings.parse flags.settingsJsonFromLocalStorage)
+      , appState = appState
+      , config = config
       , players = initialPlayers
       }
     , Cmd.none
@@ -99,12 +159,17 @@ startRound liveOrReplay model midRoundState =
     let
         gameState : GameState
         gameState =
-            Active liveOrReplay NotPaused <|
-                Spawning
-                    (makeSpawnState model.config.spawn.numberOfFlickers midRoundState)
-                    midRoundState
+            startRoundGameState liveOrReplay model.config midRoundState
     in
     ( { model | appState = InGame gameState }, ClearEverything )
+
+
+startRoundGameState : LiveOrReplay () -> Config -> Round -> GameState
+startRoundGameState liveOrReplay config midRoundState =
+    Active liveOrReplay NotPaused <|
+        Spawning
+            (makeSpawnState config.spawn.numberOfFlickers midRoundState)
+            midRoundState
 
 
 type Msg
@@ -122,6 +187,7 @@ type Msg
 type alias Flags =
     { initialSeedValue : Int
     , settingsJsonFromLocalStorage : Maybe String
+    , replayUrlParameter : Maybe String
     }
 
 
@@ -135,7 +201,7 @@ update msg ({ config } as model) =
                         Live () ->
                             ( { model | appState = InGame (Active liveOrReplay Paused s) }, DoNothing )
 
-                        Replay _ _ ->
+                        Replay _ _ _ ->
                             -- Not important to pause on focus lost when replaying.
                             ( model, DoNothing )
 
@@ -307,36 +373,40 @@ buttonUsed button ({ config, pressedButtons } as model) =
                                 Live _ ->
                                     ( handleUserInteraction Down button model, DoNothing )
 
-                                Replay overlayState _ ->
+                                Replay overlayState _ replay ->
                                     let
                                         fakeActiveGameState : ActiveGameState
                                         fakeActiveGameState =
                                             Moving MainLoop.noLeftoverFrameTime tickThatEndedIt unpackedFinishedRound
                                     in
-                                    rewindReplay overlayState pausedOrNot fakeActiveGameState finishedRound model
+                                    rewindReplay overlayState pausedOrNot fakeActiveGameState finishedRound replay model
 
                         Key "KeyO" ->
                             case liveOrReplay of
                                 Live _ ->
                                     ( handleUserInteraction Down button model, DoNothing )
 
-                                Replay overlayState _ ->
-                                    ( { model | appState = InGame (RoundOver (Replay (Overlay.toggle overlayState) finishedRound) pausedOrNot tickThatEndedIt dialogState) }, DoNothing )
+                                Replay overlayState _ replay ->
+                                    ( { model | appState = InGame (RoundOver (Replay (Overlay.toggle overlayState) finishedRound replay) pausedOrNot tickThatEndedIt dialogState) }, DoNothing )
 
                         Key "KeyR" ->
                             let
-                                newOverlayState : Overlay.State
-                                newOverlayState =
+                                ( newOverlayState, replay ) =
                                     case liveOrReplay of
                                         Live _ ->
+                                            let
+                                                theKurves : List Kurve
+                                                theKurves =
+                                                    unpackedFinishedRound.kurves.alive ++ unpackedFinishedRound.kurves.dead
+                                            in
                                             -- Users might perceive the replay as the next live round if the overlay is gone, so we reset it here.
-                                            Overlay.Visible
+                                            ( Overlay.Visible, Replay.fromKurves theKurves )
 
-                                        Replay overlayState _ ->
+                                        Replay overlayState _ replay_ ->
                                             -- Users are probably mentally "in replay mode". They'll know that they've recently hidden the overlay themselves, and that it's still a replay.
-                                            overlayState
+                                            ( overlayState, replay_ )
                             in
-                            startRound (Replay newOverlayState finishedRound) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
+                            startRound (Replay newOverlayState finishedRound replay) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
 
                         Key "Escape" ->
                             let
@@ -417,28 +487,28 @@ buttonUsed button ({ config, pressedButtons } as model) =
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
 
-        InGame (Active (Replay overlayState finishedRound) Paused s) ->
+        InGame (Active (Replay overlayState finishedRound replay) Paused s) ->
             case button of
                 Key "Space" ->
                     proceedToNextRound finishedRound model
 
                 Key "Enter" ->
-                    ( { model | appState = InGame (Active (Replay overlayState finishedRound) NotPaused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay overlayState finishedRound replay) NotPaused s) }, DoNothing )
 
                 Key "ArrowLeft" ->
-                    rewindReplay overlayState Paused s finishedRound model
+                    rewindReplay overlayState Paused s finishedRound replay model
 
                 Key "ArrowRight" ->
-                    fastForwardReplay overlayState Paused s finishedRound model
+                    fastForwardReplay overlayState Paused s finishedRound replay model
 
                 Key "KeyE" ->
-                    stepOneTick overlayState s finishedRound model
+                    stepOneTick overlayState s finishedRound replay model
 
                 Key "KeyO" ->
-                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound) Paused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound replay) Paused s) }, DoNothing )
 
                 Key "KeyR" ->
-                    startRound (Replay overlayState finishedRound) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
+                    startRound (Replay overlayState finishedRound replay) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
 
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
@@ -446,28 +516,28 @@ buttonUsed button ({ config, pressedButtons } as model) =
         InGame (Active (Live ()) NotPaused _) ->
             ( handleUserInteraction Down button model, DoNothing )
 
-        InGame (Active (Replay overlayState finishedRound) NotPaused s) ->
+        InGame (Active (Replay overlayState finishedRound replay) NotPaused s) ->
             case button of
                 Key "ArrowLeft" ->
-                    rewindReplay overlayState NotPaused s finishedRound model
+                    rewindReplay overlayState NotPaused s finishedRound replay model
 
                 Key "ArrowRight" ->
-                    fastForwardReplay overlayState NotPaused s finishedRound model
+                    fastForwardReplay overlayState NotPaused s finishedRound replay model
 
                 Key "KeyE" ->
-                    stepOneTick overlayState s finishedRound model
+                    stepOneTick overlayState s finishedRound replay model
 
                 Key "KeyO" ->
-                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound) NotPaused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound replay) NotPaused s) }, DoNothing )
 
                 Key "KeyR" ->
-                    startRound (Replay overlayState finishedRound) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
+                    startRound (Replay overlayState finishedRound replay) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
 
                 Key "Space" ->
                     proceedToNextRound finishedRound model
 
                 Key "Enter" ->
-                    ( { model | appState = InGame (Active (Replay overlayState finishedRound) Paused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay overlayState finishedRound replay) Paused s) }, DoNothing )
 
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
@@ -513,8 +583,8 @@ proceedToNextRound finishedRound ({ config, pressedButtons } as model) =
         startRound (Live ()) modelWithRecentResults <| prepareLiveRound config unpackedFinishedRound.seed (participating getHoleStatusById playersWithRecentResults) pressedButtons
 
 
-stepOneTick : Overlay.State -> ActiveGameState -> FinishedRound -> Model -> ( Model, Effect )
-stepOneTick overlayState activeGameState finishedRound model =
+stepOneTick : Overlay.State -> ActiveGameState -> FinishedRound -> Replay2 -> Model -> ( Model, Effect )
+stepOneTick overlayState activeGameState finishedRound replay model =
     case activeGameState of
         Spawning _ _ ->
             ( model, DoNothing )
@@ -533,13 +603,13 @@ stepOneTick overlayState activeGameState finishedRound model =
                         lastTick
                         midRoundState
             in
-            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound) Paused tickResult) }
+            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound replay) Paused tickResult) }
             , maybeDrawSomething whatToDraw
             )
 
 
-fastForwardReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Model -> ( Model, Effect )
-fastForwardReplay overlayState pausedOrNot activeGameState finishedRound ({ config } as model) =
+fastForwardReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Replay2 -> Model -> ( Model, Effect )
+fastForwardReplay overlayState pausedOrNot activeGameState finishedRound replay ({ config } as model) =
     case activeGameState of
         Spawning _ plannedMidRoundState ->
             let
@@ -551,7 +621,7 @@ fastForwardReplay overlayState pausedOrNot activeGameState finishedRound ({ conf
                 whatToDraw =
                     drawSpawnsPermanently plannedMidRoundState.kurves.alive
             in
-            ( { model | appState = InGame <| Active (Replay overlayState finishedRound) NotPaused newActiveGameState }
+            ( { model | appState = InGame <| Active (Replay overlayState finishedRound replay) NotPaused newActiveGameState }
             , DrawSomething whatToDraw
             )
 
@@ -565,16 +635,16 @@ fastForwardReplay overlayState pausedOrNot activeGameState finishedRound ({ conf
                         lastTick
                         midRoundState
             in
-            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound) pausedOrNot tickResult) }
+            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound replay) pausedOrNot tickResult) }
             , maybeDrawSomething whatToDraw
             )
 
 
-rewindReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Model -> ( Model, Effect )
-rewindReplay overlayState pausedOrNot activeGameState finishedRound model =
+rewindReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Replay2 -> Model -> ( Model, Effect )
+rewindReplay overlayState pausedOrNot activeGameState finishedRound replay model =
     case activeGameState of
         Spawning _ _ ->
-            startRound (Replay overlayState finishedRound) model <| prepareReplayRound model.config.world (initialStateForReplaying finishedRound)
+            startRound (Replay overlayState finishedRound replay) model <| prepareReplayRound model.config.world (initialStateForReplaying finishedRound)
 
         Moving _ lastTick _ ->
             let
@@ -623,7 +693,7 @@ rewindReplay overlayState pausedOrNot activeGameState finishedRound model =
                         Just whatToDrawForSkippingAhead ->
                             mergeWhatToDraw whatToDrawForSpawns whatToDrawForSkippingAhead
             in
-            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound) pausedOrNot tickResult) }
+            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound replay) pausedOrNot tickResult) }
             , ClearAndThenDraw whatToDraw
             )
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -102,7 +102,7 @@ init flags =
       , appState =
             case maybeReplay of
                 Just replay ->
-                    InMovie replay
+                    InMovie MainLoop.noLeftoverFrameTime Tick.genesis replay
 
                 Nothing ->
                     InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
@@ -205,8 +205,27 @@ update msg ({ config } as model) =
                     , maybeDrawSomething whatToDraw
                     )
 
-                InMovie movie ->
-                    ä
+                InMovie leftoverTimeFromPreviousFrame lastTick movie ->
+                    let
+                        ( tickResult, whatToDraw ) =
+                            MainLoop.consumeMovieAnimationFrame
+                                config
+                                delta
+                                leftoverTimeFromPreviousFrame
+                                lastTick
+                                movie
+
+                        appState =
+                            case tickResult of
+                                MainLoop.MovieKeepsGoing ( newLeftoverFrameTime, newTick, newMovie ) ->
+                                    InMovie newLeftoverFrameTime newTick newMovie
+
+                                MainLoop.MovieEnds newTick newMovie ->
+                                    InMovie MainLoop.noLeftoverFrameTime newTick newMovie
+                    in
+                    ( { model | appState = appState }
+                    , maybeDrawSomething whatToDraw
+                    )
 
                 _ ->
                     -- Not expected to ever happen.
@@ -238,7 +257,7 @@ update msg ({ config } as model) =
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
-                InMovie _ ->
+                InMovie _ _ _ ->
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
@@ -507,7 +526,7 @@ buttonUsed button ({ config, pressedButtons } as model) =
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
 
-        InMovie _ ->
+        InMovie _ _ _ ->
             let
                 _ =
                     Debug.log "keydown" button
@@ -745,7 +764,7 @@ subscriptions model =
             InMenu GameOver _ ->
                 Sub.none
 
-            InMovie _ ->
+            InMovie _ _ _ ->
                 Browser.Events.onAnimationFrameDelta AnimationFrame
         , focusLost (always FocusLost)
         ]
@@ -830,7 +849,7 @@ view model =
                     ]
                 ]
 
-        InMovie _ ->
+        InMovie _ _ _ ->
             elmRoot
                 (Events.AllowDefaultExcept playerButtons)
                 [ Attr.class "in-game-ish"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -99,7 +99,13 @@ init flags =
                 |> Debug.log "replay"
     in
     ( { pressedButtons = Set.empty
-      , appState = InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
+      , appState =
+            case maybeReplay of
+                Just replay ->
+                    InReplay replay
+
+                Nothing ->
+                    InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
       , config = Config.default |> Config.withSettings (Settings.parse flags.settingsJsonFromLocalStorage)
       , players = initialPlayers
       }
@@ -199,6 +205,9 @@ update msg ({ config } as model) =
                     , maybeDrawSomething whatToDraw
                     )
 
+                InReplay replay2 ->
+                    ä
+
                 _ ->
                     -- Not expected to ever happen.
                     ( model, DoNothing )
@@ -226,6 +235,10 @@ update msg ({ config } as model) =
                     ( model, DoNothing )
 
                 InGame _ ->
+                    -- Not expected to ever happen.
+                    ( model, DoNothing )
+
+                InReplay _ ->
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
@@ -494,6 +507,13 @@ buttonUsed button ({ config, pressedButtons } as model) =
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
 
+        InReplay _ ->
+            let
+                _ =
+                    Debug.log "keydown" button
+            in
+            ( model, DoNothing )
+
 
 proceedToNextRound : FinishedRound -> Model -> ( Model, Effect )
 proceedToNextRound finishedRound ({ config, pressedButtons } as model) =
@@ -724,6 +744,9 @@ subscriptions model =
 
             InMenu GameOver _ ->
                 Sub.none
+
+            InReplay replay2 ->
+                Browser.Events.onAnimationFrameDelta AnimationFrame
         , focusLost (always FocusLost)
         ]
 
@@ -804,6 +827,38 @@ view model =
                         , confirmQuitDialog DialogChoiceMade gameState
                         ]
                     , scoreboard gameState model.players
+                    ]
+                ]
+
+        InReplay replay2 ->
+            elmRoot
+                (Events.AllowDefaultExcept playerButtons)
+                [ Attr.class "in-game-ish"
+                , Attr.class magicClassNameToPreventUnload
+                ]
+                [ div
+                    [ Attr.id "wrapper"
+                    ]
+                    [ div
+                        [ Attr.id "border"
+                        , Attr.class "replay-mode"
+                        ]
+                        [ canvas
+                            [ Attr.id "bodyCanvas"
+                            , Attr.width 559
+                            , Attr.height 480
+                            ]
+                            []
+                        , canvas
+                            [ Attr.id "headCanvas"
+                            , Attr.width 559
+                            , Attr.height 480
+                            , Attr.class "overlay"
+                            ]
+                            []
+                        ]
+
+                    --, scoreboard gameState model.players
                     ]
                 ]
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,18 +1,14 @@
 port module Main exposing (Model, Msg(..), init, main, update)
 
 import App exposing (AppState(..), modifyGameState)
-import Base64
 import Browser
 import Browser.Events
-import Bytes.Decode
 import Canvas exposing (clearEverything, drawingCmd)
 import Config exposing (Config)
 import Dialog
-import Dict
 import Drawing exposing (WhatToDraw, drawSpawnsPermanently, mergeWhatToDraw)
 import Effect exposing (Effect(..), maybeDrawSomething)
 import Events
-import Flate
 import GUI.ConfirmQuitDialog exposing (confirmQuitDialog)
 import GUI.EndScreen exposing (endScreen)
 import GUI.Lobby exposing (lobby)
@@ -35,10 +31,10 @@ import Game
         , recordUserInteraction
         , tickResultToGameState
         )
-import Holes exposing (HoleStatus(..))
+import Holes exposing (HoleStatus)
 import Html exposing (Html, canvas, div)
 import Html.Attributes as Attr
-import Input exposing (Button(..), ButtonDirection(..), toStringSetControls, updatePressedButtons)
+import Input exposing (Button(..), ButtonDirection(..), updatePressedButtons)
 import IsGameOver exposing (isGameOver)
 import JavaScript exposing (magicClassNameToPreventUnload)
 import MainLoop
@@ -57,15 +53,13 @@ import Players
         , participating
         )
 import Random
-import Replay exposing (Replay2)
-import Round exposing (FinishedRound(..), Round, initialStateForReplaying, modifyAlive, modifyKurves)
+import Round exposing (FinishedRound, Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)
 import Settings exposing (SettingId(..), Settings)
 import Spawn exposing (flickerFrequencyToTicksPerSecond, makeSpawnState, stepSpawnState)
 import Time
-import Types.Angle exposing (Angle(..))
 import Types.FrameTime exposing (FrameTime)
-import Types.Kurve as Kurve exposing (Kurve, getHoleStatus, hasPlayerId)
+import Types.Kurve exposing (Kurve, getHoleStatus, hasPlayerId)
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
@@ -91,63 +85,9 @@ port saveToLocalStorage : String -> Cmd msg
 
 init : Flags -> ( Model, Cmd Msg )
 init flags =
-    let
-        maybeDecodedReplay =
-            flags.replayUrlParameter
-                |> Maybe.andThen Base64.toBytes
-                |> Maybe.andThen Flate.inflate
-                |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
-
-        seed =
-            Random.initialSeed flags.initialSeedValue
-
-        config =
-            Config.default |> Config.withSettings (Settings.parse flags.settingsJsonFromLocalStorage)
-
-        appState =
-            case maybeDecodedReplay of
-                Just replay ->
-                    let
-                        theKurves : List Kurve
-                        theKurves =
-                            replay.kurves
-                                |> List.filterMap
-                                    (\replayKurve ->
-                                        Dict.get replayKurve.playerId Players.initialPlayers
-                                            |> Maybe.map
-                                                (\( player, _ ) ->
-                                                    let
-                                                        state : Kurve.State
-                                                        state =
-                                                            { position = ( 0, 0 )
-                                                            , direction = Angle 0
-                                                            , holeStatus = NoHoles
-                                                            }
-                                                    in
-                                                    { color = player.color
-                                                    , id = replayKurve.playerId
-                                                    , controls = toStringSetControls config.enableAlternativeControls player.controls
-                                                    , state = state
-                                                    , stateAtSpawn = state
-                                                    , reversedInteractions = []
-                                                    , reversedHolinessChanges = []
-                                                    , reversedDrawingPositionsPerTick = []
-                                                    }
-                                                )
-                                    )
-
-                        round : Round
-                        round =
-                            prepareReplayRound config.world { seedAfterSpawn = seed, spawnedKurves = theKurves }
-                    in
-                    InGame (startRoundGameState (Replay Overlay.Visible (Finished round) replay) config round)
-
-                Nothing ->
-                    InMenu SplashScreen seed
-    in
     ( { pressedButtons = Set.empty
-      , appState = appState
-      , config = config
+      , appState = InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
+      , config = Config.default |> Config.withSettings (Settings.parse flags.settingsJsonFromLocalStorage)
       , players = initialPlayers
       }
     , Cmd.none
@@ -159,17 +99,12 @@ startRound liveOrReplay model midRoundState =
     let
         gameState : GameState
         gameState =
-            startRoundGameState liveOrReplay model.config midRoundState
+            Active liveOrReplay NotPaused <|
+                Spawning
+                    (makeSpawnState model.config.spawn.numberOfFlickers midRoundState)
+                    midRoundState
     in
     ( { model | appState = InGame gameState }, ClearEverything )
-
-
-startRoundGameState : LiveOrReplay () -> Config -> Round -> GameState
-startRoundGameState liveOrReplay config midRoundState =
-    Active liveOrReplay NotPaused <|
-        Spawning
-            (makeSpawnState config.spawn.numberOfFlickers midRoundState)
-            midRoundState
 
 
 type Msg
@@ -187,7 +122,6 @@ type Msg
 type alias Flags =
     { initialSeedValue : Int
     , settingsJsonFromLocalStorage : Maybe String
-    , replayUrlParameter : Maybe String
     }
 
 
@@ -201,7 +135,7 @@ update msg ({ config } as model) =
                         Live () ->
                             ( { model | appState = InGame (Active liveOrReplay Paused s) }, DoNothing )
 
-                        Replay _ _ _ ->
+                        Replay _ _ ->
                             -- Not important to pause on focus lost when replaying.
                             ( model, DoNothing )
 
@@ -373,40 +307,36 @@ buttonUsed button ({ config, pressedButtons } as model) =
                                 Live _ ->
                                     ( handleUserInteraction Down button model, DoNothing )
 
-                                Replay overlayState _ replay ->
+                                Replay overlayState _ ->
                                     let
                                         fakeActiveGameState : ActiveGameState
                                         fakeActiveGameState =
                                             Moving MainLoop.noLeftoverFrameTime tickThatEndedIt unpackedFinishedRound
                                     in
-                                    rewindReplay overlayState pausedOrNot fakeActiveGameState finishedRound replay model
+                                    rewindReplay overlayState pausedOrNot fakeActiveGameState finishedRound model
 
                         Key "KeyO" ->
                             case liveOrReplay of
                                 Live _ ->
                                     ( handleUserInteraction Down button model, DoNothing )
 
-                                Replay overlayState _ replay ->
-                                    ( { model | appState = InGame (RoundOver (Replay (Overlay.toggle overlayState) finishedRound replay) pausedOrNot tickThatEndedIt dialogState) }, DoNothing )
+                                Replay overlayState _ ->
+                                    ( { model | appState = InGame (RoundOver (Replay (Overlay.toggle overlayState) finishedRound) pausedOrNot tickThatEndedIt dialogState) }, DoNothing )
 
                         Key "KeyR" ->
                             let
-                                ( newOverlayState, replay ) =
+                                newOverlayState : Overlay.State
+                                newOverlayState =
                                     case liveOrReplay of
                                         Live _ ->
-                                            let
-                                                theKurves : List Kurve
-                                                theKurves =
-                                                    unpackedFinishedRound.kurves.alive ++ unpackedFinishedRound.kurves.dead
-                                            in
                                             -- Users might perceive the replay as the next live round if the overlay is gone, so we reset it here.
-                                            ( Overlay.Visible, Replay.fromKurves theKurves )
+                                            Overlay.Visible
 
-                                        Replay overlayState _ replay_ ->
+                                        Replay overlayState _ ->
                                             -- Users are probably mentally "in replay mode". They'll know that they've recently hidden the overlay themselves, and that it's still a replay.
-                                            ( overlayState, replay_ )
+                                            overlayState
                             in
-                            startRound (Replay newOverlayState finishedRound replay) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
+                            startRound (Replay newOverlayState finishedRound) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
 
                         Key "Escape" ->
                             let
@@ -487,28 +417,28 @@ buttonUsed button ({ config, pressedButtons } as model) =
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
 
-        InGame (Active (Replay overlayState finishedRound replay) Paused s) ->
+        InGame (Active (Replay overlayState finishedRound) Paused s) ->
             case button of
                 Key "Space" ->
                     proceedToNextRound finishedRound model
 
                 Key "Enter" ->
-                    ( { model | appState = InGame (Active (Replay overlayState finishedRound replay) NotPaused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay overlayState finishedRound) NotPaused s) }, DoNothing )
 
                 Key "ArrowLeft" ->
-                    rewindReplay overlayState Paused s finishedRound replay model
+                    rewindReplay overlayState Paused s finishedRound model
 
                 Key "ArrowRight" ->
-                    fastForwardReplay overlayState Paused s finishedRound replay model
+                    fastForwardReplay overlayState Paused s finishedRound model
 
                 Key "KeyE" ->
-                    stepOneTick overlayState s finishedRound replay model
+                    stepOneTick overlayState s finishedRound model
 
                 Key "KeyO" ->
-                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound replay) Paused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound) Paused s) }, DoNothing )
 
                 Key "KeyR" ->
-                    startRound (Replay overlayState finishedRound replay) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
+                    startRound (Replay overlayState finishedRound) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
 
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
@@ -516,28 +446,28 @@ buttonUsed button ({ config, pressedButtons } as model) =
         InGame (Active (Live ()) NotPaused _) ->
             ( handleUserInteraction Down button model, DoNothing )
 
-        InGame (Active (Replay overlayState finishedRound replay) NotPaused s) ->
+        InGame (Active (Replay overlayState finishedRound) NotPaused s) ->
             case button of
                 Key "ArrowLeft" ->
-                    rewindReplay overlayState NotPaused s finishedRound replay model
+                    rewindReplay overlayState NotPaused s finishedRound model
 
                 Key "ArrowRight" ->
-                    fastForwardReplay overlayState NotPaused s finishedRound replay model
+                    fastForwardReplay overlayState NotPaused s finishedRound model
 
                 Key "KeyE" ->
-                    stepOneTick overlayState s finishedRound replay model
+                    stepOneTick overlayState s finishedRound model
 
                 Key "KeyO" ->
-                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound replay) NotPaused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay (Overlay.toggle overlayState) finishedRound) NotPaused s) }, DoNothing )
 
                 Key "KeyR" ->
-                    startRound (Replay overlayState finishedRound replay) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
+                    startRound (Replay overlayState finishedRound) model <| prepareReplayRound config.world (initialStateForReplaying finishedRound)
 
                 Key "Space" ->
                     proceedToNextRound finishedRound model
 
                 Key "Enter" ->
-                    ( { model | appState = InGame (Active (Replay overlayState finishedRound replay) Paused s) }, DoNothing )
+                    ( { model | appState = InGame (Active (Replay overlayState finishedRound) Paused s) }, DoNothing )
 
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
@@ -583,8 +513,8 @@ proceedToNextRound finishedRound ({ config, pressedButtons } as model) =
         startRound (Live ()) modelWithRecentResults <| prepareLiveRound config unpackedFinishedRound.seed (participating getHoleStatusById playersWithRecentResults) pressedButtons
 
 
-stepOneTick : Overlay.State -> ActiveGameState -> FinishedRound -> Replay2 -> Model -> ( Model, Effect )
-stepOneTick overlayState activeGameState finishedRound replay model =
+stepOneTick : Overlay.State -> ActiveGameState -> FinishedRound -> Model -> ( Model, Effect )
+stepOneTick overlayState activeGameState finishedRound model =
     case activeGameState of
         Spawning _ _ ->
             ( model, DoNothing )
@@ -603,13 +533,13 @@ stepOneTick overlayState activeGameState finishedRound replay model =
                         lastTick
                         midRoundState
             in
-            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound replay) Paused tickResult) }
+            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound) Paused tickResult) }
             , maybeDrawSomething whatToDraw
             )
 
 
-fastForwardReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Replay2 -> Model -> ( Model, Effect )
-fastForwardReplay overlayState pausedOrNot activeGameState finishedRound replay ({ config } as model) =
+fastForwardReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Model -> ( Model, Effect )
+fastForwardReplay overlayState pausedOrNot activeGameState finishedRound ({ config } as model) =
     case activeGameState of
         Spawning _ plannedMidRoundState ->
             let
@@ -621,7 +551,7 @@ fastForwardReplay overlayState pausedOrNot activeGameState finishedRound replay 
                 whatToDraw =
                     drawSpawnsPermanently plannedMidRoundState.kurves.alive
             in
-            ( { model | appState = InGame <| Active (Replay overlayState finishedRound replay) NotPaused newActiveGameState }
+            ( { model | appState = InGame <| Active (Replay overlayState finishedRound) NotPaused newActiveGameState }
             , DrawSomething whatToDraw
             )
 
@@ -635,16 +565,16 @@ fastForwardReplay overlayState pausedOrNot activeGameState finishedRound replay 
                         lastTick
                         midRoundState
             in
-            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound replay) pausedOrNot tickResult) }
+            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound) pausedOrNot tickResult) }
             , maybeDrawSomething whatToDraw
             )
 
 
-rewindReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Replay2 -> Model -> ( Model, Effect )
-rewindReplay overlayState pausedOrNot activeGameState finishedRound replay model =
+rewindReplay : Overlay.State -> PausedOrNot -> ActiveGameState -> FinishedRound -> Model -> ( Model, Effect )
+rewindReplay overlayState pausedOrNot activeGameState finishedRound model =
     case activeGameState of
         Spawning _ _ ->
-            startRound (Replay overlayState finishedRound replay) model <| prepareReplayRound model.config.world (initialStateForReplaying finishedRound)
+            startRound (Replay overlayState finishedRound) model <| prepareReplayRound model.config.world (initialStateForReplaying finishedRound)
 
         Moving _ lastTick _ ->
             let
@@ -693,7 +623,7 @@ rewindReplay overlayState pausedOrNot activeGameState finishedRound replay model
                         Just whatToDrawForSkippingAhead ->
                             mergeWhatToDraw whatToDrawForSpawns whatToDrawForSkippingAhead
             in
-            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound replay) pausedOrNot tickResult) }
+            ( { model | appState = InGame (tickResultToGameState (Replay overlayState finishedRound) pausedOrNot tickResult) }
             , ClearAndThenDraw whatToDraw
             )
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -42,6 +42,7 @@ import IsGameOver exposing (isGameOver)
 import JavaScript exposing (magicClassNameToPreventUnload)
 import MainLoop
 import Menu exposing (MenuState(..))
+import Movie exposing (Movie)
 import Overlay
 import Players
     exposing
@@ -56,7 +57,6 @@ import Players
         , participating
         )
 import Random
-import Replay exposing (Replay2)
 import Round exposing (FinishedRound, Round, initialStateForReplaying, modifyAlive, modifyKurves)
 import Set exposing (Set)
 import Settings exposing (SettingId(..), Settings)
@@ -90,19 +90,19 @@ port saveToLocalStorage : String -> Cmd msg
 init : Flags -> ( Model, Cmd Msg )
 init flags =
     let
-        maybeReplay : Maybe Replay2
+        maybeReplay : Maybe Movie
         maybeReplay =
-            flags.replayQueryParameter
+            flags.movieQueryParameter
                 |> Maybe.andThen (String.replace " " "+" >> Base64.toBytes)
                 |> Maybe.andThen Flate.inflate
-                |> Maybe.andThen (Bytes.Decode.decode Replay.decoder)
-                |> Debug.log "replay"
+                |> Maybe.andThen (Bytes.Decode.decode Movie.decoder)
+                |> Debug.log "movie"
     in
     ( { pressedButtons = Set.empty
       , appState =
             case maybeReplay of
                 Just replay ->
-                    InReplay replay
+                    InMovie replay
 
                 Nothing ->
                     InMenu SplashScreen (Random.initialSeed flags.initialSeedValue)
@@ -141,7 +141,7 @@ type Msg
 type alias Flags =
     { initialSeedValue : Int
     , settingsJsonFromLocalStorage : Maybe String
-    , replayQueryParameter : Maybe String
+    , movieQueryParameter : Maybe String
     }
 
 
@@ -205,7 +205,7 @@ update msg ({ config } as model) =
                     , maybeDrawSomething whatToDraw
                     )
 
-                InReplay replay2 ->
+                InMovie movie ->
                     ä
 
                 _ ->
@@ -238,7 +238,7 @@ update msg ({ config } as model) =
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
-                InReplay _ ->
+                InMovie _ ->
                     -- Not expected to ever happen.
                     ( model, DoNothing )
 
@@ -507,7 +507,7 @@ buttonUsed button ({ config, pressedButtons } as model) =
                 _ ->
                     ( handleUserInteraction Down button model, DoNothing )
 
-        InReplay _ ->
+        InMovie _ ->
             let
                 _ =
                     Debug.log "keydown" button
@@ -745,7 +745,7 @@ subscriptions model =
             InMenu GameOver _ ->
                 Sub.none
 
-            InReplay replay2 ->
+            InMovie _ ->
                 Browser.Events.onAnimationFrameDelta AnimationFrame
         , focusLost (always FocusLost)
         ]
@@ -830,7 +830,7 @@ view model =
                     ]
                 ]
 
-        InReplay replay2 ->
+        InMovie _ ->
             elmRoot
                 (Events.AllowDefaultExcept playerButtons)
                 [ Attr.class "in-game-ish"

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -1,4 +1,4 @@
-module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime, withFloatingPointRoundingErrorCompensation)
+module MainLoop exposing (TickResultMovie(..), consumeAnimationFrame, consumeMovieAnimationFrame, noLeftoverFrameTime, withFloatingPointRoundingErrorCompensation)
 
 {-| Based on Isaac Sukin's `MainLoop.js`.
 
@@ -7,13 +7,19 @@ module MainLoop exposing (consumeAnimationFrame, noLeftoverFrameTime, withFloati
 
 -}
 
+import Colors
 import Config exposing (Config)
+import Dict
 import Drawing exposing (DrawingAccumulator, WhatToDraw)
 import Game exposing (TickResult(..))
+import Holes exposing (Holiness(..))
+import Movie exposing (Direction(..), Movie, MovieKurve)
+import Players
 import Round exposing (Round)
 import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
 import Types.Tick as Tick exposing (Tick)
 import Types.Tickrate as Tickrate
+import World exposing (DrawingPosition)
 
 
 consumeAnimationFrame :
@@ -68,6 +74,182 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
                 )
     in
     recurse timeToConsume lastTick midRoundState Drawing.initialize |> Tuple.mapSecond Drawing.finalize
+
+
+type TickResultMovie a
+    = MovieKeepsGoing a
+    | MovieEnds Tick Movie
+
+
+consumeMovieAnimationFrame :
+    Config
+    -> FrameTime
+    -> LeftoverFrameTime
+    -> Tick
+    -> Movie
+    -> ( TickResultMovie ( LeftoverFrameTime, Tick, Movie ), Maybe WhatToDraw )
+consumeMovieAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick movie =
+    let
+        timeToConsume : FrameTime
+        timeToConsume =
+            delta + leftoverTimeFromPreviousFrame
+
+        timestep : FrameTime
+        timestep =
+            1000 / Tickrate.toFloat config.kurves.tickrate
+
+        recurse :
+            LeftoverFrameTime
+            -> Tick
+            -> Movie
+            -> DrawingAccumulator
+            -> ( TickResultMovie ( LeftoverFrameTime, Tick, Movie ), DrawingAccumulator )
+        recurse timeLeftToConsume lastTickReactedTo movieSoFar drawingAccumulator =
+            if timeLeftToConsume >= timestep then
+                let
+                    incrementedTick : Tick
+                    incrementedTick =
+                        Tick.succ lastTickReactedTo
+
+                    ( newKurves, newColoredDrawingPositions, headDraws ) =
+                        movieSoFar.kurves
+                            |> List.foldl
+                                (\kurve ( accKurves, accDrawing, accHeadDraws ) ->
+                                    let
+                                        color =
+                                            Players.initialPlayers
+                                                |> Dict.get kurve.playerId
+                                                |> Maybe.map (Tuple.first >> .color)
+                                                |> Maybe.withDefault Colors.red
+
+                                        ( newKurve, newAccDrawing ) =
+                                            List.repeat movieSoFar.movesPerTick ()
+                                                |> List.foldl
+                                                    (\() ( accKurve, accDrawing_ ) ->
+                                                        case accKurve.moves of
+                                                            [] ->
+                                                                ( accKurve, accDrawing_ )
+
+                                                            move :: rest ->
+                                                                let
+                                                                    drawingPosition =
+                                                                        applyMove move accKurve.initialDrawingPosition
+                                                                in
+                                                                ( { accKurve
+                                                                    | moves = rest
+                                                                    , initialDrawingPosition = drawingPosition
+                                                                  }
+                                                                , case accKurve.initialHoliness of
+                                                                    Solid ->
+                                                                        ( color, drawingPosition ) :: accDrawing_
+
+                                                                    Holy ->
+                                                                        accDrawing_
+                                                                )
+                                                    )
+                                                    ( applyHolinessChange incrementedTick kurve, accDrawing )
+
+                                        newAccHeadDraws =
+                                            if List.isEmpty newKurve.moves then
+                                                accHeadDraws
+
+                                            else
+                                                ( color, newKurve.initialDrawingPosition ) :: accHeadDraws
+                                    in
+                                    ( newKurve :: accKurves, newAccDrawing, newAccHeadDraws )
+                                )
+                                ( [], [], [] )
+
+                    newMovie =
+                        { movieSoFar | kurves = List.reverse newKurves }
+
+                    tickResult =
+                        if List.isEmpty headDraws then
+                            MovieEnds incrementedTick newMovie
+
+                        else
+                            MovieKeepsGoing newMovie
+
+                    whatToDrawForThisTick : WhatToDraw
+                    whatToDrawForThisTick =
+                        { headDrawing = headDraws
+                        , bodyDrawing = newColoredDrawingPositions
+                        }
+
+                    newDrawingAccumulator : DrawingAccumulator
+                    newDrawingAccumulator =
+                        Drawing.accumulate drawingAccumulator whatToDrawForThisTick
+                in
+                case tickResult of
+                    MovieKeepsGoing newMovie_ ->
+                        recurse (timeLeftToConsume - timestep) incrementedTick newMovie_ newDrawingAccumulator
+
+                    MovieEnds tickThatEndedIt finishedMovie ->
+                        ( MovieEnds tickThatEndedIt finishedMovie
+                        , newDrawingAccumulator
+                        )
+
+            else
+                ( MovieKeepsGoing ( timeLeftToConsume, lastTickReactedTo, movieSoFar )
+                , drawingAccumulator
+                )
+    in
+    recurse timeToConsume lastTick movie Drawing.initialize |> Tuple.mapSecond Drawing.finalize
+
+
+applyHolinessChange : Tick -> MovieKurve -> MovieKurve
+applyHolinessChange tick kurve =
+    case kurve.holinessChanges of
+        [] ->
+            kurve
+
+        next :: rest ->
+            if next == tick then
+                { kurve
+                    | holinessChanges = rest
+                    , initialHoliness = flipHoliness kurve.initialHoliness
+                }
+
+            else
+                kurve
+
+
+applyMove : Movie.Direction -> DrawingPosition -> DrawingPosition
+applyMove direction { x, y } =
+    case direction of
+        N ->
+            { x = x, y = y - 1 }
+
+        NE ->
+            { x = x + 1, y = y - 1 }
+
+        E ->
+            { x = x + 1, y = y }
+
+        SE ->
+            { x = x + 1, y = y + 1 }
+
+        S ->
+            { x = x, y = y + 1 }
+
+        SW ->
+            { x = x - 1, y = y + 1 }
+
+        W ->
+            { x = x - 1, y = y }
+
+        NW ->
+            { x = x - 1, y = y - 1 }
+
+
+flipHoliness : Holiness -> Holiness
+flipHoliness holiness =
+    case holiness of
+        Holy ->
+            Solid
+
+        Solid ->
+            Holy
 
 
 noLeftoverFrameTime : LeftoverFrameTime

--- a/src/MainLoop.elm
+++ b/src/MainLoop.elm
@@ -7,14 +7,12 @@ module MainLoop exposing (TickResultMovie(..), consumeAnimationFrame, consumeMov
 
 -}
 
-import Colors
+import App exposing (Move(..), PlayingMovie, PlayingMovieKurve)
 import Config exposing (Config)
-import Dict
 import Drawing exposing (DrawingAccumulator, WhatToDraw)
 import Game exposing (TickResult(..))
 import Holes exposing (Holiness(..))
 import Movie exposing (Direction(..), Movie, MovieKurve)
-import Players
 import Round exposing (Round)
 import Types.FrameTime exposing (FrameTime, LeftoverFrameTime)
 import Types.Tick as Tick exposing (Tick)
@@ -76,52 +74,42 @@ consumeAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick midRou
     recurse timeToConsume lastTick midRoundState Drawing.initialize |> Tuple.mapSecond Drawing.finalize
 
 
-type TickResultMovie a
-    = MovieKeepsGoing a
-    | MovieEnds Tick Movie
+type TickResultMovie
+    = MovieKeepsGoing PlayingMovie
+    | MovieEnds PlayingMovie
 
 
 consumeMovieAnimationFrame :
     Config
     -> FrameTime
-    -> LeftoverFrameTime
-    -> Tick
-    -> Movie
-    -> ( TickResultMovie ( LeftoverFrameTime, Tick, Movie ), Maybe WhatToDraw )
-consumeMovieAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick movie =
+    -> PlayingMovie
+    -> ( TickResultMovie, Maybe WhatToDraw )
+consumeMovieAnimationFrame config delta movie =
     let
         timeToConsume : FrameTime
         timeToConsume =
-            delta + leftoverTimeFromPreviousFrame
+            delta + movie.leftoverTimeFromPreviousFrame
 
         timestep : FrameTime
         timestep =
             1000 / Tickrate.toFloat config.kurves.tickrate
 
         recurse :
-            LeftoverFrameTime
-            -> Tick
-            -> Movie
+            PlayingMovie
             -> DrawingAccumulator
-            -> ( TickResultMovie ( LeftoverFrameTime, Tick, Movie ), DrawingAccumulator )
-        recurse timeLeftToConsume lastTickReactedTo movieSoFar drawingAccumulator =
-            if timeLeftToConsume >= timestep then
+            -> ( TickResultMovie, DrawingAccumulator )
+        recurse movieSoFar drawingAccumulator =
+            if movieSoFar.leftoverTimeFromPreviousFrame >= timestep then
                 let
                     incrementedTick : Tick
                     incrementedTick =
-                        Tick.succ lastTickReactedTo
+                        Tick.succ movieSoFar.lastTick
 
                     ( newKurves, newColoredDrawingPositions, headDraws ) =
                         movieSoFar.kurves
                             |> List.foldl
                                 (\kurve ( accKurves, accDrawing, accHeadDraws ) ->
                                     let
-                                        color =
-                                            Players.initialPlayers
-                                                |> Dict.get kurve.playerId
-                                                |> Maybe.map (Tuple.first >> .color)
-                                                |> Maybe.withDefault Colors.red
-
                                         ( newKurve, newAccDrawing ) =
                                             List.repeat movieSoFar.movesPerTick ()
                                                 |> List.foldl
@@ -133,15 +121,15 @@ consumeMovieAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick m
                                                             move :: rest ->
                                                                 let
                                                                     drawingPosition =
-                                                                        applyMove move accKurve.initialDrawingPosition
+                                                                        applyMove move accKurve.drawingPosition
                                                                 in
                                                                 ( { accKurve
                                                                     | moves = rest
-                                                                    , initialDrawingPosition = drawingPosition
+                                                                    , drawingPosition = drawingPosition
                                                                   }
-                                                                , case accKurve.initialHoliness of
+                                                                , case accKurve.holiness of
                                                                     Solid ->
-                                                                        ( color, drawingPosition ) :: accDrawing_
+                                                                        ( accKurve.color, drawingPosition ) :: accDrawing_
 
                                                                     Holy ->
                                                                         accDrawing_
@@ -154,18 +142,23 @@ consumeMovieAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick m
                                                 accHeadDraws
 
                                             else
-                                                ( color, newKurve.initialDrawingPosition ) :: accHeadDraws
+                                                ( newKurve.color, newKurve.drawingPosition ) :: accHeadDraws
                                     in
                                     ( newKurve :: accKurves, newAccDrawing, newAccHeadDraws )
                                 )
                                 ( [], [], [] )
 
+                    newMovie : PlayingMovie
                     newMovie =
-                        { movieSoFar | kurves = List.reverse newKurves }
+                        { movieSoFar
+                            | kurves = List.reverse newKurves
+                            , lastTick = incrementedTick
+                            , leftoverTimeFromPreviousFrame = movieSoFar.leftoverTimeFromPreviousFrame - timestep
+                        }
 
                     tickResult =
                         if List.isEmpty headDraws then
-                            MovieEnds incrementedTick newMovie
+                            MovieEnds { newMovie | isPlaying = False }
 
                         else
                             MovieKeepsGoing newMovie
@@ -182,22 +175,20 @@ consumeMovieAnimationFrame config delta leftoverTimeFromPreviousFrame lastTick m
                 in
                 case tickResult of
                     MovieKeepsGoing newMovie_ ->
-                        recurse (timeLeftToConsume - timestep) incrementedTick newMovie_ newDrawingAccumulator
+                        recurse newMovie_ newDrawingAccumulator
 
-                    MovieEnds tickThatEndedIt finishedMovie ->
-                        ( MovieEnds tickThatEndedIt finishedMovie
-                        , newDrawingAccumulator
-                        )
+                    MovieEnds finishedMovie ->
+                        ( MovieEnds finishedMovie, newDrawingAccumulator )
 
             else
-                ( MovieKeepsGoing ( timeLeftToConsume, lastTickReactedTo, movieSoFar )
+                ( MovieKeepsGoing movieSoFar
                 , drawingAccumulator
                 )
     in
-    recurse timeToConsume lastTick movie Drawing.initialize |> Tuple.mapSecond Drawing.finalize
+    recurse { movie | leftoverTimeFromPreviousFrame = timeToConsume } Drawing.initialize |> Tuple.mapSecond Drawing.finalize
 
 
-applyHolinessChange : Tick -> MovieKurve -> MovieKurve
+applyHolinessChange : Tick -> PlayingMovieKurve -> PlayingMovieKurve
 applyHolinessChange tick kurve =
     case kurve.holinessChanges of
         [] ->
@@ -207,39 +198,44 @@ applyHolinessChange tick kurve =
             if next == tick then
                 { kurve
                     | holinessChanges = rest
-                    , initialHoliness = flipHoliness kurve.initialHoliness
+                    , holiness = flipHoliness kurve.holiness
                 }
 
             else
                 kurve
 
 
-applyMove : Movie.Direction -> DrawingPosition -> DrawingPosition
-applyMove direction { x, y } =
-    case direction of
-        N ->
-            { x = x, y = y - 1 }
+applyMove : Move -> DrawingPosition -> DrawingPosition
+applyMove move { x, y } =
+    case move of
+        NoMove ->
+            { x = x, y = y }
 
-        NE ->
-            { x = x + 1, y = y - 1 }
+        MoveDirection direction ->
+            case direction of
+                N ->
+                    { x = x, y = y - 1 }
 
-        E ->
-            { x = x + 1, y = y }
+                NE ->
+                    { x = x + 1, y = y - 1 }
 
-        SE ->
-            { x = x + 1, y = y + 1 }
+                E ->
+                    { x = x + 1, y = y }
 
-        S ->
-            { x = x, y = y + 1 }
+                SE ->
+                    { x = x + 1, y = y + 1 }
 
-        SW ->
-            { x = x - 1, y = y + 1 }
+                S ->
+                    { x = x, y = y + 1 }
 
-        W ->
-            { x = x - 1, y = y }
+                SW ->
+                    { x = x - 1, y = y + 1 }
 
-        NW ->
-            { x = x - 1, y = y - 1 }
+                W ->
+                    { x = x - 1, y = y }
+
+                NW ->
+                    { x = x - 1, y = y - 1 }
 
 
 flipHoliness : Holiness -> Holiness

--- a/src/Movie.elm
+++ b/src/Movie.elm
@@ -4,6 +4,7 @@ import Bitwise
 import Bytes
 import Bytes.Decode as Decode exposing (Decoder)
 import Bytes.Encode as Encode exposing (Encoder)
+import Holes exposing (Holiness(..))
 import Types.Kurve exposing (Kurve)
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick as Tick exposing (Tick)
@@ -19,8 +20,9 @@ type alias Movie =
 type alias MovieKurve =
     { playerId : PlayerId
     , initialDrawingPosition : DrawingPosition
+    , initialHoliness : Holiness
 
-    -- The default is `Solid`. Each listed tick it flips. If the list starts with `Tick 0`, it means that the Kurve started out holy.
+    -- Each listed tick the holiness flips. Note that the smallest possible tick is 1 (not 0).
     , holinessChanges : List Tick
 
     -- Note: A Kurve never moves in one direction and then directly in the opposite direction.
@@ -70,6 +72,7 @@ toMovieKurve movesPerTick kurve =
     in
     { playerId = kurve.id
     , initialDrawingPosition = initialDrawingPosition
+    , initialHoliness = Holes.getHoliness kurve.stateAtSpawn.holeStatus
     , holinessChanges = List.reverse kurve.reversedHolinessChanges
     , moves =
         kurve.reversedDrawingPositionsPerTick
@@ -247,6 +250,7 @@ kurveEncoder kurve =
     Encode.sequence
         [ Encode.unsignedInt8 kurve.playerId
         , drawingPositionEncoder kurve.initialDrawingPosition
+        , holinessEncoder kurve.initialHoliness
         , holinessChangesEncoder kurve.holinessChanges
         , movesEncoder kurve.moves
         ]
@@ -254,9 +258,10 @@ kurveEncoder kurve =
 
 kurveDecoder : Decoder MovieKurve
 kurveDecoder =
-    Decode.map4 MovieKurve
+    Decode.map5 MovieKurve
         Decode.unsignedInt8
         drawingPositionDecoder
+        holinessDecoder
         holinessChangesDecoder
         movesDecoder
 
@@ -274,6 +279,35 @@ drawingPositionDecoder =
     Decode.map2 DrawingPosition
         (Decode.unsignedInt16 endianness)
         (Decode.unsignedInt16 endianness)
+
+
+holinessEncoder : Holiness -> Encoder
+holinessEncoder holiness =
+    Encode.unsignedInt8
+        (case holiness of
+            Holy ->
+                0
+
+            Solid ->
+                1
+        )
+
+
+holinessDecoder : Decoder Holiness
+holinessDecoder =
+    Decode.unsignedInt8
+        |> Decode.andThen
+            (\int ->
+                case int of
+                    0 ->
+                        Decode.succeed Holy
+
+                    1 ->
+                        Decode.succeed Solid
+
+                    _ ->
+                        Decode.fail
+            )
 
 
 holinessChangesEncoder : List Tick -> Encoder

--- a/src/Movie.elm
+++ b/src/Movie.elm
@@ -1,4 +1,4 @@
-module Replay exposing (..)
+module Movie exposing (..)
 
 import Bitwise
 import Bytes
@@ -10,13 +10,13 @@ import Types.Tick as Tick exposing (Tick)
 import World exposing (DrawingPosition)
 
 
-type alias Replay2 =
+type alias Movie =
     { movesPerTick : Int
-    , kurves : List ReplayKurve
+    , kurves : List MovieKurve
     }
 
 
-type alias ReplayKurve =
+type alias MovieKurve =
     { playerId : PlayerId
     , initialDrawingPosition : DrawingPosition
 
@@ -43,14 +43,14 @@ type Direction
     | NW
 
 
-fromKurves : List Kurve -> Replay2
+fromKurves : List Kurve -> Movie
 fromKurves kurves =
     let
         movesPerTick =
             getMovesPerTick kurves
     in
     { movesPerTick = movesPerTick
-    , kurves = List.map (toReplayKurve movesPerTick) kurves
+    , kurves = List.map (toMovieKurve movesPerTick) kurves
     }
 
 
@@ -62,8 +62,8 @@ getMovesPerTick kurves =
         |> Maybe.withDefault 0
 
 
-toReplayKurve : Int -> Kurve -> ReplayKurve
-toReplayKurve movesPerTick kurve =
+toMovieKurve : Int -> Kurve -> MovieKurve
+toMovieKurve movesPerTick kurve =
     let
         initialDrawingPosition =
             World.drawingPosition kurve.stateAtSpawn.position
@@ -195,16 +195,16 @@ latestVersion =
     0
 
 
-encoder : Replay2 -> Encoder
-encoder replay =
+encoder : Movie -> Encoder
+encoder movie =
     Encode.sequence
         [ Encode.unsignedInt8 latestVersion
-        , Encode.unsignedInt8 replay.movesPerTick
-        , kurvesEncoder replay.kurves
+        , Encode.unsignedInt8 movie.movesPerTick
+        , kurvesEncoder movie.kurves
         ]
 
 
-decoder : Decoder Replay2
+decoder : Decoder Movie
 decoder =
     Decode.unsignedInt8
         |> Decode.andThen
@@ -218,14 +218,14 @@ decoder =
             )
 
 
-v0Decoder : Decoder Replay2
+v0Decoder : Decoder Movie
 v0Decoder =
-    Decode.map2 Replay2
+    Decode.map2 Movie
         Decode.unsignedInt8
         kurvesDecoder
 
 
-kurvesEncoder : List ReplayKurve -> Encoder
+kurvesEncoder : List MovieKurve -> Encoder
 kurvesEncoder kurves =
     Encode.sequence
         [ Encode.unsignedInt8 (List.length kurves)
@@ -233,7 +233,7 @@ kurvesEncoder kurves =
         ]
 
 
-kurvesDecoder : Decoder (List ReplayKurve)
+kurvesDecoder : Decoder (List MovieKurve)
 kurvesDecoder =
     Decode.unsignedInt8
         |> Decode.andThen
@@ -242,7 +242,7 @@ kurvesDecoder =
             )
 
 
-kurveEncoder : ReplayKurve -> Encoder
+kurveEncoder : MovieKurve -> Encoder
 kurveEncoder kurve =
     Encode.sequence
         [ Encode.unsignedInt8 kurve.playerId
@@ -252,9 +252,9 @@ kurveEncoder kurve =
         ]
 
 
-kurveDecoder : Decoder ReplayKurve
+kurveDecoder : Decoder MovieKurve
 kurveDecoder =
-    Decode.map4 ReplayKurve
+    Decode.map4 MovieKurve
         Decode.unsignedInt8
         drawingPositionDecoder
         holinessChangesDecoder

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -1,5 +1,7 @@
 module Replay exposing (..)
 
+import Bytes exposing (Bytes, Endianness(..))
+import Bytes.Encode as Encode exposing (Encoder)
 import Holes exposing (Holiness(..))
 import Types.Kurve exposing (Kurve)
 import Types.PlayerId exposing (PlayerId)
@@ -188,3 +190,8 @@ optimizeRepetitions reversedMoves =
                             ( last, [] )
             in
             finalMove :: finalAcc
+
+
+encoder : Replay -> Encoder
+encoder replay =
+    Encode.sequence [ Encode.unsignedInt16 BE 1 ]

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -10,7 +10,7 @@ import Types.Tick as Tick exposing (Tick)
 import World exposing (DrawingPosition)
 
 
-type alias Replay =
+type alias Replay2 =
     { movesPerTick : Int
     , kurves : List ReplayKurve
     }
@@ -43,7 +43,7 @@ type Direction
     | NW
 
 
-fromKurves : List Kurve -> Replay
+fromKurves : List Kurve -> Replay2
 fromKurves kurves =
     let
         movesPerTick =
@@ -195,7 +195,7 @@ latestVersion =
     0
 
 
-encoder : Replay -> Encoder
+encoder : Replay2 -> Encoder
 encoder replay =
     Encode.sequence
         [ Encode.unsignedInt8 latestVersion
@@ -204,7 +204,7 @@ encoder replay =
         ]
 
 
-decoder : Decoder Replay
+decoder : Decoder Replay2
 decoder =
     Decode.unsignedInt8
         |> Decode.andThen
@@ -218,9 +218,9 @@ decoder =
             )
 
 
-v0Decoder : Decoder Replay
+v0Decoder : Decoder Replay2
 v0Decoder =
-    Decode.map2 Replay
+    Decode.map2 Replay2
         Decode.unsignedInt8
         kurvesDecoder
 

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -1,14 +1,13 @@
 module Replay exposing (..)
 
-import Holes exposing (Holiness)
+import Holes exposing (Holiness(..))
+import Types.Kurve exposing (Kurve)
 import Types.PlayerId exposing (PlayerId)
-import Types.Tickrate exposing (Tickrate)
 import World exposing (DrawingPosition)
 
 
 type alias Replay =
     { kurves : List ReplayKurve
-    , tickrate : Tickrate
     , movesPerTick : Int
     }
 
@@ -20,13 +19,13 @@ type alias ReplayKurve =
     }
 
 
-type Move
-    = NoMove
-    | Move MoveData
+maxRepetitions : Int
+maxRepetitions =
+    15
 
 
-type alias MoveData =
-    { repetitions : Int
+type alias Move =
+    { repetitions : Int -- 0–15. 0 means “no movement” and the direction is ignored.
     , direction : Direction
     , holiness : Holiness
     }
@@ -40,4 +39,152 @@ type Direction
     | S
     | SW
     | W
-    | W
+    | NW
+
+
+fromKurves : List Kurve -> Replay
+fromKurves kurves =
+    let
+        movesPerTick =
+            getMovesPerTick kurves
+    in
+    { kurves = List.map (toReplayKurve movesPerTick) kurves
+    , movesPerTick = movesPerTick
+    }
+
+
+getMovesPerTick : List Kurve -> Int
+getMovesPerTick kurves =
+    kurves
+        |> List.concatMap (.reversedDrawingPositionsPerTick >> List.map List.length)
+        |> List.maximum
+        |> Maybe.withDefault 0
+
+
+toReplayKurve : Int -> Kurve -> ReplayKurve
+toReplayKurve movesPerTick kurve =
+    let
+        initialDrawingPosition =
+            World.drawingPosition kurve.stateAtSpawn.position
+    in
+    { initialDrawingPosition = initialDrawingPosition
+    , playerId = kurve.id
+    , moves =
+        kurve.reversedDrawingPositionsPerTick
+            |> List.concatMap (pad movesPerTick)
+            |> toMoves initialDrawingPosition
+            |> optimizeRepetitions
+            |> List.reverse
+    }
+
+
+pad : Int -> List ( DrawingPosition, Holiness ) -> List ( DrawingPosition, Holiness )
+pad length reversedList =
+    let
+        actualLength =
+            List.length reversedList
+    in
+    if actualLength < length then
+        let
+            padding =
+                List.head reversedList |> Maybe.withDefault ( { x = 0, y = 0 }, Holy )
+        in
+        reversedList ++ List.repeat (length - actualLength) padding
+
+    else
+        reversedList
+
+
+toMoves : DrawingPosition -> List ( DrawingPosition, Holiness ) -> List Move
+toMoves initialDrawingPosition reversedDrawingPositions =
+    reversedDrawingPositions
+        |> List.foldr
+            (\( drawingPosition, holiness ) ( lastDrawingPosition, acc ) ->
+                let
+                    move : Move
+                    move =
+                        case getDirection lastDrawingPosition drawingPosition of
+                            Just direction ->
+                                { repetitions = 1
+                                , direction = direction
+                                , holiness = holiness
+                                }
+
+                            Nothing ->
+                                { repetitions = 0
+                                , direction = N
+                                , holiness = holiness
+                                }
+                in
+                ( drawingPosition
+                , move :: acc
+                )
+            )
+            ( initialDrawingPosition
+            , []
+            )
+        |> Tuple.second
+
+
+getDirection : DrawingPosition -> DrawingPosition -> Maybe Direction
+getDirection previousDrawingPosition drawingPosition =
+    case ( compare previousDrawingPosition.x drawingPosition.x, compare previousDrawingPosition.y drawingPosition.y ) of
+        ( EQ, LT ) ->
+            Just N
+
+        ( GT, LT ) ->
+            Just NE
+
+        ( GT, EQ ) ->
+            Just E
+
+        ( GT, GT ) ->
+            Just SE
+
+        ( EQ, GT ) ->
+            Just S
+
+        ( LT, GT ) ->
+            Just SW
+
+        ( LT, EQ ) ->
+            Just W
+
+        ( LT, LT ) ->
+            Just NW
+
+        ( EQ, EQ ) ->
+            Nothing
+
+
+optimizeRepetitions : List Move -> List Move
+optimizeRepetitions reversedMoves =
+    case reversedMoves of
+        [] ->
+            []
+
+        last :: rest ->
+            let
+                ( finalMove, finalAcc ) =
+                    rest
+                        |> List.foldr
+                            (\move ( previousMove, acc ) ->
+                                let
+                                    repetitions =
+                                        previousMove.repetitions + move.repetitions
+                                in
+                                if
+                                    (repetitions < maxRepetitions)
+                                        && (previousMove.repetitions > 0)
+                                        && (move.repetitions > 0)
+                                        && (previousMove.direction == move.direction)
+                                        && (previousMove.holiness == move.holiness)
+                                then
+                                    ( { move | repetitions = repetitions }, acc )
+
+                                else
+                                    ( move, previousMove :: acc )
+                            )
+                            ( last, [] )
+            in
+            finalMove :: finalAcc

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -1,0 +1,43 @@
+module Replay exposing (..)
+
+import Holes exposing (Holiness)
+import Types.PlayerId exposing (PlayerId)
+import Types.Tickrate exposing (Tickrate)
+import World exposing (DrawingPosition)
+
+
+type alias Replay =
+    { kurves : List ReplayKurve
+    , tickrate : Tickrate
+    , movesPerTick : Int
+    }
+
+
+type alias ReplayKurve =
+    { initialDrawingPosition : DrawingPosition
+    , playerId : PlayerId
+    , moves : List Move
+    }
+
+
+type Move
+    = NoMove
+    | Move MoveData
+
+
+type alias MoveData =
+    { repetitions : Int
+    , direction : Direction
+    , holiness : Holiness
+    }
+
+
+type Direction
+    = N
+    | NE
+    | E
+    | SE
+    | S
+    | SW
+    | W
+    | W

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -2,6 +2,7 @@ module Replay exposing (..)
 
 import Bitwise
 import Bytes
+import Bytes.Decode as Decode exposing (Decoder)
 import Bytes.Encode as Encode exposing (Encoder)
 import Holes exposing (Holiness(..))
 import Types.Kurve exposing (Kurve)
@@ -10,14 +11,14 @@ import World exposing (DrawingPosition)
 
 
 type alias Replay =
-    { kurves : List ReplayKurve
-    , movesPerTick : Int
+    { movesPerTick : Int
+    , kurves : List ReplayKurve
     }
 
 
 type alias ReplayKurve =
-    { initialDrawingPosition : DrawingPosition
-    , playerId : PlayerId
+    { playerId : PlayerId
+    , initialDrawingPosition : DrawingPosition
     , moves : List Move
     }
 
@@ -51,8 +52,8 @@ fromKurves kurves =
         movesPerTick =
             getMovesPerTick kurves
     in
-    { kurves = List.map (toReplayKurve movesPerTick) kurves
-    , movesPerTick = movesPerTick
+    { movesPerTick = movesPerTick
+    , kurves = List.map (toReplayKurve movesPerTick) kurves
     }
 
 
@@ -70,8 +71,8 @@ toReplayKurve movesPerTick kurve =
         initialDrawingPosition =
             World.drawingPosition kurve.stateAtSpawn.position
     in
-    { initialDrawingPosition = initialDrawingPosition
-    , playerId = kurve.id
+    { playerId = kurve.id
+    , initialDrawingPosition = initialDrawingPosition
     , moves =
         kurve.reversedDrawingPositionsPerTick
             |> List.concatMap (pad movesPerTick)
@@ -195,7 +196,7 @@ optimizeRepetitions reversedMoves =
 
 latestVersion : Int
 latestVersion =
-    1
+    0
 
 
 endianness : Bytes.Endianness
@@ -279,3 +280,111 @@ moveToUint8 move =
     (repetitions |> Bitwise.shiftLeftBy 4)
         + (holiness |> Bitwise.shiftLeftBy 3)
         + direction
+
+
+decoder : Decoder Replay
+decoder =
+    Decode.unsignedInt8
+        |> Decode.andThen
+            (\version ->
+                case version of
+                    0 ->
+                        v0Decoder
+
+                    _ ->
+                        Decode.fail
+            )
+
+
+v0Decoder : Decoder Replay
+v0Decoder =
+    Decode.map2 Replay
+        Decode.unsignedInt8
+        kurvesDecoder
+
+
+kurvesDecoder : Decoder (List ReplayKurve)
+kurvesDecoder =
+    Decode.unsignedInt8
+        |> Decode.andThen
+            (\numKurves ->
+                Decode.map3 (List.map3 ReplayKurve)
+                    (list numKurves Decode.unsignedInt8)
+                    (list numKurves drawingPositionDecoder)
+                    (list numKurves movesDecoder)
+            )
+
+
+list : Int -> Decoder a -> Decoder (List a)
+list len itemDecoder =
+    Decode.loop ( len, [] ) (listStep itemDecoder)
+
+
+listStep : Decoder a -> ( Int, List a ) -> Decoder (Decode.Step ( Int, List a ) (List a))
+listStep itemDecoder ( n, xs ) =
+    if n <= 0 then
+        Decode.succeed (Decode.Done (List.reverse xs))
+
+    else
+        Decode.map (\x -> Decode.Loop ( n - 1, x :: xs )) itemDecoder
+
+
+drawingPositionDecoder : Decoder DrawingPosition
+drawingPositionDecoder =
+    Decode.map2 DrawingPosition
+        (Decode.unsignedInt16 endianness)
+        (Decode.unsignedInt16 endianness)
+
+
+movesDecoder : Decoder (List Move)
+movesDecoder =
+    Decode.unsignedInt32 endianness
+        |> Decode.andThen
+            (\numMoves ->
+                list numMoves moveDecoder
+            )
+
+
+moveDecoder : Decoder Move
+moveDecoder =
+    Decode.unsignedInt8 |> Decode.map uint8ToMove
+
+
+uint8ToMove : Int -> Move
+uint8ToMove int =
+    let
+        direction =
+            case Bitwise.and int 7 of
+                0 ->
+                    N
+
+                1 ->
+                    NE
+
+                2 ->
+                    E
+
+                3 ->
+                    SE
+
+                4 ->
+                    S
+
+                5 ->
+                    SW
+
+                6 ->
+                    W
+
+                _ ->
+                    NW
+    in
+    { repetitions = int |> Bitwise.shiftRightZfBy 4
+    , holiness =
+        if Bitwise.and int 8 == 1 then
+            Solid
+
+        else
+            Holy
+    , direction = direction
+    }

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -4,9 +4,9 @@ import Bitwise
 import Bytes
 import Bytes.Decode as Decode exposing (Decoder)
 import Bytes.Encode as Encode exposing (Encoder)
-import Holes exposing (Holiness(..))
 import Types.Kurve exposing (Kurve)
 import Types.PlayerId exposing (PlayerId)
+import Types.Tick as Tick exposing (Tick)
 import World exposing (DrawingPosition)
 
 
@@ -19,19 +19,16 @@ type alias Replay =
 type alias ReplayKurve =
     { playerId : PlayerId
     , initialDrawingPosition : DrawingPosition
-    , moves : List Move
-    }
 
+    -- The default is `Solid`. Each listed tick it flips. If the list starts with `Tick 0`, it means that the Kurve started out holy.
+    , holinessChanges : List Tick
 
-maxRepetitions : Int
-maxRepetitions =
-    15
-
-
-type alias Move =
-    { repetitions : Int -- 0–15. 0 means “no movement” and the direction is ignored.
-    , direction : Direction
-    , holiness : Holiness
+    -- Note: A Kurve never moves in one direction and then directly in the opposite direction.
+    -- That is instead used to denote that the kurve didn’t move at all.
+    -- `[ N, S ]` means north, then no movement.
+    -- `[ N, S, S ]` means north, then no movement twice.
+    -- `[ N, S, N ]` means north, then no movement, then north.
+    , moves : List Direction
     }
 
 
@@ -73,61 +70,60 @@ toReplayKurve movesPerTick kurve =
     in
     { playerId = kurve.id
     , initialDrawingPosition = initialDrawingPosition
+    , holinessChanges = List.reverse kurve.reversedHolinessChanges
     , moves =
         kurve.reversedDrawingPositionsPerTick
-            |> List.concatMap (pad movesPerTick)
-            |> toMoves initialDrawingPosition
-            |> optimizeRepetitions
+            |> toMoves movesPerTick initialDrawingPosition
             |> List.reverse
     }
 
 
-pad : Int -> List ( DrawingPosition, Holiness ) -> List ( DrawingPosition, Holiness )
-pad length reversedList =
+toMoves : Int -> DrawingPosition -> List (List DrawingPosition) -> List Direction
+toMoves movesPerTick initialDrawingPosition reversedDrawingPositions =
     let
-        actualLength =
-            List.length reversedList
+        ( _, _, directions ) =
+            reversedDrawingPositions
+                |> List.foldr
+                    (\tickDrawingPositions outerAcc ->
+                        let
+                            ( newLastDrawingPosition, newLastDirection, newAcc ) =
+                                tickDrawingPositions
+                                    |> List.foldr
+                                        (\drawingPosition ( lastDrawingPosition, lastDirection, acc ) ->
+                                            let
+                                                direction =
+                                                    case getDirection lastDrawingPosition drawingPosition of
+                                                        Just direction_ ->
+                                                            direction_
+
+                                                        Nothing ->
+                                                            opposite lastDirection
+                                            in
+                                            ( drawingPosition
+                                            , direction
+                                            , direction :: acc
+                                            )
+                                        )
+                                        outerAcc
+
+                            lengthDiff =
+                                movesPerTick - List.length tickDrawingPositions
+
+                            paddedAcc =
+                                if lengthDiff > 0 then
+                                    List.repeat lengthDiff (opposite newLastDirection) ++ newAcc
+
+                                else
+                                    newAcc
+                        in
+                        ( newLastDrawingPosition, newLastDirection, paddedAcc )
+                    )
+                    ( initialDrawingPosition
+                    , N
+                    , []
+                    )
     in
-    if actualLength < length then
-        let
-            padding =
-                List.head reversedList |> Maybe.withDefault ( { x = 0, y = 0 }, Holy )
-        in
-        reversedList ++ List.repeat (length - actualLength) padding
-
-    else
-        reversedList
-
-
-toMoves : DrawingPosition -> List ( DrawingPosition, Holiness ) -> List Move
-toMoves initialDrawingPosition reversedDrawingPositions =
-    reversedDrawingPositions
-        |> List.foldr
-            (\( drawingPosition, holiness ) ( lastDrawingPosition, acc ) ->
-                let
-                    move : Move
-                    move =
-                        case getDirection lastDrawingPosition drawingPosition of
-                            Just direction ->
-                                { repetitions = 1
-                                , direction = direction
-                                , holiness = holiness
-                                }
-
-                            Nothing ->
-                                { repetitions = 0
-                                , direction = N
-                                , holiness = holiness
-                                }
-                in
-                ( drawingPosition
-                , move :: acc
-                )
-            )
-            ( initialDrawingPosition
-            , []
-            )
-        |> Tuple.second
+    directions
 
 
 getDirection : DrawingPosition -> DrawingPosition -> Maybe Direction
@@ -161,42 +157,32 @@ getDirection previousDrawingPosition drawingPosition =
             Nothing
 
 
-optimizeRepetitions : List Move -> List Move
-optimizeRepetitions reversedMoves =
-    case reversedMoves of
-        [] ->
-            []
+opposite : Direction -> Direction
+opposite direction =
+    case direction of
+        N ->
+            S
 
-        last :: rest ->
-            let
-                ( finalMove, finalAcc ) =
-                    rest
-                        |> List.foldr
-                            (\move ( previousMove, acc ) ->
-                                let
-                                    repetitions =
-                                        previousMove.repetitions + move.repetitions
-                                in
-                                if
-                                    (repetitions < maxRepetitions)
-                                        && (previousMove.repetitions > 0)
-                                        && (move.repetitions > 0)
-                                        && (previousMove.direction == move.direction)
-                                        && (previousMove.holiness == move.holiness)
-                                then
-                                    ( { move | repetitions = repetitions }, acc )
+        NE ->
+            SW
 
-                                else
-                                    ( move, previousMove :: acc )
-                            )
-                            ( last, [] )
-            in
-            finalMove :: finalAcc
+        E ->
+            W
 
+        SE ->
+            NW
 
-latestVersion : Int
-latestVersion =
-    0
+        S ->
+            N
+
+        SW ->
+            NE
+
+        W ->
+            E
+
+        NW ->
+            SE
 
 
 endianness : Bytes.Endianness
@@ -204,82 +190,18 @@ endianness =
     Bytes.BE
 
 
+latestVersion : Int
+latestVersion =
+    0
+
+
 encoder : Replay -> Encoder
 encoder replay =
     Encode.sequence
         [ Encode.unsignedInt8 latestVersion
         , Encode.unsignedInt8 replay.movesPerTick
-        , Encode.unsignedInt8 (List.length replay.kurves)
-        , Encode.sequence (replay.kurves |> List.map (.playerId >> Encode.unsignedInt8))
-        , Encode.sequence (replay.kurves |> List.map (.initialDrawingPosition >> drawingPositionEncoder))
-        , Encode.sequence (replay.kurves |> List.map (.moves >> movesEncoder))
+        , kurvesEncoder replay.kurves
         ]
-
-
-drawingPositionEncoder : DrawingPosition -> Encoder
-drawingPositionEncoder { x, y } =
-    Encode.sequence
-        [ Encode.unsignedInt16 endianness x
-        , Encode.unsignedInt16 endianness y
-        ]
-
-
-movesEncoder : List Move -> Encoder
-movesEncoder moves =
-    Encode.sequence
-        [ Encode.unsignedInt32 endianness (List.length moves)
-        , Encode.sequence (List.map moveEncoder moves)
-        ]
-
-
-moveEncoder : Move -> Encoder
-moveEncoder move =
-    Encode.unsignedInt8 (moveToUint8 move)
-
-
-moveToUint8 : Move -> Int
-moveToUint8 move =
-    let
-        repetitions =
-            move.repetitions
-
-        holiness =
-            case move.holiness of
-                Holy ->
-                    1
-
-                Solid ->
-                    0
-
-        direction =
-            case move.direction of
-                N ->
-                    0
-
-                NE ->
-                    1
-
-                E ->
-                    2
-
-                SE ->
-                    3
-
-                S ->
-                    4
-
-                SW ->
-                    5
-
-                W ->
-                    6
-
-                NW ->
-                    7
-    in
-    (repetitions |> Bitwise.shiftLeftBy 4)
-        + (holiness |> Bitwise.shiftLeftBy 3)
-        + direction
 
 
 decoder : Decoder Replay
@@ -303,16 +225,267 @@ v0Decoder =
         kurvesDecoder
 
 
+kurvesEncoder : List ReplayKurve -> Encoder
+kurvesEncoder kurves =
+    Encode.sequence
+        [ Encode.unsignedInt8 (List.length kurves)
+        , Encode.sequence (List.map kurveEncoder kurves)
+        ]
+
+
 kurvesDecoder : Decoder (List ReplayKurve)
 kurvesDecoder =
     Decode.unsignedInt8
         |> Decode.andThen
-            (\numKurves ->
-                Decode.map3 (List.map3 ReplayKurve)
-                    (list numKurves Decode.unsignedInt8)
-                    (list numKurves drawingPositionDecoder)
-                    (list numKurves movesDecoder)
+            (\length ->
+                list length kurveDecoder
             )
+
+
+kurveEncoder : ReplayKurve -> Encoder
+kurveEncoder kurve =
+    Encode.sequence
+        [ Encode.unsignedInt8 kurve.playerId
+        , drawingPositionEncoder kurve.initialDrawingPosition
+        , holinessChangesEncoder kurve.holinessChanges
+        , movesEncoder kurve.moves
+        ]
+
+
+kurveDecoder : Decoder ReplayKurve
+kurveDecoder =
+    Decode.map4 ReplayKurve
+        Decode.unsignedInt8
+        drawingPositionDecoder
+        holinessChangesDecoder
+        movesDecoder
+
+
+drawingPositionEncoder : DrawingPosition -> Encoder
+drawingPositionEncoder { x, y } =
+    Encode.sequence
+        [ Encode.unsignedInt16 endianness x
+        , Encode.unsignedInt16 endianness y
+        ]
+
+
+drawingPositionDecoder : Decoder DrawingPosition
+drawingPositionDecoder =
+    Decode.map2 DrawingPosition
+        (Decode.unsignedInt16 endianness)
+        (Decode.unsignedInt16 endianness)
+
+
+holinessChangesEncoder : List Tick -> Encoder
+holinessChangesEncoder ticks =
+    Encode.sequence
+        [ Encode.unsignedInt32 endianness (List.length ticks)
+        , Encode.sequence (List.map tickEncoder ticks)
+        ]
+
+
+holinessChangesDecoder : Decoder (List Tick)
+holinessChangesDecoder =
+    Decode.unsignedInt32 endianness
+        |> Decode.andThen (\length -> list length tickDecoder)
+
+
+tickEncoder : Tick -> Encoder
+tickEncoder =
+    Tick.toInt >> Encode.unsignedInt32 endianness
+
+
+tickDecoder : Decoder Tick
+tickDecoder =
+    Decode.unsignedInt32 endianness
+        |> Decode.andThen
+            (\int ->
+                case Tick.fromInt int of
+                    Just tick ->
+                        Decode.succeed tick
+
+                    Nothing ->
+                        Decode.fail
+            )
+
+
+movesEncoder : List Direction -> Encoder
+movesEncoder moves =
+    Encode.sequence
+        [ Encode.unsignedInt32 endianness (List.length moves)
+        , Encode.sequence (movesEncoderHelper [] moves)
+        ]
+
+
+movesDecoder : Decoder (List Direction)
+movesDecoder =
+    Decode.unsignedInt32 endianness
+        |> Decode.andThen
+            (\numMoves ->
+                Decode.loop ( numMoves, [] ) movesDecoderHelper
+            )
+
+
+movesEncoderHelper : List Encoder -> List Direction -> List Encoder
+movesEncoderHelper acc moves =
+    case moves of
+        [] ->
+            List.reverse acc
+
+        _ ->
+            let
+                left =
+                    List.take 8 moves
+
+                rest =
+                    List.drop 8 moves
+
+                lengthDiff =
+                    8 - List.length left
+
+                paddedLeft =
+                    if lengthDiff > 0 then
+                        left ++ List.repeat lengthDiff N
+
+                    else
+                        left
+            in
+            movesEncoderHelper (moveEncoder paddedLeft :: acc) rest
+
+
+moveEncoder : List Direction -> Encoder
+moveEncoder piece8 =
+    let
+        combined =
+            piece8
+                |> List.foldl
+                    (\direction acc ->
+                        (acc |> Bitwise.shiftLeftBy 3) + directionToInt direction
+                    )
+                    0
+    in
+    Encode.sequence
+        [ Encode.unsignedInt8 (Bitwise.and combined b11111111_00000000_00000000)
+        , Encode.unsignedInt8 (Bitwise.and combined b00000000_11111111_00000000)
+        , Encode.unsignedInt8 (Bitwise.and combined b00000000_00000000_11111111)
+        ]
+
+
+movesDecoderHelper : ( Int, List Direction ) -> Decoder (Decode.Step ( Int, List Direction ) (List Direction))
+movesDecoderHelper ( numMoves, acc ) =
+    Decode.map3
+        (\a b c ->
+            let
+                movesLeft =
+                    numMoves - 8
+
+                toDrop =
+                    max 0 -movesLeft
+
+                combinedFull =
+                    (a |> Bitwise.shiftLeftBy 6)
+                        + (b |> Bitwise.shiftLeftBy 3)
+                        + c
+
+                combined =
+                    combinedFull
+                        |> Bitwise.shiftRightZfBy (3 * toDrop)
+
+                moves =
+                    List.range 0 (7 - toDrop)
+                        |> List.foldl
+                            (\i newAcc ->
+                                let
+                                    direction =
+                                        combined
+                                            |> Bitwise.shiftRightZfBy (3 * i)
+                                            |> Bitwise.and 7
+                                            |> intToDirection
+                                in
+                                direction :: newAcc
+                            )
+                            acc
+            in
+            if movesLeft > 0 then
+                Decode.Loop ( movesLeft, moves )
+
+            else
+                Decode.Done (List.reverse moves)
+        )
+        Decode.unsignedInt8
+        Decode.unsignedInt8
+        Decode.unsignedInt8
+
+
+b00000000_00000000_11111111 : Int
+b00000000_00000000_11111111 =
+    255
+
+
+b00000000_11111111_00000000 : Int
+b00000000_11111111_00000000 =
+    65280
+
+
+b11111111_00000000_00000000 : Int
+b11111111_00000000_00000000 =
+    16711680
+
+
+directionToInt : Direction -> Int
+directionToInt direction =
+    case direction of
+        N ->
+            0
+
+        NE ->
+            1
+
+        E ->
+            2
+
+        SE ->
+            3
+
+        S ->
+            4
+
+        SW ->
+            5
+
+        W ->
+            6
+
+        NW ->
+            7
+
+
+intToDirection : Int -> Direction
+intToDirection int =
+    case int of
+        0 ->
+            N
+
+        1 ->
+            NE
+
+        2 ->
+            E
+
+        3 ->
+            SE
+
+        4 ->
+            S
+
+        5 ->
+            SW
+
+        6 ->
+            W
+
+        _ ->
+            NW
 
 
 list : Int -> Decoder a -> Decoder (List a)
@@ -327,64 +500,3 @@ listStep itemDecoder ( n, xs ) =
 
     else
         Decode.map (\x -> Decode.Loop ( n - 1, x :: xs )) itemDecoder
-
-
-drawingPositionDecoder : Decoder DrawingPosition
-drawingPositionDecoder =
-    Decode.map2 DrawingPosition
-        (Decode.unsignedInt16 endianness)
-        (Decode.unsignedInt16 endianness)
-
-
-movesDecoder : Decoder (List Move)
-movesDecoder =
-    Decode.unsignedInt32 endianness
-        |> Decode.andThen
-            (\numMoves ->
-                list numMoves moveDecoder
-            )
-
-
-moveDecoder : Decoder Move
-moveDecoder =
-    Decode.unsignedInt8 |> Decode.map uint8ToMove
-
-
-uint8ToMove : Int -> Move
-uint8ToMove int =
-    let
-        direction =
-            case Bitwise.and int 7 of
-                0 ->
-                    N
-
-                1 ->
-                    NE
-
-                2 ->
-                    E
-
-                3 ->
-                    SE
-
-                4 ->
-                    S
-
-                5 ->
-                    SW
-
-                6 ->
-                    W
-
-                _ ->
-                    NW
-    in
-    { repetitions = int |> Bitwise.shiftRightZfBy 4
-    , holiness =
-        if Bitwise.and int 8 == 1 then
-            Solid
-
-        else
-            Holy
-    , direction = direction
-    }

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -10,7 +10,7 @@ import Types.Tick as Tick exposing (Tick)
 import World exposing (DrawingPosition)
 
 
-type alias Replay2 =
+type alias Replay =
     { movesPerTick : Int
     , kurves : List ReplayKurve
     }
@@ -43,7 +43,7 @@ type Direction
     | NW
 
 
-fromKurves : List Kurve -> Replay2
+fromKurves : List Kurve -> Replay
 fromKurves kurves =
     let
         movesPerTick =
@@ -195,7 +195,7 @@ latestVersion =
     0
 
 
-encoder : Replay2 -> Encoder
+encoder : Replay -> Encoder
 encoder replay =
     Encode.sequence
         [ Encode.unsignedInt8 latestVersion
@@ -204,7 +204,7 @@ encoder replay =
         ]
 
 
-decoder : Decoder Replay2
+decoder : Decoder Replay
 decoder =
     Decode.unsignedInt8
         |> Decode.andThen
@@ -218,9 +218,9 @@ decoder =
             )
 
 
-v0Decoder : Decoder Replay2
+v0Decoder : Decoder Replay
 v0Decoder =
-    Decode.map2 Replay2
+    Decode.map2 Replay
         Decode.unsignedInt8
         kurvesDecoder
 

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -365,9 +365,9 @@ moveEncoder piece8 =
                     0
     in
     Encode.sequence
-        [ Encode.unsignedInt8 (Bitwise.and combined b11111111_00000000_00000000)
-        , Encode.unsignedInt8 (Bitwise.and combined b00000000_11111111_00000000)
-        , Encode.unsignedInt8 (Bitwise.and combined b00000000_00000000_11111111)
+        [ Encode.unsignedInt8 (combined |> Bitwise.shiftRightZfBy 16)
+        , Encode.unsignedInt8 (combined |> Bitwise.shiftRightZfBy 8 |> Bitwise.and b11111111)
+        , Encode.unsignedInt8 (Bitwise.and combined b11111111)
         ]
 
 
@@ -383,8 +383,8 @@ movesDecoderHelper ( numMoves, acc ) =
                     max 0 -movesLeft
 
                 combinedFull =
-                    (a |> Bitwise.shiftLeftBy 6)
-                        + (b |> Bitwise.shiftLeftBy 3)
+                    (a |> Bitwise.shiftLeftBy 16)
+                        + (b |> Bitwise.shiftLeftBy 8)
                         + c
 
                 combined =
@@ -393,13 +393,13 @@ movesDecoderHelper ( numMoves, acc ) =
 
                 moves =
                     List.range 0 (7 - toDrop)
-                        |> List.foldl
+                        |> List.foldr
                             (\i newAcc ->
                                 let
                                     direction =
                                         combined
                                             |> Bitwise.shiftRightZfBy (3 * i)
-                                            |> Bitwise.and 7
+                                            |> Bitwise.and b111
                                             |> intToDirection
                                 in
                                 direction :: newAcc
@@ -417,19 +417,14 @@ movesDecoderHelper ( numMoves, acc ) =
         Decode.unsignedInt8
 
 
-b00000000_00000000_11111111 : Int
-b00000000_00000000_11111111 =
+b111 : Int
+b111 =
+    7
+
+
+b11111111 : Int
+b11111111 =
     255
-
-
-b00000000_11111111_00000000 : Int
-b00000000_11111111_00000000 =
-    65280
-
-
-b11111111_00000000_00000000 : Int
-b11111111_00000000_00000000 =
-    16711680
 
 
 directionToInt : Direction -> Int

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -1,6 +1,7 @@
 module Replay exposing (..)
 
-import Bytes exposing (Bytes, Endianness(..))
+import Bitwise
+import Bytes
 import Bytes.Encode as Encode exposing (Encoder)
 import Holes exposing (Holiness(..))
 import Types.Kurve exposing (Kurve)
@@ -192,6 +193,89 @@ optimizeRepetitions reversedMoves =
             finalMove :: finalAcc
 
 
+latestVersion : Int
+latestVersion =
+    1
+
+
+endianness : Bytes.Endianness
+endianness =
+    Bytes.BE
+
+
 encoder : Replay -> Encoder
 encoder replay =
-    Encode.sequence [ Encode.unsignedInt16 BE 1 ]
+    Encode.sequence
+        [ Encode.unsignedInt8 latestVersion
+        , Encode.unsignedInt8 replay.movesPerTick
+        , Encode.unsignedInt8 (List.length replay.kurves)
+        , Encode.sequence (replay.kurves |> List.map (.playerId >> Encode.unsignedInt8))
+        , Encode.sequence (replay.kurves |> List.map (.initialDrawingPosition >> drawingPositionEncoder))
+        , Encode.sequence (replay.kurves |> List.map (.moves >> movesEncoder))
+        ]
+
+
+drawingPositionEncoder : DrawingPosition -> Encoder
+drawingPositionEncoder { x, y } =
+    Encode.sequence
+        [ Encode.unsignedInt16 endianness x
+        , Encode.unsignedInt16 endianness y
+        ]
+
+
+movesEncoder : List Move -> Encoder
+movesEncoder moves =
+    Encode.sequence
+        [ Encode.unsignedInt32 endianness (List.length moves)
+        , Encode.sequence (List.map moveEncoder moves)
+        ]
+
+
+moveEncoder : Move -> Encoder
+moveEncoder move =
+    Encode.unsignedInt8 (moveToUint8 move)
+
+
+moveToUint8 : Move -> Int
+moveToUint8 move =
+    let
+        repetitions =
+            move.repetitions
+
+        holiness =
+            case move.holiness of
+                Holy ->
+                    1
+
+                Solid ->
+                    0
+
+        direction =
+            case move.direction of
+                N ->
+                    0
+
+                NE ->
+                    1
+
+                E ->
+                    2
+
+                SE ->
+                    3
+
+                S ->
+                    4
+
+                SW ->
+                    5
+
+                W ->
+                    6
+
+                NW ->
+                    7
+    in
+    (repetitions |> Bitwise.shiftLeftBy 4)
+        + (holiness |> Bitwise.shiftLeftBy 3)
+        + direction

--- a/src/Replay.elm
+++ b/src/Replay.elm
@@ -128,7 +128,7 @@ toMoves movesPerTick initialDrawingPosition reversedDrawingPositions =
 
 getDirection : DrawingPosition -> DrawingPosition -> Maybe Direction
 getDirection previousDrawingPosition drawingPosition =
-    case ( compare previousDrawingPosition.x drawingPosition.x, compare previousDrawingPosition.y drawingPosition.y ) of
+    case ( compare drawingPosition.x previousDrawingPosition.x, compare drawingPosition.y previousDrawingPosition.y ) of
         ( EQ, LT ) ->
             Just N
 

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -141,7 +141,7 @@ generateKurve config id numberOfPlayers existingPositions player holeStatusFromP
                 , state = state
                 , stateAtSpawn = state
                 , reversedInteractions = []
-                , reversedMoves = []
+                , reversedDrawingPositions = []
                 }
             )
 

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -141,7 +141,7 @@ generateKurve config id numberOfPlayers existingPositions player holeStatusFromP
                 , state = state
                 , stateAtSpawn = state
                 , reversedInteractions = []
-                , reversedDrawingPositions = []
+                , reversedDrawingPositionsPerTick = []
                 }
             )
 

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -16,6 +16,7 @@ import Types.Kurve as Kurve exposing (Kurve)
 import Types.Player exposing (Player)
 import Types.PlayerId exposing (PlayerId)
 import Types.Radius as Radius
+import Types.Tick as Tick
 import Util exposing (curry, isEven)
 import World exposing (Position, distanceBetween)
 
@@ -141,6 +142,13 @@ generateKurve config id numberOfPlayers existingPositions player holeStatusFromP
                 , state = state
                 , stateAtSpawn = state
                 , reversedInteractions = []
+                , reversedHolinessChanges =
+                    case Holes.getHoliness state.holeStatus of
+                        Solid ->
+                            []
+
+                        Holy ->
+                            [ Tick.genesis ]
                 , reversedDrawingPositionsPerTick = []
                 }
             )

--- a/src/Spawn.elm
+++ b/src/Spawn.elm
@@ -141,6 +141,7 @@ generateKurve config id numberOfPlayers existingPositions player holeStatusFromP
                 , state = state
                 , stateAtSpawn = state
                 , reversedInteractions = []
+                , reversedMoves = []
                 }
             )
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -12,13 +12,12 @@ module Types.Kurve exposing
 
 import Color exposing (Color)
 import Holes exposing (HoleStatus, Holiness(..), getHoliness)
-import Replay exposing (Move)
 import Set exposing (Set)
 import Types.Angle exposing (Angle)
 import Types.PlayerId exposing (PlayerId)
 import Types.Tick exposing (Tick)
 import Types.TurningState exposing (TurningState)
-import World exposing (Position)
+import World exposing (DrawingPosition, Position)
 
 
 type alias Kurve =
@@ -28,7 +27,7 @@ type alias Kurve =
     , state : State
     , stateAtSpawn : State
     , reversedInteractions : List UserInteraction
-    , reversedMoves : List Move
+    , reversedDrawingPositions : List ( DrawingPosition, Holiness )
     }
 
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -27,7 +27,7 @@ type alias Kurve =
     , state : State
     , stateAtSpawn : State
     , reversedInteractions : List UserInteraction
-    , reversedDrawingPositionsPerTick : List (List ( DrawingPosition, Holiness )) -- The outer list is reversed; the inner lists are not.
+    , reversedDrawingPositionsPerTick : List (List ( DrawingPosition, Holiness )) -- Both the outer list and the inner lists are reversed.
     }
 
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -27,7 +27,7 @@ type alias Kurve =
     , state : State
     , stateAtSpawn : State
     , reversedInteractions : List UserInteraction
-    , reversedDrawingPositions : List ( DrawingPosition, Holiness )
+    , reversedDrawingPositionsPerTick : List (List ( DrawingPosition, Holiness )) -- The outer list is reversed; the inner lists are not.
     }
 
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -27,7 +27,8 @@ type alias Kurve =
     , state : State
     , stateAtSpawn : State
     , reversedInteractions : List UserInteraction
-    , reversedDrawingPositionsPerTick : List (List ( DrawingPosition, Holiness )) -- Both the outer list and the inner lists are reversed.
+    , reversedHolinessChanges : List Tick
+    , reversedDrawingPositionsPerTick : List (List DrawingPosition) -- Both the outer list and the inner lists are reversed.
     }
 
 

--- a/src/Types/Kurve.elm
+++ b/src/Types/Kurve.elm
@@ -12,6 +12,7 @@ module Types.Kurve exposing
 
 import Color exposing (Color)
 import Holes exposing (HoleStatus, Holiness(..), getHoliness)
+import Replay exposing (Move)
 import Set exposing (Set)
 import Types.Angle exposing (Angle)
 import Types.PlayerId exposing (PlayerId)
@@ -27,6 +28,7 @@ type alias Kurve =
     , state : State
     , stateAtSpawn : State
     , reversedInteractions : List UserInteraction
+    , reversedMoves : List Move
     }
 
 


### PR DESCRIPTION
This is an _experiment_ that came out of the joy of coding and the opportunity to learn something new. I apologize for the messy and ugly code.

Currently, you can watch a replay right after a round. Once you move on, the replay is gone forever. Me and @SimonAlling have talked about wanting to save replays somehow. This PR experiments with one way of doing so. Actually, it’s an experiment of multiple related things, due to that’s how my mind works when getting excited, which unfortunately muddies each thing a bit. Oh well. Here are the experiments:

- Save a replay in a query parameter. Links are easy to share and bookmark.
- Use a bespoke binary format to save space. (I wanted to learn more about how [elm/bytes](https://elm.dmy.fr/packages/elm/bytes/latest/) works, and practice bitwise operations.)
- Use [DEFLATE](https://elm.dmy.fr/packages/folkertdev/elm-flate/latest) compression to save even more space.
- Store the _drawing positions_ – not the inputs. The idea is that this should be more future-proof. If a really cool game was played, but it turns out that there was a bug in the simulation and the fascinating gameplay relied on that bug, then that should be fine. We don’t replay the simulation, we just draw the same pixels again. More or less. (Note that the format supports drawing in ways that are impossible to achieve while playing for real. At least in this version of the game.)

Are any of the above good ideas? Maybe. But anyways, it’s good to have this concrete experiment to look at when discussing solutions to the “have a way to save replays” feature.

Now, go ahead and run this branch locally and try this [replay link](http://localhost:8000/?movie=XZBNSBtBFMffLunHoWkjzakJNDVbaSm9pU1PEoqiURbPGhfPi65RMPG0+IF4EIwQQUVBRTQqaA5+7AaF9aQeBA8qLGaQ8QMPImE9ZQ9J1LcrIgi/35vHG5iZ/wDDAsPBDQMAb1ER7QBg3qAf0D30EIANiak5cTErLk2K+eOGjeO6iiTPJWvnh6rdZVXl4g/3/4rRcKDf6XPhSQg40F4AFy4hgPdPQy/Te5UIfv2UoTt39ML0mKanWGkUK0sPg6UHHCJmD86LQaNEqay1RDUaVQ9y+YKsnRkqwcapkqhCJY3ISsFuIthIeZJ7mRPpGV7Zbn3ml12FruxtelGIndymt65juvCHhQlYsN6GD2a8KIeOodNW6kSNV973j2SuEu+8nbv+YfNLZ+CSD4yGuaSF26o//XXVn8OhWf47K+LO/ADPlZc5XH2AX2Hxza4I+FiHj8WKt8H5x38ziaDHvDcMzWNkqExpt0l3tIJTIzlEJbJK7LB2TDvOa+LZ3CZpVraluC6l9daULsS3pNgJWdEb0+NN7euR1AZZVhtX/wq/JyMBRWw7Ol1Yr+fXpnyP)!