### PR TITLE
Make .gitignore more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 *.sublime-workspace
 node_modules
 *.log
-*.map
-*.js
-*.css
+_site/**/*.map
+_site/**/*.js
+_site/**/*.css
 elm-stuff
 .compiled-scenario.gdb
 gdb-log.txt


### PR DESCRIPTION
The only files targeted by the `.gitignore` rules modified in this PR can be listed by running the following command after `git clean -xdf && npm ci && npm run build`:

```console
$ find . -path ./node_modules -prune -o -path ./elm-stuff -prune -o -regextype posix-egrep -regex '.+\.(map|js|css)$' -print
./tools/extract-glyphs-from-original-game.js
./_site/index.js
./_site/ZATACKA.js
./_site/css/Zatacka.css
./_site/css/Zatacka.css.map
```

Those that we _want_ to be ignored are all in `_site/`; this PR makes that assumption/intention explicit. We thereby won't forget to check in e.g. a future JS file in `tools/` due to our `.gitignore`.

Note that `_site/index.js` is, and should be, tracked. Its situation isn't improved by this PR, but the plan is to migrate it to TypeScript soon.

💡 `git show --color-words=.`