### PR TITLE
Enable noImplicitOverride (TypeScript)

### DIFF
--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -3,11 +3,11 @@
 customElements.define(
   "window-events-workaround",
   class extends HTMLElement {
-    addEventListener(...args: Parameters<HTMLElement["addEventListener"]>) {
+    override addEventListener(...args: Parameters<HTMLElement["addEventListener"]>) {
       return window.addEventListener(...args);
     }
 
-    removeEventListener(...args: Parameters<HTMLElement["removeEventListener"]>) {
+    override removeEventListener(...args: Parameters<HTMLElement["removeEventListener"]>) {
       return window.removeEventListener(...args);
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2020", "DOM"],
     "module": "ES2020",
     "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": false,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
In #438, I intentionally disabled `noImplicitOverride` because it reported two of these type errors:

    error TS4114: This member must have an 'override' modifier because it overrides a member in the base class 'HTMLElement'.

This PR fixes them and enables `noImplicitOverride`.

💡 `git show --color-words='false|.'`